### PR TITLE
Import scene-composition symbols and fix typing in broll_service

### DIFF
--- a/backend/services/podcast/broll_service.py
+++ b/backend/services/podcast/broll_service.py
@@ -17,6 +17,10 @@ from loguru import logger
 
 # Import chart generators directly
 from services.podcast.broll_composer import (
+    Insight,
+    SceneAssets,
+    dispatch_scene,
+    compose_video,
     make_bar_chart,
     make_horizontal_bar,
     make_line_trend,
@@ -217,7 +221,7 @@ class BrollService:
             logger.error(f"[BrollService] Failed to compose final video: {e}")
             raise
     
-    def cleanup(self, file_paths: List[str] = None):
+    def cleanup(self, file_paths: Optional[List[str]] = None):
         """
         Clean up temporary B-roll files.
         


### PR DESCRIPTION
### Motivation
- Ensure `generate_scene_broll()` can instantiate scene composition objects and call the composer functions without `NameError`, and make the file pass static type checks.

### Description
- Import `Insight`, `SceneAssets`, `dispatch_scene`, and `compose_video` from `services.podcast.broll_composer` alongside the existing chart generators in `backend/services/podcast/broll_service.py`.
- Change `cleanup(self, file_paths: List[str] = None)` to `cleanup(self, file_paths: Optional[List[str]] = None)` to address a `None`-to-`List[str]` typing issue.

### Testing
- Ran `python -m py_compile backend/services/podcast/broll_service.py` which succeeded.
- Ran `pyright backend/services/podcast/broll_service.py` which reported `0 errors, 0 warnings, 0 informations`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5939591248328b7267733b76e3dde)