### PR TITLE
Add scheduler pre-dispatch hook for NCI deferral and safe requeue

### DIFF
--- a/backend/services/scheduler/core/scheduler.py
+++ b/backend/services/scheduler/core/scheduler.py
@@ -35,6 +35,7 @@ from .platform_insights_task_restoration import restore_platform_insights_tasks
 from .advertools_task_restoration import restore_advertools_tasks
 from .check_cycle_handler import check_and_execute_due_tasks
 from .task_execution_handler import execute_task_async
+from .traffic_control import SchedulerTrafficControl
 
 logger = get_service_logger("task_scheduler")
 
@@ -137,6 +138,9 @@ class TaskScheduler:
         # Execution lease registry (prevents duplicate redispatch across check cycles)
         self._task_leases: Dict[str, str] = {}
         self._task_lease_ttl_seconds = int(os.getenv("SCHEDULER_TASK_LEASE_TTL_SECONDS", "900"))
+
+        # Pre-execution traffic-control hook
+        self.traffic_control = SchedulerTrafficControl()
     
     def _get_trigger_for_interval(self, interval_minutes: int):
         """
@@ -721,6 +725,20 @@ class TaskScheduler:
                 if not self._acquire_task_lease(lease_key):
                     continue
 
+                decision = self.traffic_control.evaluate_pre_execution(task, db)
+                if not decision.execute_now:
+                    # Release lease so deferred task can naturally re-enter future check cycles
+                    self._release_task_lease(lease_key)
+                    logger.info(
+                        "[Scheduler] Deferred %s task %s | reason=%s | prior=%s | next=%s",
+                        task_type,
+                        task_id,
+                        decision.defer_reason,
+                        decision.prior_schedule,
+                        decision.next_schedule,
+                    )
+                    continue
+
                 execution_task = asyncio.create_task(
                     execute_task_async(
                         self,
@@ -729,6 +747,7 @@ class TaskScheduler:
                         summary,
                         execution_source="scheduler",
                         user_id=user_id,
+                        execution_key=lease_key,
                     )
                 )
                 self.active_executions[lease_key] = execution_task

--- a/backend/services/scheduler/core/task_execution_handler.py
+++ b/backend/services/scheduler/core/task_execution_handler.py
@@ -24,7 +24,8 @@ async def execute_task_async(
     task: Any,
     summary: Optional[Dict[str, Any]] = None,
     execution_source: str = "scheduler",  # "scheduler" or "manual"
-    user_id: Optional[str] = None
+    user_id: Optional[str] = None,
+    execution_key: Optional[str] = None
 ):
     """
     Execute a single task asynchronously with user isolation.
