### PR TITLE
docs: add Podcast Maker feature docs and cross-links

### DIFF
--- a/docs-site/docs/features/blog-writer/overview.md
+++ b/docs-site/docs/features/blog-writer/overview.md
@@ -253,6 +253,12 @@ The Blog Writer leverages sophisticated AI orchestration to ensure quality at ev
 - **Multi-Platform Publishing**: One workflow, multiple destinations (WordPress, Wix, Medium)
 - **Scheduling & Automation**: Strategic content distribution and timing optimization
 
+
+## Related Features
+
+- [Podcast Maker Overview](../podcast-maker/overview.md) for audio-first content workflows and show-note repurposing.
+- [Image Studio Overview](../image-studio/overview.md) for episode cover art and social-ready creative assets.
+
 ### For Digital Marketing & SEO Professionals
 - **Comprehensive SEO**: Multi-dimensional scoring with actionable insights
 - **Competitive Intelligence**: AI-powered competitor analysis and content gap identification
@@ -328,6 +334,7 @@ flowchart LR
 - **[Content Strategy](../content-strategy/overview.md)** - Strategic planning
 - **[LinkedIn Writer](../linkedin-writer/overview.md)** - Social content
 - **[AI Features](../ai/assistive-writing.md)** - Advanced AI capabilities
+- **[Podcast Maker](../podcast-maker/overview.md)** - Extend blog ideas into episode scripts and repurpose audio back into articles.
 
 ---
 

--- a/docs-site/docs/features/image-studio/overview.md
+++ b/docs-site/docs/features/image-studio/overview.md
@@ -219,6 +219,12 @@ For detailed cost information, see the [Cost Guide](cost-guide.md).
 - **Template Library**: Available templates and presets
 - **Best Practices**: Tips for optimal results
 
+
+## Related Features
+
+- [Podcast Maker Overview](../podcast-maker/overview.md) to pair episode scripts with thumbnail and social asset creation.
+- [Blog Writer Overview](../blog-writer/overview.md) to repurpose podcast transcripts into SEO blog posts.
+
 ---
 
 *For more information, explore the module-specific documentation or check the [API Reference](api-reference.md).*

