### PR TITLE
NCI-based publish pre-flight deferral and traffic-control window

### DIFF
--- a/backend/services/scheduler/core/task_execution_handler.py
+++ b/backend/services/scheduler/core/task_execution_handler.py
@@ -4,10 +4,17 @@ Handles asynchronous execution of individual tasks with proper session isolation
 """
 
 from typing import TYPE_CHECKING, Any, Dict, Optional
+from datetime import datetime
 from sqlalchemy.orm import object_session
 
 from services.database import get_db_session
+from services.intelligence.agents.market_signal_detector import get_market_signal_summary
 from utils.logger_utils import get_service_logger
+from ..utils.traffic_control import (
+    apply_recalibrated_window_to_task,
+    compute_recalibrated_deployment_window,
+    upsert_deferral_metadata,
+)
 from .exception_handler import (
     SchedulerException, TaskExecutionError, DatabaseError, SchedulerConfigError
 )
@@ -16,6 +23,27 @@ if TYPE_CHECKING:
     from .scheduler import TaskScheduler
 
 logger = get_service_logger("task_execution_handler")
+
+NCI_HIGH_THRESHOLD = 0.65
+PUBLISH_TASK_TYPES = {"publish", "content_publish", "social_publish", "daily_publish_task"}
+
+
+def _is_publish_capable_task(task_type: str, task: Any) -> bool:
+    if task_type in PUBLISH_TASK_TYPES or "publish" in (task_type or ""):
+        return True
+    if getattr(task, "pillar_id", None) == "publish":
+        return True
+    if getattr(task, "action_type", None) == "publish":
+        return True
+    return bool(getattr(task, "can_publish", False))
+
+
+def _extract_nci(summary: Dict[str, Any]) -> float:
+    high_priority = float(summary.get("high_priority_signals", 0) or 0)
+    total = float(summary.get("total_signals", 0) or 0)
+    avg_impact = float(summary.get("average_impact_score", 0) or 0)
+    urgency_ratio = (high_priority / total) if total > 0 else 0.0
+    return min(1.0, max(0.0, (urgency_ratio * 0.7) + (avg_impact * 0.3)))
 
 
 async def execute_task_async(
@@ -143,6 +171,49 @@ async def execute_task_async(
             scheduler._update_user_stats(user_id, success=False)
             return
         
+        # Pre-flight hook for publish-capable tasks:
+        # evaluate market volatility/NCI before dispatching publish execution.
+        if _is_publish_capable_task(task_type, task) and user_id:
+            market_summary = await get_market_signal_summary(str(user_id))
+            nci_score = _extract_nci(market_summary)
+            if nci_score >= NCI_HIGH_THRESHOLD:
+                task_db_id = getattr(task, "id", "unknown")
+                reason_code = "high_nci"
+                marker_epoch = datetime.utcnow().strftime("%Y%m%d%H")
+                deferral_marker = f"{task_type}:{task_db_id}:{reason_code}:{marker_epoch}"
+
+                recalibrated_window = compute_recalibrated_deployment_window()
+                apply_recalibrated_window_to_task(task, recalibrated_window)
+
+                metadata = {
+                    "deferral_marker": deferral_marker,
+                    "reason": reason_code,
+                    "nci_score": nci_score,
+                    "market_signal_summary": {
+                        "total_signals": market_summary.get("total_signals", 0),
+                        "high_priority_signals": market_summary.get("high_priority_signals", 0),
+                        "average_impact_score": market_summary.get("average_impact_score", 0),
+                    },
+                    "recalibrated_window": recalibrated_window,
+                    "deferred_at": datetime.utcnow().isoformat(),
+                }
+                upsert_deferral_metadata(task, metadata)
+
+                if hasattr(task, "status"):
+                    task.status = "deferred"
+                db.commit()
+
+                scheduler.stats['tasks_skipped'] += 1
+                scheduler._update_user_stats(user_id, success=True)
+                if summary:
+                    summary.setdefault('skipped', 0)
+                    summary['skipped'] += 1
+                logger.info(
+                    f"[Scheduler] ⏸️ Deferred publish task {task_type}_{task_db_id} due to high NCI "
+                    f"(nci={nci_score:.3f}, threshold={NCI_HIGH_THRESHOLD})"
+                )
+                return
+
         # Execute task with its own session (with error handling)
         try:
             result = await executor.execute_task(task, db)
@@ -221,4 +292,3 @@ async def execute_task_async(
         # Remove from active executions
         if task_id in scheduler.active_executions:
             del scheduler.active_executions[task_id]
-

--- a/backend/services/scheduler/utils/traffic_control.py
+++ b/backend/services/scheduler/utils/traffic_control.py
@@ -1,0 +1,68 @@
+"""Traffic-control utilities for publish task pre-flight decisions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+
+DEFAULT_DEFER_MINUTES = 180
+
+
+def compute_recalibrated_deployment_window(
+    now: Optional[datetime] = None,
+    delay_minutes: int = DEFAULT_DEFER_MINUTES,
+) -> Dict[str, str]:
+    """Compute deployment window metadata for deferred publish tasks."""
+    current = now or datetime.utcnow()
+    next_window = current + timedelta(minutes=max(1, int(delay_minutes)))
+    return {
+        "recalibrated_at": current.isoformat(),
+        "next_eligible_at": next_window.isoformat(),
+        "delay_minutes": str(max(1, int(delay_minutes))),
+    }
+
+
+def apply_recalibrated_window_to_task(task: Any, window: Dict[str, str]) -> None:
+    """Persist recalibrated window on known scheduler timing fields."""
+    next_eligible = datetime.fromisoformat(window["next_eligible_at"])
+
+    if hasattr(task, "next_execution"):
+        task.next_execution = next_eligible
+    if hasattr(task, "next_check"):
+        task.next_check = next_eligible
+
+
+def upsert_deferral_metadata(task: Any, metadata: Dict[str, Any]) -> bool:
+    """Store deferral metadata idempotently.
+
+    Returns True if metadata was newly written or updated, False if already present
+    with the same deferral marker.
+    """
+    existing: Dict[str, Any] = {}
+    if hasattr(task, "result_data") and isinstance(getattr(task, "result_data", None), dict):
+        existing = dict(task.result_data or {})
+        carrier = "result_data"
+    elif hasattr(task, "metadata_json") and isinstance(getattr(task, "metadata_json", None), dict):
+        existing = dict(task.metadata_json or {})
+        carrier = "metadata_json"
+    else:
+        existing = dict(getattr(task, "metadata", {}) or {}) if hasattr(task, "metadata") else {}
+        carrier = "metadata"
+
+    deferrals = existing.get("deferrals") or []
+    marker = metadata.get("deferral_marker")
+    if marker and any(isinstance(d, dict) and d.get("deferral_marker") == marker for d in deferrals):
+        return False
+
+    deferrals.append(metadata)
+    existing["deferrals"] = deferrals
+    existing["last_deferral"] = metadata
+
+    if carrier == "result_data":
+        task.result_data = existing
+    elif carrier == "metadata_json":
+        task.metadata_json = existing
+    else:
+        setattr(task, "metadata", existing)
+    return True


