### PR TITLE
Potential fix for code scanning alert no. 134: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/backend/api/content_planning/services/content_strategy/performance/caching.py
+++ b/backend/api/content_planning/services/content_strategy/performance/caching.py
@@ -79,8 +79,8 @@ class CachingService:
             if kwargs:
                 key_data += ":" + json.dumps(kwargs, sort_keys=True)
             
-            # Create hash for consistent key length
-            key_hash = hashlib.md5(key_data.encode()).hexdigest()
+            # Create hash for consistent key length using a strong hash algorithm
+            key_hash = hashlib.sha256(key_data.encode("utf-8")).hexdigest()
             return f"content_strategy:{cache_type}:{key_hash}"
             
         except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/AJaySi/ALwrity/security/code-scanning/134](https://github.com/AJaySi/ALwrity/security/code-scanning/134)

To fix this safely, replace MD5 with a strong modern hash function for cache-key derivation, while preserving deterministic output and current behavior. The best single change is in `backend/api/content_planning/services/content_strategy/performance/caching.py`, in `get_cache_key(...)`: switch from `hashlib.md5(key_data.encode()).hexdigest()` to `hashlib.sha256(key_data.encode("utf-8")).hexdigest()`.

This keeps functionality intact:
- deterministic key generation remains unchanged,
- key length stays consistent (fixed-length hex),
- all alert variants are fixed at once since they share the same sink location.

No new imports are needed because `hashlib` is already imported. No API or call-site changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
