### PR TITLE
Profile-aware bootstrap gating in start_alwrity_backend.py

### DIFF
--- a/backend/start_alwrity_backend.py
+++ b/backend/start_alwrity_backend.py
@@ -10,6 +10,55 @@ import sys
 import argparse
 from pathlib import Path
 
+LINGUISTIC_REQUIRED_FEATURES = {
+    "blog",
+    "blog_writer",
+    "content_planning",
+    "linkedin",
+    "research",
+    "seo",
+    "story",
+}
+
+
+def get_active_profile() -> str:
+    """Resolve currently active bootstrap profile."""
+    raw_profile = (
+        os.getenv("ALWRITY_ACTIVE_PROFILE")
+        or os.getenv("ALWRITY_PROFILE")
+        or os.getenv("ALWRITY_FEATURE_PROFILE")
+        or "all"
+    )
+    profile = raw_profile.strip().lower()
+    if profile in {"", "all", "default"}:
+        return "all"
+    return profile
+
+
+def get_loaded_features() -> set:
+    """Resolve feature set from environment hints."""
+    raw_features = (
+        os.getenv("ALWRITY_LOADED_FEATURES")
+        or os.getenv("ALWRITY_ENABLED_FEATURES")
+        or os.getenv("ALWRITY_FEATURES")
+        or ""
+    )
+    return {feature.strip().lower() for feature in raw_features.split(",") if feature.strip()}
+
+
+def should_bootstrap_linguistic_models(profile: str, loaded_features: set) -> bool:
+    """Full bootstrap for all/default; selective otherwise."""
+    if profile == "all":
+        return True
+    if not loaded_features:
+        return False
+    return bool(loaded_features & LINGUISTIC_REQUIRED_FEATURES)
+
+
+def should_bootstrap_local_llm_models(profile: str) -> bool:
+    """Skip local LLM bootstrap for podcast-only profile."""
+    return profile != "podcast"
+
 
 def bootstrap_linguistic_models():
     """
@@ -145,8 +194,19 @@ def bootstrap_local_llm_models():
 
 # Bootstrap linguistic models BEFORE any imports that might need them
 if __name__ == "__main__":
-    bootstrap_linguistic_models()
-    bootstrap_local_llm_models()
+    active_profile = get_active_profile()
+    loaded_features = get_loaded_features()
+    verbose = os.getenv("ALWRITY_VERBOSE", "false").lower() == "true"
+
+    if should_bootstrap_linguistic_models(active_profile, loaded_features):
+        bootstrap_linguistic_models()
+    elif verbose:
+        print(f"⏭️  Skipping linguistic bootstrap for profile '{active_profile}'")
+
+    if should_bootstrap_local_llm_models(active_profile):
+        bootstrap_local_llm_models()
+    elif verbose:
+        print(f"⏭️  Skipping local LLM bootstrap for profile '{active_profile}'")
 
 # NOW import modular utilities (after bootstrap)
 from alwrity_utils import (


### PR DESCRIPTION
### Motivation
- Reduce unnecessary startup work by evaluating the active runtime profile before heavy bootstraps run.
- Avoid pre-downloading or initializing large local models for podcast-only deployments.
- Only perform linguistic model bootstrapping when features that require it are actually loaded, while preserving full behavior for `all/default`.

### Description
- Added `LINGUISTIC_REQUIRED_FEATURES` and helpers `get_active_profile()`, `get_loaded_features()`, `should_bootstrap_linguistic_models()` and `should_bootstrap_local_llm_models()` to detect profile/features from environment variables and decide bootstrap behavior.
- Gate the top-level bootstrap sequence to: perform full bootstrap for `all/default`, skip local-LLM bootstrap for the `podcast` profile, and only run linguistic bootstrap for non-`all` profiles when loaded features intersect with linguistic-required features.
- Read environment hints from `ALWRITY_ACTIVE_PROFILE`/`ALWRITY_PROFILE`/`ALWRITY_FEATURE_PROFILE` and feature lists from `ALWRITY_LOADED_FEATURES`/`ALWRITY_ENABLED_FEATURES`/`ALWRITY_FEATURES`.
- Changes are confined to `backend/start_alwrity_backend.py` and preserve previous behavior when no profile/features are specified.

### Testing
- Compiled the modified module with `python -m py_compile backend/start_alwrity_backend.py`, which succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb8c568a888328994966e5689b7ab7)