### PR TITLE
Persist Wix PKCE verifier per-state in DB and enforce one-time use

### DIFF
--- a/backend/api/wix_routes.py
+++ b/backend/api/wix_routes.py
@@ -9,6 +9,7 @@ from fastapi.responses import HTMLResponse
 from typing import Dict, Any, Optional
 from loguru import logger
 from pydantic import BaseModel
+import uuid
 
 from services.wix_service import WixService
 from services.integrations.wix_oauth import WixOAuthService
@@ -63,7 +64,7 @@ class WixConnectionStatus(BaseModel):
 
 
 @router.get("/auth/url")
-async def get_authorization_url(state: Optional[str] = None) -> Dict[str, str]:
+async def get_authorization_url(state: Optional[str] = None, current_user: dict = Depends(get_current_user)) -> Dict[str, str]:
     """
     Get Wix OAuth authorization URL
     
@@ -74,8 +75,21 @@ async def get_authorization_url(state: Optional[str] = None) -> Dict[str, str]:
         Authorization URL
     """
     try:
-        url = wix_service.get_authorization_url(state)
-        return {"authorization_url": url}
+        user_id = current_user.get('id') if current_user else None
+        if not user_id:
+            raise HTTPException(status_code=401, detail="Authentication required")
+
+        oauth_state = state or str(uuid.uuid4())
+        oauth_payload = wix_service.get_authorization_url(oauth_state)
+        saved = wix_oauth_service.store_pkce_verifier(
+            user_id=user_id,
+            state=oauth_state,
+            code_verifier=oauth_payload["code_verifier"],
+            ttl_seconds=600
+        )
+        if not saved:
+            raise HTTPException(status_code=500, detail="Failed to persist OAuth verifier state")
+        return {"authorization_url": oauth_payload["authorization_url"], "state": oauth_state}
     except Exception as e:
         logger.error(f"Failed to generate authorization URL: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -98,8 +112,16 @@ async def handle_oauth_callback(request: WixAuthRequest, current_user: dict = De
         if not user_id:
             raise HTTPException(status_code=400, detail="User ID not found")
         
+        if not request.state:
+            raise HTTPException(status_code=400, detail="Missing OAuth state")
+        code_verifier = wix_oauth_service.consume_pkce_verifier(user_id=user_id, state=request.state)
+        if not code_verifier:
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid or expired OAuth state. Please restart Wix connection."
+            )
         # Exchange code for tokens
-        tokens = wix_service.exchange_code_for_tokens(request.code)
+        tokens = wix_service.exchange_code_for_tokens(request.code, code_verifier=code_verifier)
         
         # Get site information to extract site_id and member_id
         site_info = wix_service.get_site_info(tokens['access_token'])
