### PR TITLE
fix: pin numpy and pandas-ta versions for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,9 +25,9 @@ imageio-ffmpeg==0.4.5
 decorator==4.4.2
 reportlab==4.4.0
 textblob==0.19.0
-numpy>=1.24.0
+numpy>=1.20.0,<1.24.0
 pandas>=2.0.0
-scikit-learn>=1.3.2
+scikit-learn<1.2.0
 matplotlib>=3.8.2
 plotly>=5.18.0
 textstat>=0.7.3
@@ -60,4 +60,4 @@ dnspython
 sqlalchemy==2.0.41
 APScheduler>=3.9.1
 SQLAlchemy>=1.4.0
-scipy>=1.10.0
+scipy<1.10.0


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
- pandas_ta 0.3.14b0 is incompatible with numpy >=1.24.
- Causes ImportError: cannot import name 'NaN' from 'numpy
- fixed these errors

## 🔗 Related Issues
Related to #(195)

## 🎯 Type of Change
- [ ] ♻️ Code refactoring

## 🧪 Testing
**How has this been tested?**
- Resolves dependency resolution issues
- Allows ALwrity to run without import errors

**Test Configuration:**
- Python version: 
- OS: 
- AI Provider(s) tested: 

## 📸 Screenshots (if applicable)
Add screenshots to help explain your changes.

## ✅ Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## 📝 Additional Notes
- Pin numpy to >=1.20.0,<1.24.0
- Pin pandas-ta to 0.3.14b0
- Pin scikit-learn and scipy to compatible versions

## 🔄 Breaking Changes
If this is a breaking change, please describe the impact and migration path for existing users.



---

**Thank you for contributing to ALwrity! 🎉** 