### PR TITLE
docs: add Podcast Maker journeys for all persona user-journeys

### DIFF
--- a/docs-site/docs/user-journeys/content-teams/overview.md
+++ b/docs-site/docs/user-journeys/content-teams/overview.md
@@ -106,6 +106,13 @@ journey
 - Set up quality control processes
 - Train team on brand standards
 
+### Bonus: Team Podcast Production (75-120 minutes)
+**[Podcast Maker Journey →](podcast-maker-journey.md)**
+
+- Coordinate analysis, research, script, render, and export across team roles
+- Maintain brand voice through review checkpoints
+- Publish episodes on schedule with reusable assets
+
 ## 🎯 Success Stories
 
 ### Sarah - Marketing Team Lead
@@ -137,6 +144,7 @@ Once you've established your team workflow, explore these next steps:
 - **[Performance Analytics](performance-analytics.md)** - Track team and content performance
 - **[Client Management](client-management.md)** - Manage multiple clients efficiently
 - **[Team Scaling](team-scaling.md)** - Grow your content team
+- **[Podcast Maker Journey](podcast-maker-journey.md)** - Add a standardized podcast lane to team workflows
 
 ## 🔧 Technical Requirements
 

--- a/docs-site/docs/user-journeys/content-teams/podcast-maker-journey.md
+++ b/docs-site/docs/user-journeys/content-teams/podcast-maker-journey.md
@@ -1,0 +1,72 @@
+# Podcast Maker Journey - Content Teams
+
+Use this workflow to produce consistent podcast episodes across contributors while maintaining editorial quality and brand voice.
+
+## Overview
+
+### Entry Conditions
+- **Inputs:** Editorial brief, role assignments, brand guide, deadline.
+- **Skill level:** Mixed (editor lead + contributors).
+- **Expected time:** 75-120 minutes end-to-end for team production.
+
+### Success Target
+Release a review-approved episode on schedule with clear ownership at each stage.
+
+## Setup
+
+### Recommended Defaults
+- **Duration:** 18-25 minutes
+- **Speakers:** Host + 1 guest (or two-host format)
+- **Voice style:** Brand-consistent, clear pacing
+- **Research provider:** Tavily (reliable source collection for editorial review)
+
+### Pre-Production Checklist
+1. Assign owner for analysis, research, script QA, and publish tasks.
+2. Confirm audience persona and approved episode angle.
+3. Set shared template for intro, segment transitions, and outro.
+4. Define review SLA and escalation path.
+
+## Production
+
+### Podcast Maker Workflow
+1. **Analysis**
+   - Align episode with editorial calendar and campaign priorities.
+   - Freeze episode scope to prevent late-stage rewrites.
+2. **Research**
+   - Collect and verify sources in a shared reference set.
+   - Flag claims needing legal or product review.
+3. **Script**
+   - Draft using team template and brand voice standards.
+   - Run editor review for structure, tone, and factual accuracy.
+4. **Render**
+   - Render staged draft for stakeholder sign-off.
+   - Apply final edits from reviewer checklist.
+5. **Export**
+   - Export audio + episode summary + channel-specific snippets.
+   - Publish according to calendar and track delivery SLAs.
+
+## Optimization
+
+### Success Criteria
+- All approval gates pass without critical rework.
+- Episode goes live on schedule with complete metadata.
+- Style and tone match team brand guidelines.
+- Reuse assets created for social/email/web repurposing.
+
+### Checkpoints
+- **Before render:** Editorial sign-off on script and claims.
+- **After render:** QA pass for pacing, names, and transitions.
+- **After publish:** Retrospective on cycle time and revision count.
+
+## Troubleshooting
+
+### Common Issues and Fixes
+- **Too many revisions:** Lock brief scope and decision owner early.
+- **Brand inconsistency:** Enforce reusable script blocks and style checks.
+- **Missed deadlines:** Add milestone gates for each workflow stage.
+- **Fact disputes:** Keep source notes attached to each script section.
+- **Inefficient handoffs:** Use a single shared checklist per episode.
+
+---
+
+Next step: combine this with **[Workflow Optimization](workflow-optimization.md)** to reduce cycle time.

