### PR TITLE
Potential fix for code scanning alert no. 107: Uncontrolled data used in path expression

### DIFF
--- a/backend/api/images.py
+++ b/backend/api/images.py
@@ -1048,12 +1048,21 @@ async def serve_image_studio_image(
             raise HTTPException(status_code=403, detail="Access denied: image not found in your library")
         
         # Determine if it's an edited image or regular image
+        # Validate user-controlled path input before filesystem path construction
+        image_filename_path = Path(image_filename)
+        if image_filename_path.is_absolute() or any(part in ("", ".", "..") for part in image_filename_path.parts):
+            raise HTTPException(status_code=403, detail="Access denied: Invalid image path")
+
         base_dir = Path(__file__).parent.parent
         image_studio_dir = (base_dir / "image_studio_images").resolve()
         
         if image_filename.startswith("edited/"):
             # Remove "edited/" prefix and serve from edited directory
             actual_filename = image_filename.replace("edited/", "", 1)
+            actual_filename_path = Path(actual_filename)
+            if actual_filename_path.is_absolute() or any(part in ("", ".", "..") for part in actual_filename_path.parts):
+                raise HTTPException(status_code=403, detail="Access denied: Invalid image path")
+
             image_path = (image_studio_dir / "edited" / actual_filename).resolve()
             base_subdir = (image_studio_dir / "edited").resolve()
         else:


### PR DESCRIPTION
Potential fix for [https://github.com/AJaySi/ALwrity/security/code-scanning/107](https://github.com/AJaySi/ALwrity/security/code-scanning/107)

Best fix: validate/sanitize `image_filename` (and derived `actual_filename`) *before* path construction, and reject suspicious path segments while keeping existing containment checks.

In `backend/api/images.py`, inside `serve_image_studio_image`:
1. Add strict path-component validation using `Path(...).parts`:
   - reject absolute paths,
   - reject empty segments, `"."`, `".."`.
2. For the `edited/` branch, validate `actual_filename` after stripping the prefix.
3. Keep the existing `resolve()` + `relative_to(...)` check as defense-in-depth.

This preserves behavior for valid nested paths while preventing traversal-like inputs earlier and addressing CodeQL taint concerns.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
