### PR TITLE
Potential fix for code scanning alert no. 139: Uncontrolled data used in path expression

### DIFF
--- a/backend/routers/image_studio/transform.py
+++ b/backend/routers/image_studio/transform.py
@@ -142,11 +142,11 @@ async def serve_transform_video(
                 detail="Invalid video path: path traversal detected"
             )
 
-        if not video_path.exists():
+        if not resolved_video_path.exists():
             raise HTTPException(status_code=404, detail="Video not found")
 
         return FileResponse(
-            path=str(video_path),
+            path=str(resolved_video_path),
             media_type="video/mp4",
             filename=video_filename
         )


### PR DESCRIPTION
Potential fix for [https://github.com/AJaySi/ALwrity/security/code-scanning/139](https://github.com/AJaySi/ALwrity/security/code-scanning/139)

Use the already-computed `resolved_video_path` (canonicalized and verified to be under `transform_videos_dir`) as the only path used for existence checks and `FileResponse`.

Best fix in this file:
- In `backend/routers/image_studio/transform.py`, inside `serve_transform_video`, replace:
  - `if not video_path.exists():`
  - `path=str(video_path)`
- with:
  - `if not resolved_video_path.exists():`
  - `path=str(resolved_video_path)`

This keeps behavior unchanged for valid requests but ensures the sink receives only the validated/canonical path, addressing both alert variants (`user_id` and `video_filename` taint flows).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