--- a/docs-site/docs/features/podcast-maker/api-reference.md
+++ b/docs-site/docs/features/podcast-maker/api-reference.md
@@ -1,0 +1,84 @@
+# Podcast Maker API Reference
+
+Complete API reference for Podcast Maker planning, script generation, narration, and episode packaging.
+
+## Base URL
+
+All endpoints are prefixed with `/api/podcast`
+
+## Authentication
+
+All endpoints require bearer authentication.
+
+```http
+Authorization: Bearer YOUR_ACCESS_TOKEN
+```
+
+## API Surface
+
+| Category | Endpoint | Description |
+|---|---|---|
+| Planning | `POST /api/podcast/plan` | Generate episode brief and structure |
+| Scripting | `POST /api/podcast/script/start` | Start async script generation |
+| Scripting | `GET /api/podcast/script/status/{task_id}` | Poll script generation status |
+| Voice | `POST /api/podcast/voice/render` | Render narration audio |
+| Metadata | `POST /api/podcast/metadata/generate` | Build title, notes, chapters, tags |
+| Export | `POST /api/podcast/export` | Export full episode package |
+| Health | `GET /api/podcast/health` | Service status |
+
+## Request/Response Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API
+    participant Tasks
+    participant Services
+
+    Client->>API: POST /script/start
+    API->>Tasks: Create task_id
+    API-->>Client: task_id + started
+
+    Tasks->>Services: Generate script segments
+    Services-->>Tasks: progress updates
+
+    loop Polling
+        Client->>API: GET /script/status/{task_id}
+        API-->>Client: queued/running/completed
+    end
+```
+
+## Planning Endpoint
+
+**Endpoint**: `POST /api/podcast/plan`
+
+**Request Example**:
+
+```json
+{
+  "topic": "AI copilots for small marketing teams",
+  "target_audience": "growth marketers",
+  "episode_goal": "educate and capture demo signups",
+  "duration_minutes": 18,
+  "persona_id": "b2b_marketer"
+}
+```
+
+**Response Fields**:
+
+| Field | Type | Description |
+|---|---|---|
+| `brief` | object | Episode positioning and angle |
+| `outline` | array | Ordered segment plan |
+| `suggested_titles` | array | SEO-aware title options |
+| `cta_options` | array | Recommended CTA language |
+
+## Common Errors
+
+| Code | Meaning | Typical Fix |
+|---|---|---|
+| 400 | Invalid request payload | Validate required fields and types |
+| 401 | Unauthorized | Refresh access token |
+| 409 | Task conflict | Retry with a new task or wait for active one |
+| 422 | Unsupported voice profile | Use a valid profile ID |
+| 500 | Internal failure | Retry and inspect task logs |

--- a/docs-site/docs/features/podcast-maker/best-practices.md
+++ b/docs-site/docs/features/podcast-maker/best-practices.md
@@ -1,0 +1,41 @@
+# Podcast Maker Best Practices
+
+These practices help you maximize quality, consistency, and output reuse.
+
+## Editorial Best Practices
+
+1. **Start from one listener problem** per episode.
+2. **Front-load the value** in the first 30–45 seconds.
+3. **Use segment-level objectives** (what listener should know/do next).
+4. **Close with one clear CTA** tied to episode intent.
+
+## Voice Production Best Practices
+
+1. Test pacing on intro and CTA before full render.
+2. Keep sentence length moderate for natural TTS rhythm.
+3. Add pronunciation hints for product and brand names.
+4. Regenerate only weak segments instead of the full episode.
+
+## Persona-Specific Best Practices
+
+### Solopreneurs
+- Reuse one proven episode template weekly.
+- Batch 2–4 episodes in one planning session.
+- Generate social cutdowns during export.
+
+### Content Teams
+- Use role-based approvals (planner, script editor, QA).
+- Maintain a shared glossary for recurring terminology.
+- Keep a library of approved intros/outros by campaign.
+
+### Enterprise Marketing
+- Align scripts to compliance and brand guardrails.
+- Require metadata QA before distribution.
+- Track performance by episode format and CTA type.
+
+## SEO & Discovery Best Practices
+
+- Put target keyword in title and opening summary.
+- Use chapter markers with query-friendly phrasing.
+- Keep show notes structured: summary, highlights, links, CTA.
+- Publish companion blog posts from episode scripts.

--- a/docs-site/docs/features/podcast-maker/implementation-overview.md
+++ b/docs-site/docs/features/podcast-maker/implementation-overview.md
@@ -1,0 +1,73 @@
+# Podcast Maker Implementation Overview
+
+This document describes the high-level architecture and delivery model for Podcast Maker.
+
+## Architecture Summary
+
+Podcast Maker follows a modular orchestration pattern similar to ALwrity's other generation workflows.
+
+```mermaid
+graph TB
+    UI[Podcast Maker UI] --> API[Podcast API Layer]
+
+    API --> PLAN[Planning Service]
+    API --> SCRIPT[Script Service]
+    API --> VOICE[Voice Service]
+    API --> META[Metadata Service]
+    API --> EXPORT[Export Service]
+
+    PLAN --> ORCH[Workflow Orchestrator]
+    SCRIPT --> ORCH
+    VOICE --> ORCH
+    META --> ORCH
+    EXPORT --> ORCH
+
+    ORCH --> CACHE[Content Cache]
+    ORCH --> TASKS[Background Task Manager]
+    ORCH --> MODELS[LLM + TTS Providers]
+
+    style UI fill:#e3f2fd
+    style API fill:#e1f5fe
+    style ORCH fill:#f3e5f5
+```
+
+## Core Services
+
+| Service | Responsibility | Typical Output |
+|---|---|---|
+| Planning Service | Topic framing, episode angles, audience mapping | Episode brief + angle shortlist |
+| Script Service | Segment generation and continuity checks | Segment scripts + host cues |
+| Voice Service | TTS conversion and narration options | Audio assets + timing metadata |
+| Metadata Service | Titles, descriptions, chapters, tags | Publishing package |
+| Export Service | Bundled assets and integration payloads | ZIP/JSON payloads for channels |
+
+## Data Flow
+
+1. User submits a brief (topic, persona, duration, CTA).
+2. Planner generates candidate structures and recommends one.
+3. Script service produces segments with continuity memory.
+4. Voice service renders selected script with voice settings.
+5. Metadata service composes show notes and platform fields.
+6. Export service returns publish-ready assets.
+
+## Persona-Aware Design
+
+Podcast Maker uses persona profiles to adjust:
+
+- Vocabulary complexity
+- Story style and pacing
+- CTA framing and conversion intent
+- Intro/outro brand consistency
+
+## Reliability & Operations
+
+- **Async jobs** for long-running generation
+- **Idempotent task IDs** to safely retry
+- **Segment-level regeneration** to avoid full reruns
+- **Structured logging** for script/voice pipeline debugging
+
+## Related Docs
+
+- [Workflow Guide](workflow-guide.md)
+- [API Reference](api-reference.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs-site/docs/features/podcast-maker/overview.md
+++ b/docs-site/docs/features/podcast-maker/overview.md
@@ -1,0 +1,82 @@
+# Podcast Maker Overview
+
+ALwrity Podcast Maker helps you plan, script, voice, and package podcast episodes from one workflow. It is designed for creators, marketers, and teams that want production speed without sacrificing narrative quality.
+
+## What is Podcast Maker?
+
+Podcast Maker is a feature hub for end-to-end episode production:
+
+- **Episode planning** from audience and goal inputs
+- **AI-assisted scripting** with segment-level controls
+- **Voice production** with multiple narration styles
+- **Show notes and metadata** for distribution
+- **Repurposing outputs** for blog, social, and newsletter channels
+
+## Key Capabilities
+
+### 🎙️ Script-First Audio Production
+- Topic-to-outline generation
+- Segment templates (intro, story, interview, CTA)
+- Tone controls (educational, conversational, executive)
+- Persona-aware language adaptation
+
+### 🔊 Voice & Delivery Controls
+- Multi-speaker script formatting
+- Voice profile selection
+- Pronunciation and pacing hints
+- Regeneration by segment instead of full episode
+
+### 📣 Distribution-Ready Packaging
+- Episode title options and subtitle variants
+- Show notes with key takeaways and chapter markers
+- Platform metadata (Spotify/Apple/YouTube)
+- Cross-channel snippets for social and blog
+
+## How It Works
+
+```mermaid
+flowchart TD
+    A[Brief: Topic + Audience + Goal] --> B[Research & Angle Selection]
+    B --> C[Episode Outline]
+    C --> D[Segment Script Drafting]
+    D --> E[Voice Production]
+    E --> F[Metadata + Show Notes]
+    F --> G[Export + Publish]
+
+    D --> D1[Persona Alignment]
+    D --> D2[Hook Optimization]
+    E --> E1[Voice Profile]
+    E --> E2[Pacing + Pronunciation]
+
+    style A fill:#e3f2fd
+    style B fill:#e8f5e8
+    style C fill:#fff3e0
+    style D fill:#fce4ec
+    style E fill:#f1f8e9
+    style F fill:#e0f2f1
+    style G fill:#f3e5f5
+```
+
+## Who Benefits Most
+
+### For Solopreneurs
+- Turn a weekly idea into a polished episode quickly
+- Keep voice and positioning consistent
+- Reuse each episode as multi-platform content
+
+### For Content Teams
+- Standardize recurring episode formats
+- Assign outline/script/review responsibilities clearly
+- Improve turnaround time with reusable segment templates
+
+### For Marketing & SEO Teams
+- Align episodes to campaign themes and keyword targets
+- Generate optimized titles and metadata at scale
+- Integrate podcast output into blog and social funnels
+
+## Next Steps
+
+- Read the [Implementation Overview](implementation-overview.md)
+- Follow the [Workflow Guide](workflow-guide.md)
+- Integrate with the [API Reference](api-reference.md)
+- Apply the [Best Practices](best-practices.md)

--- a/docs-site/docs/features/podcast-maker/troubleshooting.md
+++ b/docs-site/docs/features/podcast-maker/troubleshooting.md
@@ -1,0 +1,76 @@
+# Podcast Maker Troubleshooting
+
+Use this guide to quickly diagnose and resolve common Podcast Maker issues.
+
+## Quick Diagnostic Flow
+
+```mermaid
+flowchart TD
+    A[Issue Observed] --> B{Type?}
+    B -->|Script Quality| C[Check brief + persona]
+    B -->|Voice Output| D[Check voice profile + pacing]
+    B -->|Export Failure| E[Check metadata completeness]
+    B -->|API Errors| F[Check auth + task status]
+
+    C --> G[Regenerate only affected segments]
+    D --> G
+    E --> G
+    F --> G
+
+    G --> H[Re-run final export]
+```
+
+## Common Issues
+
+### 1) Script feels generic
+
+**Symptoms**:
+- Weak hooks
+- Repetitive language
+- Limited audience relevance
+
+**Fixes**:
+- Provide explicit audience + persona in brief
+- Add 2–3 must-cover points in outline
+- Regenerate specific segments, not full script
+
+### 2) Voice sounds unnatural
+
+**Symptoms**:
+- Robotic transitions
+- Mispronounced terms
+- Inconsistent pacing
+
+**Fixes**:
+- Reduce sentence complexity
+- Add pronunciation hints
+- Lower pace for technical segments
+
+### 3) Export package missing metadata
+
+**Symptoms**:
+- Missing chapters/tags
+- Empty description field
+
+**Fixes**:
+- Run metadata generation before export
+- Validate required fields in export request
+- Retry export with same task ID if generation succeeded
+
+### 4) Long-running task stalls
+
+**Symptoms**:
+- Status remains `running` without progress
+
+**Fixes**:
+- Poll `/script/status/{task_id}` for last update time
+- Retry from last successful stage
+- Check service health endpoint before rerun
+
+## Escalation Checklist
+
+- [ ] Task ID captured
+- [ ] Request payload saved
+- [ ] Last successful stage identified
+- [ ] Error code and timestamp logged
+- [ ] Health endpoint status confirmed

--- a/docs-site/docs/features/podcast-maker/workflow-guide.md
+++ b/docs-site/docs/features/podcast-maker/workflow-guide.md
@@ -1,0 +1,70 @@
+# Podcast Maker Workflow Guide
+
+Use this guide to move from idea to published episode efficiently.
+
+## Standard Workflow
+
+```mermaid
+flowchart LR
+    A[Define Episode Goal] --> B[Build Outline]
+    B --> C[Draft Script]
+    C --> D[Voice Render]
+    D --> E[QA + Edit]
+    E --> F[Package + Publish]
+```
+
+## Workflow 1: Weekly Solo Episode
+
+**Best for**: Solopreneurs and creator-led brands.
+
+1. Define one audience pain point and one CTA.
+2. Generate a 4-part outline (hook, context, framework, CTA).
+3. Draft script in conversational tone.
+4. Render single-speaker voice.
+5. Publish with concise show notes and 3 social snippets.
+
+## Workflow 2: Interview-Style Episode
+
+**Best for**: Content teams and B2B marketers.
+
+1. Build host/guest segment map.
+2. Generate question bank and transitions.
+3. Create dual-speaker script blocks.
+4. Render with two voice profiles (or export script for live recording).
+5. Publish with chapter timestamps and key quotes.
+
+## Workflow 3: Campaign-Driven Episode
+
+**Best for**: Marketing teams running launches.
+
+1. Set campaign objective and target keyword cluster.
+2. Generate episode variants by funnel stage.
+3. Produce main episode + short clips.
+4. Create channel-specific descriptions.
+5. Sync outputs with blog and social plans.
+
+## Persona-Focused Workflow Tips
+
+### Technical Audience Persona
+- Use evidence-led structure
+- Keep claims specific and source-aware
+- Add glossary-friendly chapter labels
+
+### Founder/Executive Persona
+- Prioritize business outcomes and narrative clarity
+- Use concise pacing and stronger CTA framing
+- Emphasize practical decisions over theory
+
+### Community/Education Persona
+- Use story-first introductions
+- Keep language approachable
+- Include recap and action checklist in outro
+
+## Handoff Checklist
+
+- [ ] Episode objective clear
+- [ ] Persona selected and validated
+- [ ] Script approved section-by-section
+- [ ] Voice settings tested (pace, pronunciation)
+- [ ] Metadata complete (title, chapters, tags)
+- [ ] Repurposed assets generated

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -42,6 +42,14 @@
 
     [:octicons-arrow-right-24: Persona System](features/persona/overview.md)
 
+-   :material-microphone:{ .lg .middle } **Podcast Maker**
+
+    ---
+
+    Plan, script, and package podcast episodes with AI workflows
+
+    [:octicons-arrow-right-24: Podcast Maker](features/podcast-maker/overview.md)
+
 -   :material-account-group:{ .lg .middle } **User Journeys**
 
     ---
@@ -62,6 +70,7 @@ ALwrity is an AI-powered digital marketing platform that revolutionizes content 
 - **👤 Personalized Writing Personas**: AI-powered writing assistants tailored to your unique voice and style
 - **📊 SEO Dashboard**: Comprehensive SEO analysis with Google Search Console integration
 - **🎯 Content Strategy**: AI-driven persona generation and content planning
+- **🎙️ Podcast Maker**: AI-assisted episode planning, scripting, and narration workflows
 - **🔍 Research Integration**: Automated research and fact-checking capabilities
 - **📈 Performance Analytics**: Track content performance and optimize strategies
 - **🔒 Enterprise Security**: Secure, scalable platform for teams of all sizes
@@ -78,6 +87,7 @@ ALwrity is an AI-powered digital marketing platform that revolutionizes content 
 - [Troubleshooting Common Issues](guides/troubleshooting.md)
 - [API Integration Guide](api/overview.md)
 - [Content Strategy Best Practices](features/content-strategy/overview.md)
+- [Podcast Maker Overview](features/podcast-maker/overview.md)
 - [SEO Optimization Tips](features/seo-dashboard/overview.md)
 
 ### Community & Support

--- a/docs-site/docs/user-journeys/content-creators/features-overview.md
+++ b/docs-site/docs/user-journeys/content-creators/features-overview.md
@@ -45,6 +45,20 @@ This guide provides a comprehensive overview of all ALwrity features available t
 - Identify content gaps and opportunities
 - Optimize your content mix for better results
 
+
+### Podcast Maker
+**AI-Assisted Audio Content Production**
+- **Episode Planning**: Turn ideas into structured episode outlines
+- **Script Generation**: Produce host-ready scripts by segment
+- **Voice Production**: Create narration-ready outputs with style controls
+- **Distribution Packaging**: Generate show notes, chapters, and metadata
+
+**Key Benefits**:
+- Expand into audio content without a full production team
+- Repurpose episodes into blogs and social posts
+- Maintain consistent brand voice across channels
+- Increase content cadence with reusable workflows
+
 ### LinkedIn Writer
 **Professional Content Creation**
 - **LinkedIn-Optimized Content**: Create content specifically for LinkedIn

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -258,16 +258,23 @@ nav:
       - Create Studio: features/image-studio/create-studio.md
       - Edit Studio: features/image-studio/edit-studio.md
       - Upscale Studio: features/image-studio/upscale-studio.md
-      - Social Optimizer: features/image-studio/social-optimizer.md
-      - Asset Library: features/image-studio/asset-library.md
       - Transform Studio: features/image-studio/transform-studio.md
       - Control Studio: features/image-studio/control-studio.md
-      - Workflow Guide: features/image-studio/workflow-guide.md
-      - Providers: features/image-studio/providers.md
+      - Social Optimizer: features/image-studio/social-optimizer.md
+      - Asset Library: features/image-studio/asset-library.md
       - Templates: features/image-studio/templates.md
+      - Providers: features/image-studio/providers.md
       - Cost Guide: features/image-studio/cost-guide.md
+      - Implementation Overview: features/image-studio/implementation-overview.md
+      - Workflow Guide: features/image-studio/workflow-guide.md
       - API Reference: features/image-studio/api-reference.md
-      - Implementation: features/image-studio/implementation-overview.md
+    - Podcast Maker:
+      - Overview: features/podcast-maker/overview.md
+      - Implementation Overview: features/podcast-maker/implementation-overview.md
+      - Workflow Guide: features/podcast-maker/workflow-guide.md
+      - API Reference: features/podcast-maker/api-reference.md
+      - Best Practices: features/podcast-maker/best-practices.md
+      - Troubleshooting: features/podcast-maker/troubleshooting.md
   - API Reference:
     - Overview: api/overview.md
     - Authentication: api/authentication.md


### PR DESCRIPTION
### Motivation

- Surface a new Podcast Maker feature in the docs using the same navigation and stylistic conventions as existing features like `blog-writer` and `image-studio` for discoverability and consistency.
- Provide a complete starter set of docs (overview, implementation, workflow, API, best practices, troubleshooting) so engineering, product, and content teams have a consistent reference for the new feature.

### Description

- Added a new `Features -> Podcast Maker` group in `docs-site/mkdocs.yml` and aligned the `Image Studio` entries to match existing patterns, including `Implementation Overview`, `Workflow Guide`, and `API Reference` entries where appropriate.
- Created `docs-site/docs/features/podcast-maker/` with six pages: `overview.md`, `implementation-overview.md`, `workflow-guide.md`, `api-reference.md`, `best-practices.md`, and `troubleshooting.md`, following the heading, mermaid diagrams, endpoint tables, and persona-focused style used in `blog-writer` and `image-studio`.
- Added cross-links and discovery surfaces: a Podcast Maker card on the docs home (`docs-site/docs/index.md`), a related-features link in `features/blog-writer/overview.md`, related links in `features/image-studio/overview.md`, and a Podcast Maker section in `user-journeys/content-creators/features-overview.md`.
- Committed the new files and navigation changes to the repository (`docs-site/...` files added/updated).

### Testing

- Ran repository status and committed the documentation changes successfully with `git` (changes staged and committed). (succeeded)
- Attempted to build the site with `cd docs-site && mkdocs build`, but the command failed because `mkdocs` is not installed in the current environment; no site build artifacts were produced. (failed due to missing `mkdocs`)
- Performed file-level validations by printing relevant file snippets to confirm the new nav entries and page contents were written as expected. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d4c5aad09c83289e77044cb62e209a)