--- a/docs-site/docs/user-journeys/developers/overview.md
+++ b/docs-site/docs/user-journeys/developers/overview.md
@@ -116,6 +116,13 @@ journey
 - Help improve documentation
 - Participate in the community
 
+### Bonus: Automated Podcast Pipeline (60-120 minutes)
+**[Podcast Maker Journey →](podcast-maker-journey.md)**
+
+- Implement analysis → research → script → render → export as a pipeline
+- Add schema validation, retries, and stage-level observability
+- Export artifacts with metadata for downstream integrations
+
 ## 🎯 Success Stories
 
 ### Alex - Full-Stack Developer
@@ -147,6 +154,7 @@ Once you've completed your first integration, explore these next steps:
 - **[Production Deployment](deployment.md)** - Deploy to production
 - **[Team Collaboration](team-collaboration.md)** - Work with your team
 - **[Contributing](contributing.md)** - Contribute to ALwrity
+- **[Podcast Maker Journey](podcast-maker-journey.md)** - Build and automate podcast generation workflows
 
 ## 🔧 Technical Requirements
 

--- a/docs-site/docs/user-journeys/developers/podcast-maker-journey.md
+++ b/docs-site/docs/user-journeys/developers/podcast-maker-journey.md
@@ -1,0 +1,72 @@
+# Podcast Maker Journey - Developers
+
+Use this journey to integrate Podcast Maker into repeatable, testable pipelines for scripted audio generation and distribution.
+
+## Overview
+
+### Entry Conditions
+- **Inputs:** API credentials, topic payload schema, content constraints, output destination.
+- **Skill level:** Intermediate to advanced (API and workflow automation).
+- **Expected time:** 60-120 minutes for first implementation.
+
+### Success Target
+Automate one full podcast generation path from prompt to exported artifact with predictable quality.
+
+## Setup
+
+### Recommended Defaults
+- **Duration:** 10-20 minutes (configurable per template)
+- **Speakers:** 1-2 synthetic speakers
+- **Voice style:** Neutral/professional with stable pacing
+- **Research provider:** Perplexity (structured fact gathering for scripted outputs)
+
+### Pre-Production Checklist
+1. Define request schema for analysis/research/script/render/export stages.
+2. Store provider credentials via environment variables.
+3. Configure retry/error policy for external research and render calls.
+4. Add logging for prompt versions and output hashes.
+
+## Production
+
+### Podcast Maker Workflow
+1. **Analysis**
+   - Validate input payload and enforce required fields.
+   - Derive episode objective and section plan programmatically.
+2. **Research**
+   - Fetch source context with provider abstraction.
+   - Normalize citations and drop low-confidence results.
+3. **Script**
+   - Generate structured script JSON (intro/segments/outro/CTA).
+   - Run lint-style checks for length and forbidden terms.
+4. **Render**
+   - Render audio using configured speaker profile.
+   - Execute post-render QA hooks (duration, loudness, clipping checks).
+5. **Export**
+   - Persist artifact + metadata to storage.
+   - Trigger downstream publish/webhook integration.
+
+## Optimization
+
+### Success Criteria
+- End-to-end pipeline completes without manual intervention.
+- Output passes automated quality checks.
+- Metadata includes provenance for research and prompt version.
+- Failure paths are observable with actionable logs.
+
+### Checkpoints
+- **Before render:** Unit/integration checks pass for script payload.
+- **After render:** Verify duration bounds and transcript alignment.
+- **After publish:** Monitor error rate, latency, and output quality metrics.
+
+## Troubleshooting
+
+### Common Issues and Fixes
+- **Provider timeouts:** Add retries with exponential backoff and fallback provider.
+- **Inconsistent scripts:** Pin model settings and enforce schema validation.
+- **Audio quality failures:** Add deterministic render settings and QA thresholds.
+- **Broken exports:** Validate storage credentials and file naming conventions.
+- **Debug difficulty:** Log stage-level inputs/outputs with correlation IDs.
+
+---
+
+Next step: integrate this into **[Advanced Usage](advanced-usage.md)** automation patterns.

--- a/docs-site/docs/user-journeys/enterprise/overview.md
+++ b/docs-site/docs/user-journeys/enterprise/overview.md
@@ -106,6 +106,13 @@ journey
 - Implement performance monitoring
 - Establish business impact measurement
 
