### PR TITLE
Introduce canonical workspace path helpers and migrate workspace management to use them

### DIFF
--- a/backend/api/podcast/constants.py
+++ b/backend/api/podcast/constants.py
@@ -5,14 +5,13 @@ Centralized constants and directory configuration for podcast module.
 All workspace paths use utils.storage_paths for root resolution.
 """
 
-import os
 from pathlib import Path
 from typing import Literal
 from loguru import logger
 from services.story_writer.audio_generation_service import StoryAudioGenerationService
-from utils.storage_paths import get_repo_root, sanitize_user_id as _sanitize_user_id
+from services.workspace_paths import get_workspace_root, get_user_workspace_dir
 
-ROOT_DIR = get_repo_root()
+ROOT_DIR = get_workspace_root().parent
 
 # Video subdirectory (relative to workspace media dir)
 AI_VIDEO_SUBDIR = Path("AI_Videos")
@@ -45,15 +44,10 @@ def get_podcast_media_dir(
     }[media_type]
 
     if user_id:
-        sanitized = _sanitize_user_id(user_id)
-        resolved_dir = (
-            ROOT_DIR / "workspace" / f"workspace_{sanitized}" / "media" / media_subdir
-        ).resolve()
+        resolved_dir = (get_user_workspace_dir(user_id) / "media" / media_subdir).resolve()
     else:
         logger.warning(f"[Podcast] get_podcast_media_dir called without user_id for {media_type} — using default workspace. This should not happen in production.")
-        resolved_dir = (
-            ROOT_DIR / "workspace" / "workspace_alwrity" / "media" / media_subdir
-        ).resolve()
+        resolved_dir = (get_workspace_root() / "workspace_alwrity" / "media" / media_subdir).resolve()
 
     if ensure_exists:
         resolved_dir.mkdir(parents=True, exist_ok=True)

--- a/backend/services/user_workspace_manager.py
+++ b/backend/services/user_workspace_manager.py
@@ -3,10 +3,8 @@ User Workspace Manager
 Handles user-specific workspace creation, configuration, and progressive setup.
 """
 
-import os
 import json
 import shutil
-from pathlib import Path
 from typing import Dict, Any, Optional, List
 from datetime import datetime
 from loguru import logger
@@ -14,6 +12,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import text
 
 from services.database import init_user_database, ensure_user_workspace_db_directory
+from services.workspace_paths import get_workspace_root, get_user_workspace_dir
 from services.workspace_dirs import ensure_user_workspace_dirs
 
 class UserWorkspaceManager:
@@ -21,22 +20,10 @@ class UserWorkspaceManager:
     
     def __init__(self, db_session: Session):
         self.db = db_session
-        # Use environment-safe paths for production
-        if os.getenv("RENDER") or os.getenv("RAILWAY") or os.getenv("HEROKU"):
-            # In production, use temp directories or skip file operations
-            self.base_workspace_dir = Path("/tmp/alwrity_workspace")
-            self.user_workspaces_dir = self.base_workspace_dir / "users"
-        else:
-            # In development, use project root 'workspace' directory
-            # services/user_workspace_manager.py -> services -> backend -> root
-            root_dir = Path(__file__).parent.parent.parent
-            self.base_workspace_dir = root_dir / "workspace"
-            self.user_workspaces_dir = self.base_workspace_dir
+        # Use canonical workspace root in all environments
+        self.base_workspace_dir = get_workspace_root()
+        self.user_workspaces_dir = self.base_workspace_dir
         
-    def _sanitize_user_id(self, user_id: str) -> str:
-        """Sanitize user_id to be safe for filesystem (matches database.py logic)."""
-        return "".join(c for c in user_id if c.isalnum() or c in ('-', '_'))
-
     def _ensure_workspace_db_directory(self, user_id: str) -> None:
         """Ensure workspace uses canonical `db/` layout via database service authority."""
         ensure_user_workspace_db_directory(user_id)
@@ -47,23 +34,8 @@ class UserWorkspaceManager:
         try:
             logger.info(f"Creating workspace for user {user_id}")
             
-            # Sanitize user_id
-            safe_user_id = self._sanitize_user_id(user_id)
-            
-            # Check if we're in production and skip file operations if needed
-            if os.getenv("RENDER") or os.getenv("RAILWAY") or os.getenv("HEROKU"):
-                logger.info("Production environment detected - skipping file workspace creation")
-                return {
-                    "user_id": user_id,
-                    "workspace_path": "/tmp/alwrity_workspace/users/user_" + safe_user_id,
-                    "config": self._create_user_config(user_id),
-                    "created_at": datetime.utcnow().isoformat(),
-                    "production_mode": True
-                }
-            
-            # Create user-specific directories
-            # Format: workspaces/workspace_{user_id}
-            user_dir = self.user_workspaces_dir / f"workspace_{safe_user_id}"
+            # Create user-specific directories (canonical layout)
+            user_dir = get_user_workspace_dir(user_id)
             user_dir.mkdir(parents=True, exist_ok=True)
 
             # Ensure canonical DB directory and migrate legacy layout if needed
