### PR TITLE
Harden Wix test endpoints and exclude them from production startup

### DIFF
--- a/backend/alwrity_utils/router_manager.py
+++ b/backend/alwrity_utils/router_manager.py
@@ -45,6 +45,7 @@ OPTIONAL_ROUTER_REGISTRY = [
     {"name": "blog_writer", "module": "api.blog_writer.router", "attr": "router", "features": {"all", "blog-writer"}},
     {"name": "story_writer", "module": "api.story_writer.router", "attr": "router", "features": {"all", "story-writer"}},
     {"name": "wix", "module": "api.wix_routes", "attr": "router", "features": {"all"}},
+    {"name": "wix_test", "module": "api.wix_routes", "attr": "qa_router", "features": {"all"}},
     {"name": "blog_seo_analysis", "module": "api.blog_writer.seo_analysis", "attr": "router", "features": {"all", "blog-writer"}},
     {"name": "persona", "module": "api.persona_routes", "attr": "router", "features": {"all", "persona"}},
     {"name": "video_studio", "module": "api.video_studio.router", "attr": "router", "features": {"all", "video-studio"}},
@@ -159,6 +160,12 @@ class RouterManager:
                 logger.info(f"Including {group_name} routers with features: {enabled_features}...")
             
             for entry in registry:
+                if entry["name"] == "wix_test" and not self._should_include_wix_test_router():
+                    reason = "wix test routes disabled or running in production environment"
+                    self.skipped_routers.append({"name": entry["name"], "reason": reason})
+                    if verbose:
+                        logger.info(f"⏭️  Skipping {entry['name']}: {reason}")
+                    continue
                 if not self._should_include_router(entry, enabled_features):
                     reason = f"features {enabled_features} not matching {entry.get('features', set())}"
                     self.skipped_routers.append({"name": entry["name"], "reason": reason})
@@ -178,6 +185,13 @@ class RouterManager:
         except Exception as e:
             logger.error(f"❌ Error including {group_name} routers: {e}")
             return False
+
+    @staticmethod
+    def _should_include_wix_test_router() -> bool:
+        environment = (os.getenv("ENVIRONMENT") or os.getenv("APP_ENV") or "development").strip().lower()
+        is_production = environment in {"prod", "production"}
+        wix_test_enabled = os.getenv("WIX_TEST_ROUTES_ENABLED", "false").lower() in {"1", "true", "yes", "on"}
+        return wix_test_enabled and not is_production
     
     def include_core_routers(self) -> bool:
         """Include core application routers."""

--- a/backend/api/wix_routes.py
+++ b/backend/api/wix_routes.py
@@ -16,6 +16,7 @@ from middleware.auth_middleware import get_current_user
 import os
 
 router = APIRouter(prefix="/api/wix", tags=["Wix Integration"])
+qa_router = APIRouter(prefix="/api/wix/test", tags=["Wix Integration QA"])
 
 # Initialize Wix service
 wix_service = WixService()
@@ -60,6 +61,39 @@ class WixConnectionStatus(BaseModel):
     site_info: Optional[Dict[str, Any]] = None
     permissions: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
+
+
+def _is_wix_test_mode_enabled() -> bool:
+    return os.getenv("WIX_TEST_ROUTES_ENABLED", "false").lower() in {"1", "true", "yes", "on"}
+
+
+def _is_admin_user(current_user: Dict[str, Any]) -> bool:
+    email = (current_user.get("email") or "").lower()
+    role = current_user.get("role")
+    public_metadata = current_user.get("public_metadata")
+    if isinstance(public_metadata, dict):
+        role = public_metadata.get("role") or role
+
+    admin_emails = {
+        e.strip().lower()
+        for e in os.getenv("ADMIN_EMAILS", "").split(",")
+        if e.strip()
+    }
+    admin_domain = (os.getenv("ADMIN_EMAIL_DOMAIN") or "").lower().strip()
+
+    return bool(
+        role == "admin"
+        or (email and email in admin_emails)
+        or (email and admin_domain and email.endswith(f"@{admin_domain}"))
+    )
+
+
+def _require_wix_test_access(current_user: Dict[str, Any] = Depends(get_current_user)) -> Dict[str, Any]:
+    if not _is_wix_test_mode_enabled():
+        raise HTTPException(status_code=404, detail="Not found")
+    if not _is_admin_user(current_user):
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return current_user
 
 
 @router.get("/auth/url")
@@ -454,8 +488,8 @@ async def disconnect_wix(current_user: dict = Depends(get_current_user)) -> Dict
 # TEST ENDPOINTS - No authentication required for testing
 # =============================================================================
 
-@router.get("/test/connection/status")
-async def get_test_connection_status() -> WixConnectionStatus:
+@qa_router.get("/connection/status")
+async def get_test_connection_status(_: Dict[str, Any] = Depends(_require_wix_test_access)) -> WixConnectionStatus:
     """
     TEST ENDPOINT: Check Wix connection status without authentication
     
@@ -480,8 +514,8 @@ async def get_test_connection_status() -> WixConnectionStatus:
         )
 
 
-@router.get("/test/auth/url")
-async def get_test_authorization_url(state: Optional[str] = None) -> Dict[str, str]:
+@qa_router.get("/auth/url")
+async def get_test_authorization_url(state: Optional[str] = None, _: Dict[str, Any] = Depends(_require_wix_test_access)) -> Dict[str, str]:
     """
     TEST ENDPOINT: Get Wix OAuth authorization URL without authentication
     
@@ -518,8 +552,8 @@ async def get_test_authorization_url(state: Optional[str] = None) -> Dict[str, s
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post("/test/publish")
-async def test_publish_to_wix(request: WixPublishRequest) -> Dict[str, Any]:
+@qa_router.post("/publish")
+async def test_publish_to_wix(request: WixPublishRequest, _: Dict[str, Any] = Depends(_require_wix_test_access)) -> Dict[str, Any]:
     """
     TEST ENDPOINT: Simulate publishing a blog post to Wix without authentication.
 
@@ -571,8 +605,8 @@ async def refresh_wix_token(request: Dict[str, Any]) -> Dict[str, Any]:
         raise HTTPException(status_code=500, detail=f"Failed to refresh token: {str(e)}")
 
 
-@router.post("/test/publish/real")
-async def test_publish_real(payload: Dict[str, Any]) -> Dict[str, Any]:
+@qa_router.post("/publish/real")
+async def test_publish_real(payload: Dict[str, Any], _: Dict[str, Any] = Depends(_require_wix_test_access)) -> Dict[str, Any]:
     """
     TEST ENDPOINT: Perform a real publish to Wix using a provided access token.
 
@@ -649,8 +683,8 @@ async def test_publish_real(payload: Dict[str, Any]) -> Dict[str, Any]:
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post("/test/category")
-async def test_create_category(request: WixCreateCategoryRequest) -> Dict[str, Any]:
+@qa_router.post("/category")
+async def test_create_category(request: WixCreateCategoryRequest, _: Dict[str, Any] = Depends(_require_wix_test_access)) -> Dict[str, Any]:
     try:
         result = wix_service.create_category(
             access_token=request.access_token,
@@ -664,8 +698,8 @@ async def test_create_category(request: WixCreateCategoryRequest) -> Dict[str, A
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post("/test/tag")
-async def test_create_tag(request: WixCreateTagRequest) -> Dict[str, Any]:
+@qa_router.post("/tag")
+async def test_create_tag(request: WixCreateTagRequest, _: Dict[str, Any] = Depends(_require_wix_test_access)) -> Dict[str, Any]:
     try:
         result = wix_service.create_tag(
             access_token=request.access_token,


### PR DESCRIPTION
### Motivation
- Prevent accidental exposure of internal QA/test Wix endpoints under `/api/wix/test` in production. 
- Require explicit opt-in and admin authorization for any retained internal testing flows.

### Description
- Split test routes onto a dedicated `qa_router` mounted at `/api/wix/test` and left the main integration `router` unchanged. 
- Added runtime checks and helpers: `WIX_TEST_ROUTES_ENABLED` feature flag, `_is_admin_user`, and `_require_wix_test_access` which enforces admin auth and returns `404` when the feature flag is off or `403` when the caller is not an admin. 
- Updated retained test endpoints to use the `qa_router` and require the `_require_wix_test_access` dependency for access. 
- Registered a new optional router entry `wix_test` in `OPTIONAL_ROUTER_REGISTRY` and added startup gating in `RouterManager._should_include_wix_test_router` so the QA router only mounts when `WIX_TEST_ROUTES_ENABLED` is true and the app is not running in production (`ENVIRONMENT`/`APP_ENV` not in `prod|production`).

### Testing
- Ran `python -m py_compile backend/api/wix_routes.py backend/alwrity_utils/router_manager.py` to validate syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01aa19cef48328ae22f4efe197c545)