### PR TITLE
Potential fix for code scanning alert no. 121: Uncontrolled data used in path expression

### DIFF
--- a/backend/routers/video_studio/endpoints/serve.py
+++ b/backend/routers/video_studio/endpoints/serve.py
@@ -40,29 +40,25 @@ async def serve_video_studio_video(
         video_studio_videos_dir = base_dir / "video_studio_videos"
         video_path = video_studio_videos_dir / user_id / video_filename
         
-        # Security: Ensure path is within video_studio_videos directory
+        # Security: Resolve and ensure path is within video_studio_videos directory
         try:
-            resolved_path = video_path.resolve()
             resolved_base = video_studio_videos_dir.resolve()
-            if not str(resolved_path).startswith(str(resolved_base)):
-                raise HTTPException(
-                    status_code=403,
-                    detail="Invalid video path"
-                )
+            resolved_path = video_path.resolve()
+            resolved_path.relative_to(resolved_base)
         except (OSError, ValueError) as e:
             logger.error(f"[VideoStudio] Path resolution error: {e}")
             raise HTTPException(status_code=403, detail="Invalid video path")
         
         # Check if file exists
-        if not video_path.exists() or not video_path.is_file():
+        if not resolved_path.exists() or not resolved_path.is_file():
             raise HTTPException(
                 status_code=404,
                 detail=f"Video not found: {video_filename}"
             )
         
-        logger.info(f"[VideoStudio] Serving video: {video_path}")
+        logger.info(f"[VideoStudio] Serving video: {resolved_path}")
         return FileResponse(
-            path=str(video_path),
+            path=str(resolved_path),
             media_type="video/mp4",
             filename=video_filename,
         )


### PR DESCRIPTION
Potential fix for [https://github.com/AJaySi/ALwrity/security/code-scanning/121](https://github.com/AJaySi/ALwrity/security/code-scanning/121)

To fix this safely without changing intended behavior, validate and serve **only a canonical path** and enforce directory containment using `Path.relative_to(...)` rather than string prefix checks.

Best fix in this file:
1. Build `video_path` as before.
2. Resolve both `video_path` and `video_studio_videos_dir`.
3. Enforce containment with `resolved_path.relative_to(resolved_base)` inside a `try` block; if it raises `ValueError`, reject with 403.
4. Perform existence/file checks on `resolved_path` (the validated path), not `video_path`.
5. Pass `str(resolved_path)` to `FileResponse`.
6. Keep `video_filename` for download/display filename if desired; this does not control filesystem access.

This addresses both variants (`user_id` and `video_filename`) in one change and aligns with secure path-handling guidance.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