@@ -160,8 +132,7 @@ class UserWorkspaceManager:
     
     def get_user_workspace(self, user_id: str) -> Optional[Dict[str, Any]]:
         """Get user workspace information."""
-        safe_user_id = self._sanitize_user_id(user_id)
-        user_dir = self.user_workspaces_dir / f"workspace_{safe_user_id}"
+        user_dir = get_user_workspace_dir(user_id)
         
         if not user_dir.exists():
             return None
@@ -180,8 +151,7 @@ class UserWorkspaceManager:
     def update_user_config(self, user_id: str, updates: Dict[str, Any]) -> bool:
         """Update user configuration."""
         try:
-            safe_user_id = self._sanitize_user_id(user_id)
-            user_dir = self.user_workspaces_dir / f"workspace_{safe_user_id}"
+            user_dir = get_user_workspace_dir(user_id)
             config_file = user_dir / "config" / "user_config.json"
             
             if config_file.exists():
@@ -330,8 +300,7 @@ class UserWorkspaceManager:
     def cleanup_user_workspace(self, user_id: str) -> bool:
         """Clean up user workspace (for account deletion)."""
         try:
-            safe_user_id = self._sanitize_user_id(user_id)
-            user_dir = self.user_workspaces_dir / f"workspace_{safe_user_id}"
+            user_dir = get_user_workspace_dir(user_id)
             if user_dir.exists():
                 shutil.rmtree(user_dir)
             

--- a/backend/services/workspace_dirs.py
+++ b/backend/services/workspace_dirs.py
@@ -6,7 +6,7 @@ Centralizes directory creation so API/service imports stay side-effect free.
 from pathlib import Path
 from typing import Iterable, Optional, Set
 
-from services.database import WORKSPACE_DIR
+from services.workspace_paths import get_user_workspace_dir
 
 
 GLOBAL_OPERATIONAL_DIRS = {
@@ -42,10 +42,6 @@ USER_CAPABILITY_DIRS = {
 }
 
 
-def _sanitize_user_id(user_id: str) -> str:
-    return "".join(c for c in user_id if c.isalnum() or c in ("-", "_"))
-
-
 def ensure_global_operational_dirs(dir_names: Optional[Iterable[str]] = None) -> None:
     """Create only operational global directories (logs/temp), on demand."""
     targets = set(dir_names or GLOBAL_OPERATIONAL_DIRS.keys())
@@ -62,8 +58,7 @@ def ensure_user_workspace_dirs(user_id: str, capabilities: Optional[Iterable[str
         user_id: tenant/user identifier.
         capabilities: iterable of capability keys from USER_CAPABILITY_DIRS.
     """
-    safe_user_id = _sanitize_user_id(user_id)
-    user_dir = Path(WORKSPACE_DIR) / f"workspace_{safe_user_id}"
+    user_dir = get_user_workspace_dir(user_id)
 
     requested = set(capabilities or {"core"})
     requested.add("core")

--- a/backend/services/workspace_paths.py
+++ b/backend/services/workspace_paths.py
@@ -1,0 +1,20 @@
+"""Canonical workspace path helpers.
+
+This module is the single authority for resolving tenant workspace paths.
+"""
+
+from pathlib import Path
+
+from services.database import WORKSPACE_DIR
+from utils.storage_paths import sanitize_user_id
+
+
+def get_workspace_root() -> Path:
+    """Return canonical workspace root directory path."""
+    return Path(WORKSPACE_DIR)
+
+
+def get_user_workspace_dir(user_id: str) -> Path:
+    """Return canonical tenant workspace directory path for user_id."""
+    safe_user_id = sanitize_user_id(user_id)
+    return get_workspace_root() / f"workspace_{safe_user_id}"


### PR DESCRIPTION
### Motivation
- Centralize and standardize resolution of tenant workspace paths to remove ad-hoc path and sanitization logic scattered across services.
- Make workspace root handling consistent across environments and remove environment-special-casing for path building.
- Reduce duplication of `workspace` path logic and provide a single authority for future path-related changes.

### Description
- Add `services/workspace_paths.py` with `get_workspace_root()` and `get_user_workspace_dir(user_id)` as the canonical path helpers using `services.database.WORKSPACE_DIR` and `utils.storage_paths.sanitize_user_id`.
- Update `backend/api/podcast/constants.py` to use `get_workspace_root()` and `get_user_workspace_dir()` instead of ad-hoc `get_repo_root()` and manual sanitization, and adjust `ROOT_DIR` semantics accordingly.
- Refactor `backend/services/user_workspace_manager.py` to use `get_workspace_root()` and `get_user_workspace_dir()` for all workspace operations, remove environment-specific workspace path branching, and drop a local `_sanitize_user_id` helper.
- Update `backend/services/workspace_dirs.py` to call `get_user_workspace_dir()` and remove duplicated sanitization and `WORKSPACE_DIR` direct usage.

### Testing
- No new automated tests were added for this refactor and no behavior-changing unit tests were included.
- Ran the existing backend test suite with `pytest` against the modified modules and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b2303744832885b1868c3ff62aeb)