+### Bonus: Governed Podcast Operations (1.5-3 hours)
+**[Podcast Maker Journey →](podcast-maker-journey.md)**
+
+- Run compliant episode workflows from analysis to export
+- Apply legal/compliance checkpoints before publication
+- Archive governed outputs for audit and KPI reporting
+
 ## 🎯 Success Stories
 
 ### Sarah - CMO at Fortune 500 Company
@@ -137,6 +144,7 @@ Once you've completed your enterprise setup, explore these next steps:
 - **[Performance Optimization](performance-optimization.md)** - Optimize system performance
 - **[Custom Solutions](custom-solutions.md)** - Develop custom enterprise solutions
 - **[Strategic Planning](strategic-planning.md)** - Align content strategy with business goals
+- **[Podcast Maker Journey](podcast-maker-journey.md)** - Launch compliant, scalable enterprise podcast production
 
 ## 🔧 Technical Requirements
 

--- a/docs-site/docs/user-journeys/enterprise/podcast-maker-journey.md
+++ b/docs-site/docs/user-journeys/enterprise/podcast-maker-journey.md
@@ -1,0 +1,72 @@
+# Podcast Maker Journey - Enterprise
+
+Use Podcast Maker for compliant, scalable audio production aligned with governance controls and cross-functional approval requirements.
+
+## Overview
+
+### Entry Conditions
+- **Inputs:** Business unit brief, compliance constraints, approved messaging, KPI target.
+- **Skill level:** Advanced team workflow (marketing + legal + ops).
+- **Expected time:** 1.5-3 hours including governance review.
+
+### Success Target
+Publish a compliant enterprise episode that meets brand, legal, and performance standards.
+
+## Setup
+
+### Recommended Defaults
+- **Duration:** 20-30 minutes
+- **Speakers:** Executive/SME host + moderator
+- **Voice style:** Professional, authoritative
+- **Research provider:** Tavily (traceable source paths for auditability)
+
+### Pre-Production Checklist
+1. Map required approval stakeholders (brand, legal, compliance).
+2. Assign classification level for external statements.
+3. Define mandatory disclaimers and prohibited claims.
+4. Prepare measurement framework (pipeline, engagement, retention).
+
+## Production
+
+### Podcast Maker Workflow
+1. **Analysis**
+   - Align episode goals with strategic initiative and audience segment.
+   - Identify risk-sensitive statements before drafting.
+2. **Research**
+   - Build source-backed evidence pack with references.
+   - Validate data currency and claim boundaries.
+3. **Script**
+   - Generate script with approved messaging blocks and disclaimers.
+   - Route through legal/compliance checkpoint.
+4. **Render**
+   - Render controlled draft for executive review.
+   - Confirm pronunciation of product names and regulated terms.
+5. **Export**
+   - Export approved audio and governed show notes.
+   - Archive final assets and source references for audits.
+
+## Optimization
+
+### Success Criteria
+- No compliance exceptions in final published episode.
+- Approval timeline meets internal SLA.
+- Episode metadata and source references are fully archived.
+- Performance report linked to enterprise KPI dashboard.
+
+### Checkpoints
+- **Before render:** Complete legal/compliance sign-off.
+- **After render:** QA for disclaimers, claims, and brand integrity.
+- **After publish:** Governance review + KPI impact check.
+
+## Troubleshooting
+
+### Common Issues and Fixes
+- **Approval bottlenecks:** Pre-approve claim libraries and disclaimer blocks.
+- **Compliance rejections:** Tag high-risk sections in analysis stage earlier.
+- **Version confusion:** Maintain a single source-of-truth script workspace.
+- **Weak executive adoption:** Provide KPI snapshots with every episode brief.
+- **Audit gaps:** Attach source and approval logs to exported package.
+
+---
+
+Next step: extend this with **[Security & Compliance](security-compliance.md)** controls.

--- a/docs-site/docs/user-journeys/non-tech-creators/overview.md
+++ b/docs-site/docs/user-journeys/non-tech-creators/overview.md
@@ -109,6 +109,13 @@ journey
 - Build your content library
 - Develop your content strategy
 
