### PR TITLE
Add NCI module with calibration and publication preflight logging

### DIFF
--- a/backend/config/nci_calibration.py
+++ b/backend/config/nci_calibration.py
@@ -1,0 +1,25 @@
+"""Runtime calibration for Noise Congestion Index (NCI)."""
+
+import os
+
+from services.intelligence.nci import NCICalibrationConfig
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def get_nci_calibration_config() -> NCICalibrationConfig:
+    return NCICalibrationConfig(
+        version=os.getenv("NCI_VERSION", "1.0"),
+        competitor_velocity_weight=_env_float("NCI_WEIGHT_COMPETITOR_VELOCITY", 0.35),
+        feed_density_weight=_env_float("NCI_WEIGHT_FEED_DENSITY", 0.25),
+        topic_overlap_weight=_env_float("NCI_WEIGHT_TOPIC_OVERLAP", 0.25),
+        authority_weighting_weight=_env_float("NCI_WEIGHT_AUTHORITY", 0.15),
+        clear_max=_env_float("NCI_THRESHOLD_CLEAR_MAX", 0.33),
+        caution_max=_env_float("NCI_THRESHOLD_CAUTION_MAX", 0.66),
+    )
+

--- a/backend/services/intelligence/agents/market_signal_detector.py
+++ b/backend/services/intelligence/agents/market_signal_detector.py
@@ -15,6 +15,8 @@ from enum import Enum
 from services.intelligence.monitoring.semantic_dashboard import RealTimeSemanticMonitor
 from services.intelligence.semantic_cache import SemanticCacheManager
 from services.seo_analyzer import ComprehensiveSEOAnalyzer
+from services.intelligence.nci import compute_nci
+from config.nci_calibration import get_nci_calibration_config
 from utils.logger_utils import get_service_logger
 
 logger = get_service_logger(__name__)
@@ -108,6 +110,33 @@ class MarketSignalDetector:
         self.baseline_metrics: Dict[str, float] = {}
         
         logger.info(f"Initialized MarketSignalDetector for user: {user_id}")
+
+    def compute_noise_congestion_index(self, context: Optional[SignalContext] = None) -> Dict[str, Any]:
+        """Compute Noise Congestion Index (NCI) for current market conditions."""
+        context = context or SignalContext(
+            user_id=self.user_id,
+            competitor_data={},
+            semantic_health={},
+            seo_performance={},
+            content_analysis={},
+            historical_data={},
+        )
+        competitors = context.competitor_data.get("competitors", []) or []
+        competitor_velocity = min(len(competitors) / 10.0, 1.0)
+        feed_density = min(float(context.semantic_health.get("active_alerts", 0)) / 20.0, 1.0)
+        topic_overlap = min(float(context.content_analysis.get("semantic_overlap", 0.0)), 1.0)
+        authority_weighting = min(
+            sum(float(c.get("authority_score", 0.0)) for c in competitors) / max(len(competitors), 1),
+            1.0,
+        )
+
+        return compute_nci(
+            competitor_velocity=competitor_velocity,
+            feed_density=feed_density,
+            topic_overlap=topic_overlap,
+            authority_weighting=authority_weighting,
+            config=get_nci_calibration_config(),
+        )
     
     async def detect_market_signals(self) -> List[MarketSignal]:
         """Detect all current market signals"""

--- a/backend/services/intelligence/agents/trend_surfer_agent.py
+++ b/backend/services/intelligence/agents/trend_surfer_agent.py
@@ -38,6 +38,7 @@ class TrendSurferAgent(SIFBaseAgent):
 
             # 2. Detect internal market signals (competitors, SERP, etc.)
             signals = await self.signal_detector.detect_market_signals()
+            nci = self.signal_detector.compute_noise_congestion_index()
             
             # 3. Analyze real-time trends and convert to signals if actionable
             trend_signals = await self._analyze_realtime_trends(realtime_trends)
@@ -54,11 +55,13 @@ class TrendSurferAgent(SIFBaseAgent):
             ]
             
             logger.info(f"[{self.__class__.__name__}] Found {len(actionable_trends)} actionable trends")
+            logger.info(f"[{self.__class__.__name__}] NCI score={nci.get('score')} band={nci.get('band')} version={nci.get('version')}")
             
             opportunities = []
             for trend in actionable_trends:
                 opp = await self._analyze_opportunity(trend)
                 if opp:
+                    opp["nci"] = nci
                     opportunities.append(opp)
             
             return opportunities

