### PR TITLE
Align chart preview endpoint and normalize B-roll preview URLs

### DIFF
--- a/frontend/src/components/PodcastMaker/ScriptEditor/ScriptEditorContext.tsx
+++ b/frontend/src/components/PodcastMaker/ScriptEditor/ScriptEditorContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from "react";
 import { Script, Knobs, Scene, PodcastMode } from "../types";
 import { podcastApi } from "../../../services/podcastApi";
+import { getApiUrl } from "../../../api/client";
 
 interface ScriptEditorContextType {
   // State
@@ -57,6 +58,13 @@ interface ScriptEditorContextType {
 }
 
 const ScriptEditorContext = createContext<ScriptEditorContextType | undefined>(undefined);
+
+const toUsablePreviewUrl = (previewUrl?: string): string | undefined => {
+  if (!previewUrl) return undefined;
+  if (/^https?:\/\//i.test(previewUrl)) return previewUrl;
+  const cleanPath = previewUrl.startsWith("/") ? previewUrl : `/${previewUrl}`;
+  return `${getApiUrl()}${cleanPath}`;
+};
 
 interface ScriptEditorProviderProps {
   children: ReactNode;
@@ -413,7 +421,7 @@ export const ScriptEditorProvider: React.FC<ScriptEditorProviderProps> = ({
             
             return {
               ...scene,
-              broll_preview_url: result.preview_url,
+              broll_preview_url: toUsablePreviewUrl(result.preview_url),
               chart_id: result.chart_id,
             };
           } catch (err) {
@@ -451,7 +459,7 @@ export const ScriptEditorProvider: React.FC<ScriptEditorProviderProps> = ({
       
       const updatedScenes = activeScript.scenes.map((s) =>
         s.id === sceneId
-          ? { ...s, broll_preview_url: result.preview_url, chart_id: result.chart_id }
+          ? { ...s, broll_preview_url: toUsablePreviewUrl(result.preview_url), chart_id: result.chart_id }
           : s
       );
       

--- a/frontend/src/services/podcastApi.ts
+++ b/frontend/src/services/podcastApi.ts
@@ -967,8 +967,10 @@ export const podcastApi = {
     chart_data: Record<string, any>;
     chart_type: string;
     title: string;
-  }): Promise<{ image_url: string; preview_url: string; chart_id: string }> {
-    const response = await aiApiClient.post('/api/podcast/chart/preview', params);
+  }): Promise<{ preview_url: string; chart_id: string }> {
+    // Canonical backend endpoint from api/podcast/handlers/broll.py after router prefix composition:
+    // /api/podcast (main router) + /broll (handler prefix) + /preview/chart (endpoint)
+    const response = await aiApiClient.post('/api/podcast/broll/preview/chart', params);
     return response.data;
   },
 };


### PR DESCRIPTION
### Motivation
- Ensure the frontend calls the exact backend B-roll chart preview route exposed by the podcast router so preview generation works reliably. 
- Make `preview_url` values stored in scene state directly usable by the UI by normalizing relative backend paths to absolute URLs.

### Description
- Updated `podcastApi.generateChartPreview()` to call the canonical backend endpoint `POST /api/podcast/broll/preview/chart` and tightened the returned shape to `{ preview_url, chart_id }` (file: `frontend/src/services/podcastApi.ts`).
- Added `toUsablePreviewUrl()` in `ScriptEditorContext` which uses `getApiUrl()` to convert relative `preview_url` paths into absolute URLs while leaving absolute URLs unchanged (file: `frontend/src/components/PodcastMaker/ScriptEditor/ScriptEditorContext.tsx`).
- Applied the normalization when creating or regenerating chart previews so `scene.broll_preview_url` is stored as a directly usable URL immediately after the API response (same `ScriptEditorContext` file).

### Testing
- Attempted a frontend build with `npm --prefix frontend run -s build` to validate compile/TS surface, but the build failed in this environment because `frontend/node_modules` (including `react-scripts`) is not installed; no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5936ac6e08328875f22cd082caca6)