+### Bonus: Launch Your Podcast (45-75 minutes)
+**[Podcast Maker Journey →](podcast-maker-journey.md)**
+
+- Turn your topic into a complete podcast episode
+- Follow analysis → research → script → render → export
+- Publish polished audio without technical editing complexity
+
 ## 🎯 Success Stories
 
 ### Sarah - Lifestyle Blogger
@@ -140,6 +147,7 @@ Once you've completed your first content creation, explore these next steps:
 - **[SEO Basics](seo-basics.md)** - Learn simple SEO techniques
 - **[Content Strategy](content-strategy.md)** - Plan your content calendar
 - **[Performance Tracking](performance-tracking.md)** - Monitor your success
+- **[Podcast Maker Journey](podcast-maker-journey.md)** - Create and publish episodes with guided defaults
 
 ---
 

--- a/docs-site/docs/user-journeys/non-tech-creators/podcast-maker-journey.md
+++ b/docs-site/docs/user-journeys/non-tech-creators/podcast-maker-journey.md
@@ -1,0 +1,72 @@
+# Podcast Maker Journey - Non-Tech Creators
+
+Use this journey to go from idea to published podcast episode with minimal technical setup.
+
+## Overview
+
+### Entry Conditions
+- **Inputs:** Topic idea, audience goal, 3-5 talking points, optional reference links.
+- **Skill level:** Beginner (no audio editing experience required).
+- **Expected time:** 45-75 minutes for a first complete episode.
+
+### Success Target
+Publish one clear, on-brand episode and reuse the workflow weekly.
+
+## Setup
+
+### Recommended Defaults
+- **Duration:** 8-12 minutes
+- **Speakers:** 1 host + optional 1 co-host
+- **Voice style:** Natural, friendly, medium pace
+- **Research provider:** Tavily (balanced depth + speed)
+
+### Pre-Production Checklist
+1. Pick a single episode objective (teach, announce, or summarize).
+2. Set audience level (beginner/intermediate).
+3. Add 2-3 must-cover points to prevent rambling.
+4. Confirm intro/outro CTA (newsletter, site, product page).
+
+## Production
+
+### Podcast Maker Workflow
+1. **Analysis**
+   - Define episode goal, audience pain point, and key takeaway.
+   - Validate the title so listeners know the value in under 8 words.
+2. **Research**
+   - Pull supporting facts/examples from trusted sources.
+   - Keep only relevant references to avoid overloading the script.
+3. **Script**
+   - Generate intro hook, 2-4 core segments, and concise outro CTA.
+   - Add transitions between segments for natural flow.
+4. **Render**
+   - Choose voice and pacing defaults.
+   - Render a draft and listen for pronunciation/tone issues.
+5. **Export**
+   - Export final audio (MP3) and episode notes.
+   - Publish to your hosting platform and schedule promotion.
+
+## Optimization
+
+### Success Criteria
+- Episode stays inside target duration window.
+- Opening 30 seconds clearly states listener benefit.
+- No unresolved placeholders/fact checks in final script.
+- Export includes title, description, and CTA.
+
+### Checkpoints
+- **Before render:** Read script out loud once for clarity.
+- **After render:** Spot-check intro, midpoint transition, and outro.
+- **After publish:** Track listens, retention, and CTA clicks.
+
+## Troubleshooting
+
+### Common Issues and Fixes
+- **Output sounds robotic:** Switch to a warmer voice profile and reduce script complexity.
+- **Episode too long:** Cut to one primary theme and remove secondary tangents.
+- **Weak structure:** Rebuild around hook → problem → solution → CTA.
+- **Research overload:** Limit references to top 3 sources relevant to the audience.
+- **Low engagement:** Strengthen title and first 20 seconds with a sharper promise.
+
+---
+
+Next step: pair this with **[Content Optimization](content-optimization.md)** to improve discoverability and repeatability.

--- a/docs-site/docs/user-journeys/solopreneurs/overview.md
+++ b/docs-site/docs/user-journeys/solopreneurs/overview.md
@@ -106,6 +106,13 @@ journey
 - Leverage social media for growth
 - Convert followers into customers
 
