### PR TITLE
Potential fix for code scanning alert no. 88: Clear-text logging of sensitive information

### DIFF
--- a/backend/api/content_planning/services/content_strategy/autofill/ai_structured_autofill.py
+++ b/backend/api/content_planning/services/content_strategy/autofill/ai_structured_autofill.py
@@ -499,7 +499,7 @@ Generate the complete JSON with all 30 fields personalized for {website_url}:
         # Log context summary for debugging
         logger.info("AIStructuredAutofillService: context summary | user=%s", user_id)
         logger.info("  - Website analysis exists: %s", bool(context_summary.get('user_profile', {}).get('website_url')))
-        logger.info("  - Research config: %s", context_summary.get('research_config', {}).get('research_depth', 'None'))
+        logger.info("  - Research config present: %s", bool(context_summary.get('research_config', {}).get('research_depth')))
         logger.info("  - API capabilities: %s", len(context_summary.get('api_capabilities', {}).get('providers', [])))
         logger.info("  - Content analysis: %s", bool(context_summary.get('content_analysis')))
         logger.info("  - Audience insights: %s", bool(context_summary.get('audience_insights')))


### PR DESCRIPTION
Potential fix for [https://github.com/AJaySi/ALwrity/security/code-scanning/88](https://github.com/AJaySi/ALwrity/security/code-scanning/88)

Best fix: stop logging raw `research_depth` from `context_summary`, and log only a safe, non-sensitive derived signal (presence/absence or a fixed whitelist-derived status). This preserves debugging value without exposing potentially sensitive data and satisfies all variants at the same sink.

Concretely in `backend/api/content_planning/services/content_strategy/autofill/ai_structured_autofill.py` near lines 499–506, replace the line that logs the raw `research_depth` value with a boolean/label derived from its presence. This is a minimal, behavior-preserving logging hardening change and does not require new imports or helper methods.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
