### PR TITLE
Add Podcast Maker documentation and navigation entries

### DIFF
--- a/docs-site/docs/features/podcast-maker/api-reference.md
+++ b/docs-site/docs/features/podcast-maker/api-reference.md
@@ -1,0 +1,37 @@
+# Podcast Maker API Reference
+
+This reference summarizes key endpoint groups exposed by the Podcast API domain.
+
+## Endpoint Map
+
+```mermaid
+flowchart TD
+    A[/api/podcast]
+    A --> P[projects.py]
+    A --> AN[analysis.py]
+    A --> R[research.py]
+    A --> S[script.py]
+    A --> AU[audio.py]
+    A --> V[video.py]
+    A --> I[images.py]
+    A --> AV[avatar.py]
+    A --> D[dubbing.py]
+
+    P --> P1[Create project]
+    P --> P2[List project history]
+    AN --> AN1[Run episode analysis]
+    R --> R1[Generate/select queries]
+    S --> S1[Create/update script]
+    AU --> AU1[Render audio]
+    V --> V1[Render video]
+    I --> I1[Generate supporting images]
+    AV --> AV1[Configure presenter avatar]
+    D --> D1[Voice dubbing / localization]
+```
+
+## Endpoint Families
+
+- **Project endpoints**: lifecycle operations for episode containers and history.
+- **Analysis endpoints**: diagnostic scoring and recommendation extraction.
+- **Research & script endpoints**: query planning, source grounding, and script management.
+- **Media endpoints**: audio/video render, image generation, avatar personalization, and dubbing.

--- a/docs-site/docs/features/podcast-maker/implementation-overview.md
+++ b/docs-site/docs/features/podcast-maker/implementation-overview.md
@@ -1,0 +1,40 @@
+# Podcast Maker Implementation Overview
+
+Podcast Maker orchestrates a multi-stage content pipeline: project configuration, research grounding, script composition, media rendering, and publish-state tracking.
+
+## Architecture & Data Flow
+
+```mermaid
+flowchart LR
+    UI[Podcast Maker UI]
+    API[Podcast API Router]
+    PROJ[Project Service]
+    RESEARCH[Research Handler]
+    SCRIPT[Script Handler]
+    RENDER[Audio/Video Render Handlers]
+    STORE[(Podcast Tables)]
+    JOBS[(Render Queue)]
+
+    UI --> API
+    API --> PROJ
+    API --> RESEARCH
+    API --> SCRIPT
+    API --> RENDER
+
+    PROJ --> STORE
+    RESEARCH --> STORE
+    SCRIPT --> STORE
+    RENDER --> JOBS
+    RENDER --> STORE
+
+    JOBS --> UI
+    STORE --> UI
+```
+
+## Component Responsibilities
+
+- **UI layer**: captures project metadata, persona settings, and script/editor actions.
+- **API router**: central endpoint registration and request dispatch.
+- **Research and script handlers**: generate, validate, and persist episode knowledge and narration assets.
+- **Render handlers**: combine narration, visuals, and scene timing into draft/final media outputs.
+- **Storage + queue**: maintain immutable version history and asynchronous job state.

--- a/docs-site/docs/features/podcast-maker/persona-journey-host.md
+++ b/docs-site/docs/features/podcast-maker/persona-journey-host.md
@@ -1,0 +1,23 @@
+# Persona Journey: Podcast Host
+
+## Host Goal
+Deliver a confident, natural-sounding episode with clear narrative transitions and evidence-backed claims.
+
+## Journey Stages
+
+### Stage 1: Brief Setup
+!!! note "Annotated view: Host setup modal"
+    **Alt text:** Create modal annotated for host persona setup, including tone and pacing controls.
+
+### Stage 2: Insight Review
+!!! note "Annotated view: Host analysis panel"
+    **Alt text:** Analysis panel annotated to highlight speaking pace and confidence recommendations for host delivery.
+
+### Stage 3: Script Approval
+!!! note "Annotated view: Host script editor"
+    **Alt text:** Script editor annotated for host line-level edits, transition cues, and final approval workflow.
+
+## Success Criteria
+- Host reads naturally without overlong sentences.
+- Topic transitions stay on-message.
+- Sources remain transparent when making claims.