--- a/backend/services/intelligence/nci.py
+++ b/backend/services/intelligence/nci.py
@@ -1,0 +1,76 @@
+"""Noise Congestion Index (NCI) scoring utilities.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Any
+
+
+@dataclass(frozen=True)
+class NCICalibrationConfig:
+    """Calibration knobs for NCI scoring and band thresholds."""
+
+    version: str = "1.0"
+    competitor_velocity_weight: float = 0.35
+    feed_density_weight: float = 0.25
+    topic_overlap_weight: float = 0.25
+    authority_weighting_weight: float = 0.15
+    clear_max: float = 0.33
+    caution_max: float = 0.66
+
+
+DEFAULT_NCI_CONFIG = NCICalibrationConfig()
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _weighted_average(weights: Dict[str, float], values: Dict[str, float]) -> float:
+    total_weight = sum(max(0.0, w) for w in weights.values())
+    if total_weight <= 0:
+        return 0.0
+    weighted_sum = sum(_clamp01(values.get(k, 0.0)) * max(0.0, w) for k, w in weights.items())
+    return _clamp01(weighted_sum / total_weight)
+
+
+def compute_nci(
+    *,
+    competitor_velocity: float,
+    feed_density: float,
+    topic_overlap: float,
+    authority_weighting: float,
+    config: NCICalibrationConfig = DEFAULT_NCI_CONFIG,
+) -> Dict[str, Any]:
+    """Compute normalized NCI score and congestion band from four inputs."""
+    weights = {
+        "competitor_velocity": config.competitor_velocity_weight,
+        "feed_density": config.feed_density_weight,
+        "topic_overlap": config.topic_overlap_weight,
+        "authority_weighting": config.authority_weighting_weight,
+    }
+    values = {
+        "competitor_velocity": competitor_velocity,
+        "feed_density": feed_density,
+        "topic_overlap": topic_overlap,
+        "authority_weighting": authority_weighting,
+    }
+    score = _weighted_average(weights, values)
+
+    if score <= config.clear_max:
+        band = "clear"
+    elif score <= config.caution_max:
+        band = "caution"
+    else:
+        band = "congested"
+
+    return {
+        "score": round(score, 4),
+        "band": band,
+        "version": config.version,
+        "inputs": {k: round(_clamp01(v), 4) for k, v in values.items()},
+        "thresholds": {
+            "clear_max": config.clear_max,
+            "caution_max": config.caution_max,
+        },
+    }
+

--- a/backend/services/llm_providers/textgen_utils/llm_text_generator.py
+++ b/backend/services/llm_providers/textgen_utils/llm_text_generator.py
@@ -35,6 +35,7 @@ def llm_text_gen(
     preferred_hf_models: Optional[List[str]] = None,
     preferred_provider: Optional[str] = None,
     flow_type: str = "default",
+    publication_preflight_log: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     Generate text using Language Model (LLM) based on the provided prompt.
@@ -47,6 +48,7 @@ def llm_text_gen(
         preferred_hf_models (list, optional): Preferred HuggingFace models to use.
         preferred_provider (str, optional): Preferred provider to use.
         flow_type (str): Type of flow for logging and routing.
+        publication_preflight_log (dict, optional): Mutable preflight log payload.
         
     Returns:
         str: Generated text based on the prompt.
@@ -239,6 +241,18 @@ def llm_text_gen(
                     actual_provider_name or provider_enum.value,
                     estimated_total_tokens,
                 )
+
+                if publication_preflight_log is not None:
+                    nci_payload = publication_preflight_log.get("nci") or {}
+                    publication_preflight_log["nci"] = {
+                        "score": nci_payload.get("score"),
+                        "version": nci_payload.get("version"),
+                    }
+                    logger.info(
+                        "[llm_text_gen][publication_preflight] nci_score={} nci_version={}",
+                        publication_preflight_log["nci"].get("score"),
+                        publication_preflight_log["nci"].get("version"),
+                    )
 
                 # Get current usage for limit checking only
                 current_period = pricing_service.get_current_billing_period(user_id) or datetime.now().strftime("%Y-%m")


### PR DESCRIPTION
### Motivation
- Provide a stable, normalized Noise Congestion Index (NCI) to quantify content/market congestion using competitor velocity, feed density, topic overlap, and authority weighting. 
- Make NCI tunable at runtime via configuration so thresholds and weights can be calibrated without code changes. 
- Surface NCI to agents and publication preflight logs so downstream flows (e.g., `TrendSurferAgent` and publishing) can make informed decisions and record the index for auditing. 

### Description
- Added a new NCI implementation in `backend/services/intelligence/nci.py` including `NCICalibrationConfig` and `compute_nci(...)` that normalizes inputs to `[0.0, 1.0]`, applies weighted averaging, and returns a versioned payload with threshold bands (`clear`, `caution`, `congested`). 
- Added runtime calibration loader `backend/config/nci_calibration.py` with `get_nci_calibration_config()` that reads env vars (weights, `NCI_VERSION`, and threshold knobs) so thresholds/weights can be tuned without code changes. 
- Integrated NCI into signal path by adding `compute_noise_congestion_index(...)` to `MarketSignalDetector` which derives the four inputs from the detection `SignalContext` and uses the calibration config. 
- Propagated NCI into flows: `TrendSurferAgent` computes the NCI during `surf_trends()`, logs `score/band/version`, and attaches the NCI payload to each returned opportunity; `llm_text_gen(...)` now accepts an optional `publication_preflight_log` and persists/logs `nci.score` and `nci.version` when provided. 

### Testing
- Ran Python bytecode compilation on changed files with `python -m py_compile backend/services/intelligence/nci.py backend/config/nci_calibration.py backend/services/intelligence/agents/market_signal_detector.py backend/services/intelligence/agents/trend_surfer_agent.py backend/services/llm_providers/textgen_utils/llm_text_generator.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ada5f6c4c8328b4a25a1062bed8f7)