### PR TITLE
Add DB-backed goal cadence checkpoints and idempotent checkpoint orchestration

### DIFF
--- a/backend/models/agent_activity_models.py
+++ b/backend/models/agent_activity_models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, JSON, ForeignKey, Index, Float
+from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, JSON, ForeignKey, Index, Float, UniqueConstraint
 from sqlalchemy.orm import relationship
 
 from models.enhanced_strategy_models import Base
@@ -107,3 +107,62 @@ class AgentProfile(Base):
 
 
 Index("ix_agent_profiles_user_key", AgentProfile.user_id, AgentProfile.agent_key, unique=True)
+
+
+class GoalInstance(Base):
+    __tablename__ = "goal_instances"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(String(255), nullable=False, index=True)
+    invocation_id = Column(String(255), nullable=False, index=True)
+    status = Column(String(30), nullable=False, default="active", index=True)
+    goal_input = Column(JSON, nullable=True)
+    latest_output = Column(JSON, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, index=True)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, index=True)
+    completed_at = Column(DateTime, nullable=True, index=True)
+
+    checkpoints = relationship("GoalCheckpoint", back_populates="goal_instance", cascade="all, delete-orphan")
+    action_logs = relationship("GoalActionLog", back_populates="goal_instance", cascade="all, delete-orphan")
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "invocation_id", name="uq_goal_instances_user_invocation"),
+    )
+
+
+class GoalCheckpoint(Base):
+    __tablename__ = "goal_checkpoints"
+
+    id = Column(Integer, primary_key=True, index=True)
+    goal_instance_id = Column(Integer, ForeignKey("goal_instances.id"), nullable=False, index=True)
+    checkpoint_key = Column(String(50), nullable=False, index=True)  # T+2h, T+24h, T+7d
+    status = Column(String(30), nullable=False, default="pending", index=True)  # pending, running, completed, failed
+    due_at = Column(DateTime, nullable=False, index=True)
+    started_at = Column(DateTime, nullable=True, index=True)
+    completed_at = Column(DateTime, nullable=True, index=True)
+    payload = Column(JSON, nullable=True)
+    output = Column(JSON, nullable=True)
+    error_message = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, index=True)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, index=True)
+
+    goal_instance = relationship("GoalInstance", back_populates="checkpoints")
+
+    __table_args__ = (
+        UniqueConstraint("goal_instance_id", "checkpoint_key", name="uq_goal_checkpoint_instance_key"),
+    )
+
+
+class GoalActionLog(Base):
+    __tablename__ = "goal_action_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    goal_instance_id = Column(Integer, ForeignKey("goal_instances.id"), nullable=False, index=True)
+    checkpoint_id = Column(Integer, ForeignKey("goal_checkpoints.id"), nullable=True, index=True)
+    action = Column(String(100), nullable=False, index=True)
+    status = Column(String(30), nullable=False, default="info", index=True)
+    detail = Column(Text, nullable=True)
+    payload = Column(JSON, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, index=True)
+
+    goal_instance = relationship("GoalInstance", back_populates="action_logs")

--- a/backend/services/intelligence/agents/agent_orchestrator.py
+++ b/backend/services/intelligence/agents/agent_orchestrator.py
@@ -7,7 +7,7 @@ Built on txtai's native agent framework
 import asyncio
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, List, Any, Optional
 from dataclasses import dataclass, asdict
 
@@ -40,6 +40,8 @@ from services.intelligence.agents.safety_framework import (
 from services.intelligence.agents.performance_monitor import (
     PerformanceMetric, AgentStatus, AgentPerformanceMonitor, performance_service
 )
+from models.agent_activity_models import GoalInstance, GoalCheckpoint, GoalActionLog
+from services.database import get_session_for_user
 
 logger = get_service_logger(__name__)
 
@@ -320,6 +322,22 @@ class ALwrityAgentOrchestrator:
         """Execute coordinated marketing strategy using agent team"""
         try:
             logger.info(f"Executing marketing strategy for user {self.user_id}")
+            invocation_id = str(market_context.get("invocation_id") or market_context.get("run_id") or "").strip()
+            if not invocation_id:
+                raise ValueError("market_context must include invocation_id for checkpoint orchestration")
+
+            goal_instance, checkpoint = self._get_or_create_goal_state(
+                invocation_id=invocation_id,
+                goal_input=market_context
+            )
+            if checkpoint is None:
+                return {
+                    "success": True,
+                    "status": "complete",
+                    "invocation_id": invocation_id,
+                    "message": "All checkpoints are already completed",
+                    "timestamp": datetime.utcnow().isoformat(),
+                }
             
             # Prepare comprehensive context
             context = await self._prepare_orchestrator_context(market_context)
@@ -342,6 +360,7 @@ class ALwrityAgentOrchestrator:
                 
             orchestrator_prompt = self.orchestrator_agent.build_task_prompt(instruction=instruction, task_context=context)
             result = await self.orchestrator_agent.run(orchestrator_prompt)
+            self._persist_checkpoint_completion(goal_instance, checkpoint, result)
             
             # Record performance metrics for the orchestration itself
             if self.config.enable_performance_monitoring:
@@ -353,6 +372,8 @@ class ALwrityAgentOrchestrator:
             return {
                 "success": True,
                 "strategy": result,
+                "invocation_id": invocation_id,
+                "checkpoint": checkpoint.checkpoint_key,
                 "timestamp": datetime.utcnow().isoformat(),
                 # In a real system, we might parse the result to extract structured data
             }
@@ -365,6 +386,93 @@ class ALwrityAgentOrchestrator:
                 "error": str(e),
                 "timestamp": datetime.utcnow().isoformat()
             }