@@ -219,6 +220,11 @@ async def execute_task_async(
                 logger.error(f"Error closing database session for task {task_id}: {e}")
         
         # Remove from active executions
-        if task_id in scheduler.active_executions:
-            del scheduler.active_executions[task_id]
+        removal_key = execution_key or task_id
+        if removal_key in scheduler.active_executions:
+            del scheduler.active_executions[removal_key]
+
+        # Release in-memory lease if this execution originated from scheduler dispatch
+        if execution_key:
+            scheduler._release_task_lease(execution_key)
 

--- a/backend/services/scheduler/core/traffic_control.py
+++ b/backend/services/scheduler/core/traffic_control.py
@@ -1,0 +1,106 @@
+"""Traffic-aware pre-dispatch control for scheduler tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+from sqlalchemy.orm import Session
+
+from utils.logger_utils import get_service_logger
+
+logger = get_service_logger("traffic_control")
+
+
+@dataclass
+class DispatchDecision:
+    execute_now: bool
+    defer_reason: Optional[str] = None
+    prior_schedule: Optional[str] = None
+    next_schedule: Optional[str] = None
+    nci_evidence: Optional[Dict[str, Any]] = None
+
+
+class SchedulerTrafficControl:
+    """Evaluates whether publish-like tasks should execute immediately or be deferred."""
+
+    def evaluate_pre_execution(self, task: Any, db: Session) -> DispatchDecision:
+        nci = self._query_nci(task)
+        if nci.get("action") == "defer":
+            prior_schedule = self._task_schedule_iso(task)
+            next_window = self._compute_next_low_density_window(task, nci)
+            self._update_post_delivery_state(
+                task=task,
+                db=db,
+                defer_reason=nci.get("reason", "nci_deferred"),
+                prior_schedule=prior_schedule,
+                next_schedule=next_window.isoformat() if next_window else None,
+                nci_evidence=nci,
+            )
+            return DispatchDecision(
+                execute_now=False,
+                defer_reason=nci.get("reason", "nci_deferred"),
+                prior_schedule=prior_schedule,
+                next_schedule=next_window.isoformat() if next_window else None,
+                nci_evidence=nci,
+            )
+
+        return DispatchDecision(execute_now=True, nci_evidence=nci)
+
+    def _query_nci(self, task: Any) -> Dict[str, Any]:
+        """Query NCI signal and branch decision. Default is pass-through unless payload asks defer."""
+        payload = getattr(task, "payload", None) or {}
+        nci = payload.get("nci") or {}
+        should_defer = bool(nci.get("should_defer", False))
+        return {
+            "signal": nci.get("signal", "unknown"),
+            "score": nci.get("score"),
+            "action": "defer" if should_defer else "execute_now",
+            "reason": nci.get("reason", "nci_green" if not should_defer else "nci_requested_deferral"),
+            "observed_at": datetime.utcnow().isoformat(),
+        }
+
+    def _compute_next_low_density_window(self, task: Any, nci: Dict[str, Any]) -> datetime:
+        """Compute next low-density publish window."""
+        payload = getattr(task, "payload", None) or {}
+        delay_minutes = int(payload.get("defer_minutes", 60) or 60)
+        return datetime.utcnow() + timedelta(minutes=max(delay_minutes, 1))
+
+    def _update_post_delivery_state(
+        self,
+        task: Any,
+        db: Session,
+        defer_reason: str,
+        prior_schedule: Optional[str],
+        next_schedule: Optional[str],
+        nci_evidence: Dict[str, Any],
+    ):
+        """Persist deferral metadata and re-schedule task for normal queue processing."""
+        payload = dict(getattr(task, "payload", None) or {})
+        payload["defer_state"] = {
+            "defer_reason": defer_reason,
+            "prior_schedule": prior_schedule,
+            "next_schedule": next_schedule,
+            "nci_evidence": nci_evidence,
+            "deferred_at": datetime.utcnow().isoformat(),
+        }
+        setattr(task, "payload", payload)
+
+        if next_schedule and hasattr(task, "next_execution"):
+            task.next_execution = datetime.fromisoformat(next_schedule)
+        if hasattr(task, "status"):
+            task.status = "active"
+
+        db.add(task)
+        db.commit()
+        logger.info(
+            "[Traffic Control] Deferred task %s | reason=%s | next=%s",
+            getattr(task, "id", None),
+            defer_reason,
+            next_schedule,
+        )
+
+    def _task_schedule_iso(self, task: Any) -> Optional[str]:
+        next_execution = getattr(task, "next_execution", None)
+        return next_execution.isoformat() if next_execution else None


### PR DESCRIPTION
### Motivation
- Reduce publish-time traffic collisions by letting the scheduler inspect NCI (network/traffic-intent) signals and decide to execute or defer publish-like tasks before dispatch. 
- Persist deferral metadata so downstream systems and UI can reason about why a task was deferred and when it will be retried.

### Description
- Added a new module `backend/services/scheduler/core/traffic_control.py` that provides `SchedulerTrafficControl` and `DispatchDecision` to query an NCI signal (payload-driven) and compute the next low-density window.
- Integrated a pre-execution hook in the scheduler core (`TaskScheduler`) by instantiating `SchedulerTrafficControl` and calling `evaluate_pre_execution` inside `_process_task_type` before creating `execute_task_async`.
- When `evaluate_pre_execution` returns a deferral, the code persists `payload["defer_state"]` containing `defer_reason`, `prior_schedule`, `next_schedule`, and full `nci_evidence`, updates `task.next_execution`/`task.status` as appropriate, commits the change, releases the in-memory lease, and logs the deferral so the task naturally re-enters normal check cycles without duplicate dispatch.
- Updated `execute_task_async` to accept an `execution_key`, use it for `active_executions` bookkeeping, and release the in-memory lease in the `finally` block to avoid stale leases and duplicate re-dispatches.

### Testing
- Compiled the modified modules with `python -m compileall backend/services/scheduler/core/scheduler.py backend/services/scheduler/core/task_execution_handler.py backend/services/scheduler/core/traffic_control.py` and the compilation completed successfully.
- No additional automated tests were added in this change; runtime behavior validated by static compilation only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ada6735388328addf895b3c3a686a)