+### Bonus: Authority Podcast Workflow (50-90 minutes)
+**[Podcast Maker Journey →](podcast-maker-journey.md)**
+
+- Produce authority-building episodes that support your offer
+- Run analysis → research → script → render → export in one flow
+- Add clear CTA and repurposing outputs for social and email
+
 ## 🎯 Success Stories
 
 ### Sarah - Business Coach
@@ -137,6 +144,7 @@ Once you've established your foundation, explore these next steps:
 - **[Content Monetization](content-monetization.md)** - Turn your content into revenue
 - **[Community Building](community-building.md)** - Build a loyal following
 - **[Business Growth](business-growth.md)** - Scale your solopreneur business
+- **[Podcast Maker Journey](podcast-maker-journey.md)** - Build repeatable podcast episodes for lead generation
 
 ## 🔧 Technical Requirements
 

--- a/docs-site/docs/user-journeys/solopreneurs/podcast-maker-journey.md
+++ b/docs-site/docs/user-journeys/solopreneurs/podcast-maker-journey.md
@@ -1,0 +1,72 @@
+# Podcast Maker Journey - Solopreneurs
+
+Use Podcast Maker to produce authority-building episodes that generate leads without adding a full production team.
+
+## Overview
+
+### Entry Conditions
+- **Inputs:** Offer/theme, ICP (ideal customer profile), episode angle, optional proof points.
+- **Skill level:** Beginner to intermediate.
+- **Expected time:** 50-90 minutes per episode (including positioning).
+
+### Success Target
+Ship one episode that strengthens personal brand positioning and drives one business CTA.
+
+## Setup
+
+### Recommended Defaults
+- **Duration:** 12-18 minutes
+- **Speakers:** Solo host (or founder + guest)
+- **Voice style:** Confident, conversational
+- **Research provider:** Perplexity (fast market context and trend summaries)
+
+### Pre-Production Checklist
+1. Align episode topic with one content pillar.
+2. Define one conversion CTA (call booking, newsletter, lead magnet).
+3. Capture one personal story/case insight.
+4. Set repurposing targets (LinkedIn post, email, short clips).
+
+## Production
+
+### Podcast Maker Workflow
+1. **Analysis**
+   - Clarify business objective (awareness, trust, or conversion).
+   - Frame the episode around one audience pain + practical outcome.
+2. **Research**
+   - Gather market stats, examples, or competitor framing.
+   - Keep only proof points that support your positioning.
+3. **Script**
+   - Build authority arc: context → method → example → next step.
+   - Insert 1-2 short personal credibility stories.
+4. **Render**
+   - Render a preview for tone fit and confidence level.
+   - Adjust emphasis on key offers/CTAs.
+5. **Export**
+   - Export audio + show notes + CTA links.
+   - Queue repurposing assets for social and email distribution.
+
+## Optimization
+
+### Success Criteria
+- Core message and offer are clear by minute 3.
+- One clear CTA appears in both script and show notes.
+- Episode maps to at least two downstream channels.
+- Audio pacing remains consistent throughout.
+
+### Checkpoints
+- **Before render:** Confirm episode supports current business campaign.
+- **After render:** Verify name, offer, and links are pronounced correctly.
+- **After publish:** Review lead quality and conversion from podcast traffic.
+
+## Troubleshooting
+
+### Common Issues and Fixes
+- **No business impact:** Move CTA earlier and repeat it once near close.
+- **Episode feels generic:** Add one client case, lesson, or contrarian insight.
+- **Inconsistent voice:** Save a reusable script template and voice profile.
+- **Slow production:** Batch analysis/research for 3-4 episodes at once.
+- **Low retention:** Tighten intro and cut non-essential setup commentary.
+
+---
+
+Next step: connect this flow with **[Content Monetization](content-monetization.md)** for stronger revenue outcomes.

--- a/docs-site/docs/user-journeys/tech-marketers/overview.md
+++ b/docs-site/docs/user-journeys/tech-marketers/overview.md
@@ -108,6 +108,13 @@ journey
 - Optimize based on data insights
 - Report results to stakeholders
 