+
+    def _get_or_create_goal_state(self, invocation_id: str, goal_input: Dict[str, Any]):
+        """Return goal instance and next actionable checkpoint (one per invocation)."""
+        db = get_session_for_user(self.user_id)
+        try:
+            goal_instance = (
+                db.query(GoalInstance)
+                .filter(
+                    GoalInstance.user_id == self.user_id,
+                    GoalInstance.invocation_id == invocation_id,
+                )
+                .first()
+            )
+            now = datetime.utcnow()
+            if not goal_instance:
+                goal_instance = GoalInstance(
+                    user_id=self.user_id,
+                    invocation_id=invocation_id,
+                    status="active",
+                    goal_input=goal_input,
+                )
+                db.add(goal_instance)
+                db.flush()
+                for key, delta in (("T+2h", timedelta(hours=2)), ("T+24h", timedelta(hours=24)), ("T+7d", timedelta(days=7))):
+                    db.add(
+                        GoalCheckpoint(
+                            goal_instance_id=goal_instance.id,
+                            checkpoint_key=key,
+                            status="pending",
+                            due_at=now + delta,
+                            payload={"cadence": key},
+                        )
+                    )
+                db.add(GoalActionLog(goal_instance_id=goal_instance.id, action="goal_initialized", status="completed", payload={"invocation_id": invocation_id}))
+                db.commit()
+                db.refresh(goal_instance)
+
+            checkpoints = (
+                db.query(GoalCheckpoint)
+                .filter(GoalCheckpoint.goal_instance_id == goal_instance.id)
+                .order_by(GoalCheckpoint.due_at.asc())
+                .all()
+            )
+            next_checkpoint = next((cp for cp in checkpoints if cp.status in {"pending", "failed"}), None)
+            if next_checkpoint and next_checkpoint.status != "running":
+                next_checkpoint.status = "running"
+                next_checkpoint.started_at = now
+                db.add(next_checkpoint)
+                db.add(GoalActionLog(goal_instance_id=goal_instance.id, checkpoint_id=next_checkpoint.id, action="checkpoint_started", status="running", payload={"checkpoint_key": next_checkpoint.checkpoint_key}))
+                db.commit()
+                db.refresh(next_checkpoint)
+            return goal_instance, next_checkpoint
+        finally:
+            db.close()
+
+    def _persist_checkpoint_completion(self, goal_instance: GoalInstance, checkpoint: GoalCheckpoint, result: Any) -> None:
+        """Persist completion outputs and advance goal state idempotently."""
+        db = get_session_for_user(self.user_id)
+        try:
+            instance = db.query(GoalInstance).filter(GoalInstance.id == goal_instance.id).first()
+            cp = db.query(GoalCheckpoint).filter(GoalCheckpoint.id == checkpoint.id).first()
+            if not instance or not cp:
+                return
+            if cp.status == "completed":
+                return
+
+            cp.status = "completed"
+            cp.completed_at = datetime.utcnow()
+            cp.output = {"result": result}
+            instance.latest_output = cp.output
+            db.add(GoalActionLog(goal_instance_id=instance.id, checkpoint_id=cp.id, action="checkpoint_completed", status="completed", payload={"checkpoint_key": cp.checkpoint_key}))
+
+            remaining = (
+                db.query(GoalCheckpoint)
+                .filter(
+                    GoalCheckpoint.goal_instance_id == instance.id,
+                    GoalCheckpoint.status.in_(["pending", "failed", "running"]),
+                )
+                .count()
+            )
+            if remaining <= 1:
+                instance.status = "completed"
+                instance.completed_at = datetime.utcnow()
+                db.add(GoalActionLog(goal_instance_id=instance.id, action="goal_completed", status="completed"))
+            db.commit()
+        finally:
+            db.close()
     
     async def process_market_signals(self) -> List[MarketSignal]:
         """Process market signals and generate agent responses"""


### PR DESCRIPTION
### Motivation
- Make long-running agent goals restart-safe and re-entrant by persisting goal state and cadence checkpoints in the database. 
- Ensure each invocation processes exactly one checkpoint and that repeated or restarted executions resume from DB state only.

### Description
- Added new persistence models in `models/agent_activity_models.py`: `GoalInstance` (`goal_instances`), `GoalCheckpoint` (`goal_checkpoints`), and `GoalActionLog` (`goal_action_logs`) with uniqueness constraints for idempotency.
- Encode cadence checkpoints as persisted rows created at goal initialization for `T+2h`, `T+24h`, and `T+7d` with `status`, `due_at`, `started_at`, `completed_at`, `payload`, and `output` fields.
- Updated `services/intelligence/agents/agent_orchestrator.py` to require an `invocation_id` from `market_context` and to load-or-create a `GoalInstance`, then select and mark exactly one eligible `GoalCheckpoint` as `running` per invocation via `_get_or_create_goal_state`.
- Implemented `_persist_checkpoint_completion` to persist outputs, add `GoalActionLog` entries, update `latest_output`, and mark the `GoalInstance` completed when no actionable checkpoints remain, making transitions idempotent and driven solely from DB state.

### Testing
- Compiled the modified modules with `python -m py_compile backend/models/agent_activity_models.py backend/services/intelligence/agents/agent_orchestrator.py` and it succeeded. 
- No automated unit/integration tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ada41ecb88328913d82f8e2bda1ea)