### PR TITLE
Potential fix for code scanning alert no. 116: Uncontrolled data used in path expression

### DIFF
--- a/backend/routers/product_marketing.py
+++ b/backend/routers/product_marketing.py
@@ -942,9 +942,20 @@ async def serve_product_avatar(
         if current_user_id != user_id:
             raise HTTPException(status_code=403, detail="Access denied")
         
-        # Locate video file
+        # Restrict to a filename only (no nested paths)
+        requested_name = Path(filename)
+        if requested_name.is_absolute() or requested_name.name != filename:
+            raise HTTPException(status_code=400, detail="Invalid filename")
+        
+        # Locate and validate video file path within user's avatar directory
         base_dir = Path(__file__).parent.parent.parent
-        video_path = base_dir / "product_avatars" / user_id / filename
+        user_root = (base_dir / "product_avatars" / current_user_id).resolve()
+        video_path = (user_root / requested_name).resolve()
+
+        try:
+            video_path.relative_to(user_root)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid filename")
         
         if not video_path.exists():
             raise HTTPException(status_code=404, detail="Video not found")
@@ -952,7 +963,7 @@ async def serve_product_avatar(
         return FileResponse(
             path=str(video_path),
             media_type="video/mp4",
-            filename=filename
+            filename=requested_name.name
         )
         
     except HTTPException:


### PR DESCRIPTION
Potential fix for [https://github.com/AJaySi/ALwrity/security/code-scanning/116](https://github.com/AJaySi/ALwrity/security/code-scanning/116)

To fix this safely without changing intended functionality, constrain all file access to a computed safe root (`<repo>/product_avatars/<current_user_id>`) and validate that the requested file resolves inside that root after normalization. Also reject suspicious `filename` values early (absolute paths / path separators) since this endpoint is clearly for serving a single file name, not nested paths.

Best concrete fix in `backend/routers/product_marketing.py` (inside `serve_product_avatar`):

1. Build `user_root = (base_dir / "product_avatars" / current_user_id).resolve()`.
2. Validate `filename` as a basename only (no `/`, `\`, and not absolute).
3. Build `video_path = (user_root / filename).resolve()`.
4. Enforce containment using `video_path.relative_to(user_root)` (raises `ValueError` if outside root).
5. Keep existing `exists()` check and return `FileResponse` with the validated path.

This addresses both alert variants (`user_id` and `filename`) because neither untrusted value can influence file access outside the authorized user directory after the containment check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