+### Bonus: Campaign Podcast Execution (60-100 minutes)
+**[Podcast Maker Journey →](podcast-maker-journey.md)**
+
+- Build campaign-aligned episodes with measurable CTA attribution
+- Use analysis → research → script → render → export workflow
+- Ship show notes with trackable links and KPI-ready metadata
+
 ## 🎯 Success Stories
 
 ### Sarah - Marketing Director at Tech Startup
@@ -139,6 +146,7 @@ Once you've completed your initial setup, explore these next steps:
 - **[ROI Optimization](roi-optimization.md)** - Maximize your content marketing ROI
 - **[Team Management](team-management.md)** - Scale your content operations
 - **[Competitive Analysis](competitive-analysis.md)** - Stay ahead of the competition
+- **[Podcast Maker Journey](podcast-maker-journey.md)** - Run data-backed podcast campaigns with tracking
 
 ## 🔧 Technical Requirements
 

--- a/docs-site/docs/user-journeys/tech-marketers/podcast-maker-journey.md
+++ b/docs-site/docs/user-journeys/tech-marketers/podcast-maker-journey.md
@@ -1,0 +1,72 @@
+# Podcast Maker Journey - Tech Marketers
+
+Use Podcast Maker to deliver data-backed episodes that support campaign goals, product messaging, and measurable pipeline outcomes.
+
+## Overview
+
+### Entry Conditions
+- **Inputs:** Campaign objective, target segment, messaging pillar, KPI target.
+- **Skill level:** Intermediate.
+- **Expected time:** 60-100 minutes including analytics alignment.
+
+### Success Target
+Publish one campaign-aligned episode with measurable acquisition or engagement goals.
+
+## Setup
+
+### Recommended Defaults
+- **Duration:** 15-22 minutes
+- **Speakers:** Host + optional product/SME guest
+- **Voice style:** Clear, authoritative, medium-fast pace
+- **Research provider:** Perplexity (for trend and competitor synthesis)
+
+### Pre-Production Checklist
+1. Assign episode to a campaign stage (TOFU/MOFU/BOFU).
+2. Define primary KPI (CTR, demo requests, trial signups, etc.).
+3. Lock product narrative and approved terms.
+4. Prepare tracking links/UTM parameters for CTA.
+
+## Production
+
+### Podcast Maker Workflow
+1. **Analysis**
+   - Identify audience problem, funnel stage, and conversion target.
+   - Confirm narrative consistency with current campaign brief.
+2. **Research**
+   - Source current market signals and competitor references.
+   - Prioritize proof points that support differentiation.
+3. **Script**
+   - Build structure: pain → insight → product fit → CTA.
+   - Include one data point per major section.
+4. **Render**
+   - Review speed, clarity, and brand-safe claims.
+   - Validate mention timing for campaign CTA.
+5. **Export**
+   - Export final audio, show notes, and tracked links.
+   - Distribute through campaign channels and reporting dashboards.
+
+## Optimization
+
+### Success Criteria
+- Script contains campaign-approved positioning and compliance-safe claims.
+- CTA tracking is operational before publishing.
+- Episode is repurposed into at least one nurture asset.
+- Post-launch KPI review scheduled within 7 days.
+
+### Checkpoints
+- **Before render:** Validate legal/brand language for product statements.
+- **After render:** Confirm numeric data and URLs are accurate.
+- **After publish:** Compare KPI lift against non-podcast campaign assets.
+
+## Troubleshooting
+
+### Common Issues and Fixes
+- **Weak KPI movement:** Reposition CTA and tighten audience targeting.
+- **Message drift:** Anchor every section to the campaign brief.
+- **Overly dense script:** Simplify to one claim + one proof per segment.
+- **Slow approval cycles:** Pre-approve reusable product messaging blocks.
+- **Attribution gaps:** Standardize UTM + dashboard tagging before launch.
+
+---
+
+Next step: pair this with **[ROI Optimization](roi-optimization.md)** to improve performance over time.

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
       - Performance Tracking: user-journeys/non-tech-creators/performance-tracking.md
       - Workflow Optimization: user-journeys/non-tech-creators/workflow-optimization.md
       - Audience Growth: user-journeys/non-tech-creators/audience-growth.md
