### PR TITLE
Potential fix for code scanning alert no. 85: Clear-text logging of sensitive information

### DIFF
--- a/backend/api/content_planning/services/content_strategy/autofill/ai_refresh.py
+++ b/backend/api/content_planning/services/content_strategy/autofill/ai_refresh.py
@@ -52,7 +52,7 @@ class AutoFillRefreshService:
             
             logger.info(f"  - Website analysis keys: {list(website_analysis.keys()) if website_analysis else 'None'}")
             logger.info(f"  - Research preferences keys: {list(research_preferences.keys()) if research_preferences else 'None'}")
-            logger.info(f"  - API keys data keys: {list(api_keys_data.keys()) if api_keys_data else 'None'}")
+            logger.info("  - API keys data present: %s | entry_count=%s", bool(api_keys_data), len(api_keys_data) if isinstance(api_keys_data, dict) else 0)
             logger.info(f"  - Onboarding session keys: {list(onboarding_session.keys()) if onboarding_session else 'None'}")
             
             # Log specific data points


### PR DESCRIPTION
Potential fix for [https://github.com/AJaySi/ALwrity/security/code-scanning/85](https://github.com/AJaySi/ALwrity/security/code-scanning/85)

To fix this without changing business functionality, replace the sensitive key-name logging with a non-sensitive aggregate summary (for example, whether API key data exists and a numeric count). This preserves observability while avoiding disclosure of credential-related structure.

In `backend/api/content_planning/services/content_strategy/autofill/ai_refresh.py`, update the log at line 55:

- Remove: logging of `list(api_keys_data.keys())`
- Replace with: a sanitized message that does not include any key names or values, e.g. `API keys data present: yes/no` and/or `entry count`.

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