### PR DESCRIPTION
### Motivation
- Prevent automated publish actions when market signals indicate high near-term conflict (NCI) to avoid harmful or poorly timed content deployments.
- Provide a deterministic, idempotent way to defer publish-capable tasks and compute a recalibrated deployment window so the scheduler can safely retry later.

### Description
- Add `backend/services/scheduler/utils/traffic_control.py` with `compute_recalibrated_deployment_window`, `apply_recalibrated_window_to_task`, and `upsert_deferral_metadata` to compute/persist deployment windows and idempotent deferral metadata.
- Add a pre-flight hook in `backend/services/scheduler/core/task_execution_handler.py` that calls `get_market_signal_summary` immediately before execution, derives an NCI score, and compares it to `NCI_HIGH_THRESHOLD` (0.65) for publish-capable tasks detected by `_is_publish_capable_task`.
- When NCI is high the handler applies the recalibrated window, upserts deferral metadata (using a deterministic `deferral_marker` of the form `<task_type>:<task_id>:high_nci:<YYYYMMDDHH>` to avoid duplicate deferrals), sets task status to `deferred`, commits, and records the skip in scheduler stats instead of executing the publish.
- Ensure the path is idempotent across cycles by only appending deferral entries when the `deferral_marker` is not already present and by advancing `next_execution`/`next_check` via the traffic-control utilities.

### Testing
- Ran Python byte-compile on the modified modules with `python -m py_compile backend/services/scheduler/core/task_execution_handler.py backend/services/scheduler/utils/traffic_control.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad866be9c8328b6a3abbd4608c1c5)