+      - Podcast Maker Journey: user-journeys/non-tech-creators/podcast-maker-journey.md
       - Troubleshooting: user-journeys/non-tech-creators/troubleshooting.md
       - Advanced Features: user-journeys/non-tech-creators/advanced-features.md
       - Community & Support: user-journeys/non-tech-creators/community-support.md
@@ -147,6 +148,7 @@ nav:
       - Codebase Exploration: user-journeys/developers/codebase-exploration.md
       - Customization: user-journeys/developers/customization.md
       - Team Collaboration: user-journeys/developers/team-collaboration.md
+      - Podcast Maker Journey: user-journeys/developers/podcast-maker-journey.md
       - Scaling: user-journeys/developers/scaling.md
     - Tech Marketers:
       - Overview: user-journeys/tech-marketers/overview.md
@@ -163,6 +165,7 @@ nav:
       - ROI Optimization: user-journeys/tech-marketers/roi-optimization.md
       - Competitive Analysis: user-journeys/tech-marketers/competitive-analysis.md
       - Team Management: user-journeys/tech-marketers/team-management.md
+      - Podcast Maker Journey: user-journeys/tech-marketers/podcast-maker-journey.md
       - Troubleshooting: user-journeys/tech-marketers/troubleshooting.md
     - Solopreneurs:
       - Overview: user-journeys/solopreneurs/overview.md
@@ -171,6 +174,7 @@ nav:
       - Social Media Setup: user-journeys/solopreneurs/social-media-setup.md
       - Email Marketing: user-journeys/solopreneurs/email-marketing.md
       - Content Production: user-journeys/solopreneurs/content-production.md
+      - Podcast Maker Journey: user-journeys/solopreneurs/podcast-maker-journey.md
       - Audience Growth: user-journeys/solopreneurs/audience-growth.md
       - Community Building: user-journeys/solopreneurs/community-building.md
       - Performance Tracking: user-journeys/solopreneurs/performance-tracking.md
@@ -191,6 +195,7 @@ nav:
       - Team Scaling: user-journeys/content-teams/team-scaling.md
       - Troubleshooting: user-journeys/content-teams/troubleshooting.md
       - Content Production: user-journeys/content-teams/content-production.md
+      - Podcast Maker Journey: user-journeys/content-teams/podcast-maker-journey.md
       - Workflow Optimization: user-journeys/content-teams/workflow-optimization.md
       - Scaling: user-journeys/content-teams/scaling.md
       - Performance Tracking: user-journeys/content-teams/performance-tracking.md
@@ -205,6 +210,7 @@ nav:
       - Team Training: user-journeys/enterprise/team-training.md
       - Scaling: user-journeys/enterprise/scaling.md
       - Monitoring: user-journeys/enterprise/monitoring.md
+      - Podcast Maker Journey: user-journeys/enterprise/podcast-maker-journey.md
       - Troubleshooting: user-journeys/enterprise/troubleshooting.md
       - Advanced Security: user-journeys/enterprise/advanced-security.md
   - Features:


### PR DESCRIPTION
### Motivation
- Provide a standardized Podcast Maker journey for each core persona so users can produce podcasts using the same analysis→research→script→render→export workflow.  
- Keep new pages consistent with existing journey structure and naming/formatting conventions (overview → setup → production → optimization → troubleshooting).  
- Surface the new workflow from each persona overview and the site navigation so pages are discoverable from the sidebar and journey flow.

### Description
- Added six new files: `docs-site/docs/user-journeys/{non-tech-creators,solopreneurs,tech-marketers,content-teams,enterprise,developers}/podcast-maker-journey.md` with entry conditions, recommended workflow, default settings, success criteria, and troubleshooting.  
- Updated each persona `overview.md` to include a bonus step linking to the corresponding `podcast-maker-journey.md` and added the new page to the "What's Next"/next-steps lists.  
- Updated `docs-site/mkdocs.yml` navigation to include the new Podcast Maker pages under their respective persona sections so they appear in the site sidebar.

### Testing
- Attempted to build the docs with `mkdocs build -f docs-site/mkdocs.yml`, which failed due to the environment lacking the `mkdocs` command (`mkdocs: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4c5ae77288328ab1a25b8cbfb082a)