@@ -152,32 +174,38 @@ async def handle_oauth_callback(request: WixAuthRequest, current_user: dict = De
 async def handle_oauth_callback_get(code: str, state: Optional[str] = None, request: Request = None, current_user: dict = Depends(get_current_user)):
     """HTML callback page for Wix OAuth that exchanges code and notifies opener via postMessage."""
     try:
-        tokens = wix_service.exchange_code_for_tokens(code)
+        user_id = current_user.get('id') if current_user else None
+        if not user_id:
+            raise HTTPException(status_code=401, detail="Authentication required")
+        if not state:
+            raise HTTPException(status_code=400, detail="Missing OAuth state")
+        code_verifier = wix_oauth_service.consume_pkce_verifier(user_id=user_id, state=state)
+        if not code_verifier:
+            raise HTTPException(status_code=400, detail="Invalid or expired OAuth state. Please reconnect Wix.")
+        tokens = wix_service.exchange_code_for_tokens(code, code_verifier=code_verifier)
         site_info = wix_service.get_site_info(tokens['access_token'])
         permissions = wix_service.check_blog_permissions(tokens['access_token'])
         
         # Store tokens in database if we have user_id
-        user_id = current_user.get('id') if current_user else None
-        if user_id:
-            site_id = site_info.get('siteId') or site_info.get('site_id')
-            member_id = None
-            try:
-                member_id = wix_service.extract_member_id_from_access_token(tokens['access_token'])
-            except Exception:
-                pass
-            
-            stored = wix_oauth_service.store_tokens(
-                user_id=user_id,
-                access_token=tokens['access_token'],
-                refresh_token=tokens.get('refresh_token'),
-                expires_in=tokens.get('expires_in'),
-                token_type=tokens.get('token_type', 'Bearer'),
-                scope=tokens.get('scope'),
-                site_id=site_id,
-                member_id=member_id
-            )
-            if not stored:
-                logger.warning(f"Failed to store Wix tokens for user {user_id} in GET callback")
+        site_id = site_info.get('siteId') or site_info.get('site_id')
+        member_id = None
+        try:
+            member_id = wix_service.extract_member_id_from_access_token(tokens['access_token'])
+        except Exception:
+            pass
+        
+        stored = wix_oauth_service.store_tokens(
+            user_id=user_id,
+            access_token=tokens['access_token'],
+            refresh_token=tokens.get('refresh_token'),
+            expires_in=tokens.get('expires_in'),
+            token_type=tokens.get('token_type', 'Bearer'),
+            scope=tokens.get('scope'),
+            site_id=site_id,
+            member_id=member_id
+        )
+        if not stored:
+            logger.warning(f"Failed to store Wix tokens for user {user_id} in GET callback")
 
         # Build success payload for postMessage
         payload = {

--- a/backend/services/integrations/wix_oauth.py
+++ b/backend/services/integrations/wix_oauth.py
@@ -48,7 +48,94 @@ class WixOAuthService:
                     is_active BOOLEAN DEFAULT TRUE
                 )
             ''')
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS wix_oauth_pkce_states (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id TEXT NOT NULL,
+                    state TEXT NOT NULL UNIQUE,
+                    code_verifier TEXT NOT NULL,
+                    expires_at TIMESTAMP NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    used_at TIMESTAMP
+                )
+            ''')
+            cursor.execute('''
+                CREATE INDEX IF NOT EXISTS idx_wix_oauth_pkce_user_state
+                ON wix_oauth_pkce_states (user_id, state)
+            ''')
             conn.commit()
