### PR TITLE
Add startup summary for active profile, routers, and bootstraps

### DIFF
--- a/backend/alwrity_utils/router_manager.py
+++ b/backend/alwrity_utils/router_manager.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from loguru import logger
 from typing import List, Dict, Any, Optional
 import os
+import json
 
 
 class RouterManager:
@@ -16,6 +17,11 @@ class RouterManager:
         self.app = app
         self.included_routers = []
         self.failed_routers = []
+        self.skipped_routers = []
+
+    def _record_skipped_router(self, router_name: str, reason: str) -> None:
+        """Track routers intentionally skipped at startup."""
+        self.skipped_routers.append({"name": router_name, "reason": reason})
     
     def include_router_safely(self, router, router_name: str = None) -> bool:
         """Include a router safely with error handling."""
@@ -176,6 +182,7 @@ class RouterManager:
                 from api.blog_writer.router import router as blog_writer_router
                 self.include_router_safely(blog_writer_router, "blog_writer")
             except Exception as e:
+                self._record_skipped_router("blog_writer", str(e))
                 logger.warning(f"AI Blog Writer router not mounted: {e}")
             
             # Story Writer router
@@ -183,6 +190,7 @@ class RouterManager:
                 from api.story_writer.router import router as story_writer_router
                 self.include_router_safely(story_writer_router, "story_writer")
             except Exception as e:
+                self._record_skipped_router("story_writer", str(e))
                 logger.warning(f"Story Writer router not mounted: {e}")
             
             # Wix Integration router
@@ -190,6 +198,7 @@ class RouterManager:
                 from api.wix_routes import router as wix_router
                 self.include_router_safely(wix_router, "wix")
             except Exception as e:
+                self._record_skipped_router("wix", str(e))
                 logger.warning(f"Wix Integration router not mounted: {e}")
             
             # Blog Writer SEO Analysis router
@@ -197,6 +206,7 @@ class RouterManager:
                 from api.blog_writer.seo_analysis import router as blog_seo_analysis_router
                 self.include_router_safely(blog_seo_analysis_router, "blog_seo_analysis")
             except Exception as e:
+                self._record_skipped_router("blog_seo_analysis", str(e))
                 logger.warning(f"Blog Writer SEO Analysis router not mounted: {e}")
             
             # Persona router
@@ -204,6 +214,7 @@ class RouterManager:
                 from api.persona_routes import router as persona_router
                 self.include_router_safely(persona_router, "persona")
             except Exception as e:
+                self._record_skipped_router("persona", str(e))
                 logger.warning(f"Persona router not mounted: {e}")
             
             # Video Studio router
@@ -211,6 +222,7 @@ class RouterManager:
                 from api.video_studio.router import router as video_studio_router
                 self.include_router_safely(video_studio_router, "video_studio")
             except Exception as e:
+                self._record_skipped_router("video_studio", str(e))
                 logger.warning(f"Video Studio router not mounted: {e}")
 
             # Stability AI routers
@@ -224,6 +236,7 @@ class RouterManager:
                 from routers.stability_admin import router as stability_admin_router
                 self.include_router_safely(stability_admin_router, "stability_admin")
             except Exception as e:
+                self._record_skipped_router("stability_suite", str(e))
                 logger.warning(f"Stability AI routers not mounted: {e}")
             
             
@@ -239,6 +252,40 @@ class RouterManager:
         return {
             "included_routers": self.included_routers,
             "failed_routers": self.failed_routers,
+            "skipped_routers": self.skipped_routers,
             "total_included": len(self.included_routers),
-            "total_failed": len(self.failed_routers)
+            "total_failed": len(self.failed_routers),
+            "total_skipped": len(self.skipped_routers),
         }
+
+    def log_startup_summary(self) -> None:
+        """Log concise startup summary for demos."""
+        active_profile = os.getenv("ALWRITY_ACTIVE_PROFILE", "development")
+        logger.info(f"[startup] active profile: {active_profile}")
+        logger.info(f"[startup] enabled routers: {self.included_routers}")
+
+        raw_bootstrap_summary = os.getenv("ALWRITY_BOOTSTRAP_SUMMARY")
+        if not raw_bootstrap_summary:
+            logger.info("[startup] enabled bootstraps: []")
+            logger.info("[startup] skipped bootstraps: []")
+            return
+
+        try:
+            bootstrap_summary = json.loads(raw_bootstrap_summary)
+        except json.JSONDecodeError:
+            logger.warning("[startup] skipped bootstraps: unable to parse ALWRITY_BOOTSTRAP_SUMMARY")
+            return
+
+        enabled_bootstraps = [
+            item.get("name")
+            for item in bootstrap_summary
+            if item.get("enabled")
+        ]
+        skipped_bootstraps = [
+            {"name": item.get("name"), "reason": item.get("reason", "unspecified")}
+            for item in bootstrap_summary
+            if item.get("skipped")
+        ]
+
+        logger.info(f"[startup] enabled bootstraps: {enabled_bootstraps}")
+        logger.info(f"[startup] skipped bootstraps with reason: {skipped_bootstraps}")

--- a/backend/app.py
+++ b/backend/app.py
@@ -261,6 +261,7 @@ async def onboarding_status():
 # Include routers using modular utilities
 router_manager.include_core_routers()
 router_manager.include_optional_routers()
+router_manager.log_startup_summary()
 
 # Include assets serving router (must be mounted to serve generated images)
 app.include_router(assets_serving_router)

--- a/backend/start_alwrity_backend.py
+++ b/backend/start_alwrity_backend.py
@@ -8,6 +8,7 @@ Run this from the backend directory to set up and start the FastAPI server.
 import os
 import sys
 import argparse
