### PR TITLE
Add social goal persistence models and register them in DB bootstrap

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -2,3 +2,5 @@
 
 # Import onboarding models to make them available globally
 from .onboarding import OnboardingSession, APIKey, WebsiteAnalysis, ResearchPreferences, PersonaData, CompetitorAnalysis
+# Import goal/autonomy models for metadata discovery
+from .social_spaces import GoalInstance, GoalCheckpoint, GoalActionLog

--- a/backend/models/social_spaces.py
+++ b/backend/models/social_spaces.py
@@ -1,0 +1,88 @@
+"""Models for autonomous social/goal execution tracking."""
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, JSON, String, Text
+from sqlalchemy.orm import relationship
+
+from models.enhanced_strategy_models import Base
+
+
+class GoalInstance(Base):
+    """A persisted goal configuration and execution state for a user."""
+
+    __tablename__ = "goal_instances"
+    __table_args__ = (
+        Index("ix_goal_instances_user_id", "user_id"),
+        Index("ix_goal_instances_status", "status"),
+        Index("ix_goal_instances_next_wakeup_at", "next_wakeup_at"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(String(255), nullable=False)
+    goal_type = Column(String(100), nullable=False)
+    objective_json = Column(JSON, nullable=False)
+    cadence_json = Column(JSON, nullable=False)
+    status = Column(String(50), nullable=False, default="active")
+
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+    next_wakeup_at = Column(DateTime, nullable=True)
+    last_error = Column(Text, nullable=True)
+
+    checkpoints = relationship(
+        "GoalCheckpoint",
+        back_populates="goal_instance",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+    action_logs = relationship(
+        "GoalActionLog",
+        back_populates="goal_instance",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+
+class GoalCheckpoint(Base):
+    """Checkpoint schedule and execution metadata for a goal instance."""
+
+    __tablename__ = "goal_checkpoints"
+
+    id = Column(Integer, primary_key=True)
+    goal_instance_id = Column(
+        Integer,
+        ForeignKey("goal_instances.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    checkpoint_key = Column(String(30), nullable=False)
+    scheduled_for = Column(DateTime, nullable=False)
+    executed_at = Column(DateTime, nullable=True)
+    status = Column(String(50), nullable=False, default="scheduled", index=True)
+    result_summary = Column(Text, nullable=True)
+    metrics_snapshot_json = Column(JSON, nullable=True)
+
+    goal_instance = relationship("GoalInstance", back_populates="checkpoints")
+
+
+class GoalActionLog(Base):
+    """Audit records for autonomous actions, edits, and escalations."""
+
+    __tablename__ = "goal_action_logs"
+
+    id = Column(Integer, primary_key=True)
+    goal_instance_id = Column(
+        Integer,
+        ForeignKey("goal_instances.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    action_type = Column(String(100), nullable=False)
+    actor = Column(String(100), nullable=True)
+    status = Column(String(50), nullable=False, default="success", index=True)
+    summary = Column(Text, nullable=True)
+    payload_json = Column(JSON, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+
+    goal_instance = relationship("GoalInstance", back_populates="action_logs")

--- a/backend/services/database.py
+++ b/backend/services/database.py
@@ -45,6 +45,7 @@ import models.website_analysis_monitoring_models
 import models.platform_insights_monitoring_models
 import models.agent_activity_models
 import models.daily_workflow_models
+import models.social_spaces
 
 # Database configuration
 # Get project root (3 levels up from services/database.py: services -> backend -> root)


### PR DESCRIPTION
### Motivation
- Persist autonomous social/goal execution state and checkpoints so scheduler and automation components can track, execute, and audit goal-driven workflows.
- Expose the new models to the existing metadata/bootstrap path so `EnhancedStrategyBase.metadata.create_all()` picks up the tables for tenant databases.

### Description
- Added `backend/models/social_spaces.py` with `GoalInstance` (fields: `id`, `user_id`, `goal_type`, `objective_json`, `cadence_json`, `status`, `created_at`, `updated_at`, `next_wakeup_at`, `last_error`).
- Added `GoalCheckpoint` (fields: `goal_instance_id`, `checkpoint_key`, `scheduled_for`, `executed_at`, `status`, `result_summary`, `metrics_snapshot_json`) and `GoalActionLog` (audit fields including `action_type`, `actor`, `status`, `summary`, `payload_json`, `created_at`).
- Added indexes on `user_id`, `status`, and `next_wakeup_at`, and wired foreign keys with `ondelete="CASCADE"` and relationship cascades for automatic cleanup.
- Registered the models for discovery by importing them in `backend/models/__init__.py` and adding `import models.social_spaces` to `backend/services/database.py` so the DB bootstrap will include the new tables.

### Testing
- Ran `python -m py_compile backend/models/social_spaces.py backend/services/database.py backend/models/__init__.py` and the files compiled successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad837045c8328aa5718b88f4f2931)