--- a/docs-site/docs/features/podcast-maker/persona-journey-producer.md
+++ b/docs-site/docs/features/podcast-maker/persona-journey-producer.md
@@ -1,0 +1,23 @@
+# Persona Journey: Podcast Producer
+
+## Producer Goal
+Coordinate research quality, production timelines, and render output consistency across every episode.
+
+## Journey Stages
+
+### Stage 1: Research Curation
+!!! note "Annotated view: Producer research query selection"
+    **Alt text:** Research query selection annotated for producer review, source locking, and query prioritization.
+
+### Stage 2: Render Oversight
+!!! note "Annotated view: Producer render queue"
+    **Alt text:** Render queue annotated for producer monitoring of job status, retries, and SLA adherence.
+
+### Stage 3: Catalog Management
+!!! note "Annotated view: Producer project list and episode history"
+    **Alt text:** Project list and episode history annotated for producer-level tracking of versions and publishing channels.
+
+## Success Criteria
+- Each episode has approved research scope.
+- Queue health stays within SLA.
+- History records are clear enough for postmortem and reuse.

--- a/docs-site/docs/features/podcast-maker/workflow-guide.md
+++ b/docs-site/docs/features/podcast-maker/workflow-guide.md
@@ -1,0 +1,63 @@
+# Podcast Maker Workflow Guide
+
+This guide walks through the complete Podcast Maker lifecycle from project creation to final render delivery.
+
+## 1) Create a New Episode Project
+
+!!! note "Annotated view: Create modal"
+    **Alt text:** Create modal showing fields for podcast title, target audience, tone, and language selection.
+
+**What to validate before continuing**
+- Working title and episode angle are clear.
+- Persona is selected (Host, Analyst, Interviewer, etc.).
+- Output profile (audio-only vs video podcast) matches channel needs.
+
+## 2) Review the Analysis Panel
+
+!!! note "Annotated view: Analysis panel"
+    **Alt text:** Analysis panel with audience-fit score, speaking pace metrics, and citation confidence indicators.
+
+Use this panel to align creative intent with production constraints:
+- Audience fit and intent match
+- Style and voice consistency
+- Citation confidence and source quality
+
+## 3) Select Research Queries
+
+!!! note "Annotated view: Research query selection"
+    **Alt text:** Research query selection interface with approved query chips and source locking controls.
+
+Recommended sequence:
+1. Approve high-signal queries.
+2. Exclude broad/ambiguous prompts.
+3. Lock trusted domains before script generation.
+
+## 4) Edit and Approve the Script
+
+!!! note "Annotated view: Script editor"
+    **Alt text:** Script editor with host dialogue blocks, scene transitions, and approval status in sidebar.
+
+In editor review, confirm:
+- Segment timing is balanced.
+- Host transitions sound conversational.
+- Fact-heavy sections include source context.
+
+## 5) Monitor Render Queue
+
+!!! note "Annotated view: Render queue"
+    **Alt text:** Render queue showing in-progress, completed, and failed render jobs with retry actions.
+
+Queue best practices:
+- Prioritize short drafts for rapid QA.
+- Retry failures after checking asset integrity.
+- Archive superseded versions to reduce noise.
+
+## 6) Manage Project & Episode History
+
+!!! note "Annotated view: Project list and episode history"
+    **Alt text:** Project list and episode history view with version labels, publish status, and destination channels.
+
+Use episode history to track:
+- Revision progression
+- Performance-linked updates
+- Publishing destination consistency

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -236,6 +236,12 @@ nav:
       - Grounding UI: features/ai/grounding-ui.md
     - LinkedIn Writer:
       - Overview: features/linkedin-writer/overview.md
+    - Podcast Maker:
+      - Workflow Guide: features/podcast-maker/workflow-guide.md
+      - Persona Journey (Host): features/podcast-maker/persona-journey-host.md
+      - Persona Journey (Producer): features/podcast-maker/persona-journey-producer.md
+      - Implementation Overview: features/podcast-maker/implementation-overview.md
+      - API Reference: features/podcast-maker/api-reference.md
     - Integrations:
       - Wix:
         - Overview: features/integrations/wix/overview.md


### PR DESCRIPTION
### Motivation

- Introduce comprehensive documentation for the new Podcast Maker feature covering workflows, personas, implementation, and API surface.
- Provide product and engineering teams with guidance on project lifecycle, research/script flow, and render/queue responsibilities.

### Description

- Add feature documentation files: `features/podcast-maker/workflow-guide.md`, `features/podcast-maker/persona-journey-host.md`, `features/podcast-maker/persona-journey-producer.md`, `features/podcast-maker/implementation-overview.md`, and `features/podcast-maker/api-reference.md`.
- Include Mermaid diagrams and annotated notes to illustrate architecture, endpoint map, component responsibilities, persona journeys, and the end-to-end workflow.
- Update `mkdocs.yml` to wire the Podcast Maker pages into the site navigation under a new "Podcast Maker" section.

### Testing

- Built the docs site with `mkdocs build` and confirmed the site compiles successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d4c5b0519083289decd5e46f955438)