+import json
 from pathlib import Path
 
 
@@ -44,7 +45,12 @@ def bootstrap_linguistic_models():
                 if verbose:
                     print(f"   ❌ Failed to download spaCy model: {e}")
                     print("   Please run: python -m spacy download en_core_web_sm")
-                return False
+                return {
+                    "name": "linguistic_models",
+                    "enabled": False,
+                    "skipped": False,
+                    "reason": f"spaCy model download failed: {e}",
+                }
     except ImportError:
         if verbose:
             print("   ⚠️  spaCy not installed - skipping")
@@ -87,7 +93,12 @@ def bootstrap_linguistic_models():
     
     if verbose:
         print("✅ Linguistic model bootstrap complete")
-    return True
+    return {
+        "name": "linguistic_models",
+        "enabled": True,
+        "skipped": False,
+        "reason": "loaded",
+    }
 
 
 def bootstrap_local_llm_models():
@@ -117,7 +128,12 @@ def bootstrap_local_llm_models():
     if os.getenv("RENDER") or os.getenv("RAILWAY_ENVIRONMENT"):
         if verbose:
             print("   ⚠️  Cloud environment detected (Render/Railway). Skipping local LLM bootstrap to save RAM/Time.")
-        return True
+        return {
+            "name": "local_llm_models",
+            "enabled": False,
+            "skipped": True,
+            "reason": "Cloud environment detected (Render/Railway)",
+        }
     
     target_model = "Qwen/Qwen2.5-3B-Instruct"
     
@@ -135,18 +151,53 @@ def bootstrap_local_llm_models():
             if verbose:
                 print(f"   ⚠️  Failed to download/check local LLM: {e}")
                 print("       SIF agents may try to download it at runtime.")
-            return False
+            return {
+                "name": "local_llm_models",
+                "enabled": False,
+                "skipped": False,
+                "reason": f"failed to download/check local LLM: {e}",
+            }
     except ImportError:
         if verbose:
             print("   ⚠️  huggingface_hub not installed - skipping LLM bootstrap")
-    
-    return True
+        return {
+            "name": "local_llm_models",
+            "enabled": False,
+            "skipped": True,
+            "reason": "huggingface_hub not installed",
+        }
+
+    return {
+        "name": "local_llm_models",
+        "enabled": True,
+        "skipped": False,
+        "reason": "loaded",
+    }
+
+
+def _log_bootstrap_summary(bootstrap_results):
+    """Log deterministic bootstrap summary for demos and debugging."""
+    enabled = [item["name"] for item in bootstrap_results if item.get("enabled")]
+    skipped = [item for item in bootstrap_results if item.get("skipped")]
+
+    print("\n[*] Bootstrap summary")
+    print(f"Enabled bootstraps: {enabled if enabled else 'none'}")
+    if skipped:
+        print("Skipped bootstraps:")
+        for item in skipped:
+            print(f" - {item['name']}: {item.get('reason', 'no reason provided')}")
+    else:
+        print("Skipped bootstraps: none")
 
 
 # Bootstrap linguistic models BEFORE any imports that might need them
 if __name__ == "__main__":
-    bootstrap_linguistic_models()
-    bootstrap_local_llm_models()
+    bootstrap_results = [
+        bootstrap_linguistic_models(),
+        bootstrap_local_llm_models(),
+    ]
+    os.environ["ALWRITY_BOOTSTRAP_SUMMARY"] = json.dumps(bootstrap_results)
+    _log_bootstrap_summary(bootstrap_results)
 
 # NOW import modular utilities (after bootstrap)
 from alwrity_utils import (
@@ -307,10 +358,13 @@ def main():
     
     # Set global verbose flag for utilities
     os.environ["ALWRITY_VERBOSE"] = "true" if verbose_mode else "false"
+    active_profile = "production" if production_mode else "development"
+    os.environ["ALWRITY_ACTIVE_PROFILE"] = active_profile
     
     print("[*] ALwrity Backend Server")
     print("=" * 40)
     print(f"Mode: {'PRODUCTION' if production_mode else 'DEVELOPMENT'}")
+    print(f"Active profile: {active_profile}")
     print(f"Auto-reload: {'ENABLED' if enable_reload else 'DISABLED'}")
     if verbose_mode:
         print("Verbose logging: ENABLED")


### PR DESCRIPTION
### Motivation
- Improve startup observability for demos by making it explicit which profile is active and which routers/bootstraps were enabled or intentionally skipped. 
- Prevent confusion about whether optional routers or heavy bootstraps were omitted intentionally or failed silently. 

### Description
- Updated `backend/start_alwrity_backend.py` so bootstrap functions (`bootstrap_linguistic_models`, `bootstrap_local_llm_models`) return structured result objects and the process writes `ALWRITY_BOOTSTRAP_SUMMARY` (JSON) and prints a deterministic bootstrap summary at startup. 
- Propagated the active profile via `ALWRITY_ACTIVE_PROFILE` and print the `Active profile` during startup. 
- Extended `backend/alwrity_utils/router_manager.py` to track skipped optional routers with reasons, expose `skipped_routers` in `get_router_status()`, and add `log_startup_summary()` which logs the active profile, enabled routers, enabled bootstraps, and skipped bootstraps with reasons. 
- Invoked `router_manager.log_startup_summary()` from `backend/app.py` immediately after core/optional router inclusion so the startup summary is emitted during app initialization. 

### Testing
- Compiled the modified modules to verify syntax with `python -m py_compile backend/start_alwrity_backend.py backend/alwrity_utils/router_manager.py backend/app.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb8c6822fc83288112433dd763cc13)