### PR TITLE
Add broll router to podcast API registrations

### DIFF
--- a/backend/api/podcast/router.py
+++ b/backend/api/podcast/router.py
@@ -12,7 +12,7 @@ from api.story_writer.utils.auth import require_authenticated_user
 from api.story_writer.task_manager import task_manager
 
 # Import all handler routers
-from .handlers import projects, analysis, research, script, audio, images, video, avatar, dubbing
+from .handlers import projects, analysis, research, script, audio, images, video, avatar, dubbing, broll
 
 # Create main router
 router = APIRouter(prefix="/api/podcast", tags=["Podcast Maker"])
@@ -27,6 +27,7 @@ router.include_router(images.router)
 router.include_router(video.router)
 router.include_router(avatar.router)
 router.include_router(dubbing.router)
+router.include_router(broll.router)
 
 
 @router.get("/task/{task_id}/status")


### PR DESCRIPTION
### Motivation
- Ensure the B-roll endpoints are mounted under the same `/api/podcast/...` namespace as the rest of the podcast handlers by registering the `broll` handler with the main podcast router.

### Description
- Import the `broll` handler and register it by adding `from .handlers import ..., broll` and `router.include_router(broll.router)` in `backend/api/podcast/router.py`.

### Testing
- Ran `python -m py_compile backend/api/podcast/router.py` which completed successfully, and verified the podcast handler modules expose `APIRouter()` instances so the `broll` router will be mounted under the existing `/api/podcast` prefix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59347f2e48328873f42c257b3eb8d)