+
+    def cleanup_expired_pkce_states(self, user_id: str) -> int:
+        """Delete expired or already-used PKCE state records."""
+        try:
+            self._init_db(user_id)
+            db_path = self._get_db_path(user_id)
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    '''
+                    DELETE FROM wix_oauth_pkce_states
+                    WHERE used_at IS NOT NULL OR expires_at <= datetime('now')
+                    '''
+                )
+                deleted = cursor.rowcount
+                conn.commit()
+                return deleted if deleted is not None else 0
+        except Exception as e:
+            logger.warning(f"Failed to cleanup expired Wix PKCE states for user {user_id}: {e}")
+            return 0
+
+    def store_pkce_verifier(self, user_id: str, state: str, code_verifier: str, ttl_seconds: int = 600) -> bool:
+        """Store PKCE code verifier by OAuth state with short TTL."""
+        try:
+            self._init_db(user_id)
+            self.cleanup_expired_pkce_states(user_id)
+            db_path = self._get_db_path(user_id)
+            expires_at = datetime.now() + timedelta(seconds=ttl_seconds)
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    '''
+                    INSERT OR REPLACE INTO wix_oauth_pkce_states (user_id, state, code_verifier, expires_at, created_at, used_at)
+                    VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, NULL)
+                    ''',
+                    (user_id, state, code_verifier, expires_at)
+                )
+                conn.commit()
+            return True
+        except Exception as e:
+            logger.error(f"Failed storing Wix PKCE verifier for user {user_id}, state {state}: {e}")
+            return False
+
+    def consume_pkce_verifier(self, user_id: str, state: str) -> Optional[str]:
+        """Get and invalidate one-time PKCE verifier for a state if valid and unexpired."""
+        try:
+            self._init_db(user_id)
+            self.cleanup_expired_pkce_states(user_id)
+            db_path = self._get_db_path(user_id)
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    '''
+                    SELECT id, code_verifier
+                    FROM wix_oauth_pkce_states
+                    WHERE user_id = ? AND state = ? AND used_at IS NULL AND expires_at > datetime('now')
+                    LIMIT 1
+                    ''',
+                    (user_id, state)
+                )
+                row = cursor.fetchone()
+                if not row:
+                    return None
+                cursor.execute(
+                    "UPDATE wix_oauth_pkce_states SET used_at = CURRENT_TIMESTAMP WHERE id = ?",
+                    (row[0],)
+                )
+                conn.commit()
+                return row[1]
+        except Exception as e:
+            logger.error(f"Failed consuming Wix PKCE verifier for user {user_id}, state {state}: {e}")
+            return None
     
     def store_tokens(
         self,
@@ -302,4 +389,3 @@ class WixOAuthService:
         except Exception as e:
             logger.error(f"Error revoking Wix token: {e}")
             return False
-

--- a/backend/services/wix_service.py
+++ b/backend/services/wix_service.py
@@ -40,7 +40,7 @@ class WixService:
         if not self.client_id:
             logger.warning("Wix client ID not configured. Set WIX_CLIENT_ID environment variable.")
     
-    def get_authorization_url(self, state: str = None) -> str:
+    def get_authorization_url(self, state: str = None) -> Dict[str, str]:
         """
         Generate Wix OAuth authorization URL for "on behalf of user" authentication
         
@@ -54,8 +54,7 @@ class WixService:
             Authorization URL for user to visit
         """
         url, code_verifier = self.auth_service.generate_authorization_url(state)
-        self._code_verifier = code_verifier
-        return url
+        return {"authorization_url": url, "state": state, "code_verifier": code_verifier}
     
     def _create_redirect_session_for_auth(self, redirect_uri: str, client_id: str, code_challenge: str, state: str) -> str:
         """
@@ -97,13 +96,13 @@ class WixService:
             logger.error(f"Failed to create redirect session for auth: {e}")
             raise
     
-    def exchange_code_for_tokens(self, code: str, code_verifier: str = None) -> Dict[str, Any]:
+    def exchange_code_for_tokens(self, code: str, code_verifier: str) -> Dict[str, Any]:
         """
         Exchange authorization code for access and refresh tokens using PKCE
         
         Args:
             code: Authorization code from Wix
-            code_verifier: PKCE code verifier (uses stored one if not provided)
+            code_verifier: PKCE code verifier
             
         Returns:
             Token response with access_token, refresh_token, etc.
@@ -111,9 +110,7 @@ class WixService:
         if not self.client_id:
             raise ValueError("Wix client ID not configured")
         if not code_verifier:
-            code_verifier = getattr(self, '_code_verifier', None)
-            if not code_verifier:
-                raise ValueError("Code verifier not found. Please provide code_verifier parameter.")
+            raise ValueError("Code verifier is required.")
         try:
             return self.auth_service.exchange_code_for_tokens(code, code_verifier)
         except requests.RequestException as e:


### PR DESCRIPTION
### Motivation
- Replace in-memory storage of PKCE `code_verifier` with durable per-`state` storage to support multi-process deployments and avoid instance-scoped secrets.
- Ensure the verifier is owned by the initiating user, is single-use, and expires shortly to reduce attack surface.
- Surface clear errors when a callback arrives with a missing, expired, or already-consumed `state` so callers can retry cleanly.

### Description
- Added a new `wix_oauth_pkce_states` table and index and implemented `store_pkce_verifier`, `consume_pkce_verifier`, and `cleanup_expired_pkce_states` in `services/integrations/wix_oauth.py` to persist verifier + TTL and to atomically consume/invalidate it.
- Changed `WixService.get_authorization_url` to return a payload (`authorization_url`, `state`, `code_verifier`) instead of storing the verifier on the service instance and made `exchange_code_for_tokens` require an explicit `code_verifier` argument.
- Updated `GET /api/wix/auth/url` to require authentication, generate a `state` when absent, persist the `code_verifier` for the current `user_id` with a short TTL, and return only the URL and `state` to the client.
- Updated `POST /api/wix/auth/callback` and `GET /api/wix/callback` to validate presence of `state`, look up and consume the verifier scoped to the authenticated `user_id`, return a clear 400 error for invalid/expired states, and use the consumed verifier for token exchange and subsequent token storage.

### Testing
- Ran `python -m py_compile backend/services/wix_service.py backend/services/integrations/wix_oauth.py backend/api/wix_routes.py` and it completed successfully.
- Verified that route code paths now call `store_pkce_verifier` and `consume_pkce_verifier` and that callbacks return explicit 400 errors when a `state` is missing or invalid during local testing of the flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01aa0ffabc8328b5d0dc4d320408f3)