### PR TITLE
docs: add verified content strategy implementation status and align doc guidance

### DIFF
--- a/docs-site/docs/features/content-strategy/implementation-status.md
+++ b/docs-site/docs/features/content-strategy/implementation-status.md
@@ -1,0 +1,89 @@
+# Content Strategy Implementation Status (Verified)
+
+_Last verified: May 26, 2026_
+
+This page reflects a static code review of the **current implementation** and supersedes older roadmap claims in internal notes.
+
+## What is implemented now
+
+### Backend service architecture
+Implemented modular service structure under:
+- `backend/api/content_planning/services/content_strategy/core/`
+- `backend/api/content_planning/services/content_strategy/ai_analysis/`
+- `backend/api/content_planning/services/content_strategy/onboarding/`
+- `backend/api/content_planning/services/content_strategy/performance/`
+- `backend/api/content_planning/services/content_strategy/utils/`
+
+### AI analysis module
+Implemented:
+- AI recommendation and analysis services
+- Prompt engineering support
+- Quality validation paths
+- Multiple analysis modes and fallback handling
+
+Key files:
+- `ai_analysis/ai_recommendations.py`
+- `ai_analysis/prompt_engineering.py`
+- `ai_analysis/quality_validation.py`
+- `ai_analysis/strategy_analyzer.py`
+
+### Onboarding integration
+Implemented (not placeholder-only):
+- Onboarding data aggregation/integration
+- Field transformation from onboarding inputs to strategy fields
+- Data quality assessment scaffolding and scoring paths
+
+Key files:
+- `onboarding/data_integration.py`
+- `onboarding/field_transformation.py`
+- `onboarding/data_quality.py`
+
+### Core strategy orchestration
+Implemented:
+- Main strategy service orchestration
+- Constants and field mapping support
+- API endpoint wiring in content strategy route modules
+
+Key files:
+- `core/strategy_service.py`
+- `core/constants.py`
+- `core/field_mappings.py`
+
+## Partially implemented / needs hardening
+
+### Performance layer
+Files exist and are wired, but should be treated as **hardening required** for production-grade behavior:
+- `performance/caching.py`
+- `performance/optimization.py`
+- `performance/health_monitoring.py`
+
+Recommended hardening:
+- Redis TTL policy verification
+- cache invalidation consistency
+- dependency health telemetry and alertability
+
+### Utility + transformation overlap
+There is overlap risk between:
+- `onboarding/field_transformation.py`
+- `utils/data_processors.py`
+
+Recommended hardening:
+- define one canonical transformation path
+- align confidence/data-quality contract across services
+
+## Not yet complete (from roadmap perspective)
+
+- Advanced real-time analytics dashboards
+- fully matured predictive insights / ML workflows
+- enterprise collaboration workflows (versioning/approval patterns)
+
+## Documentation policy
+
+For public docs-site pages:
+1. Treat this page as implementation truth for status language.
+2. Use "implemented", "partial", or "planned" only when mapped to concrete files.
+3. Avoid stale milestone dates; use explicit verification dates.
+
+For internal docs in `docs/`:
+- keep architecture notes and historical plans,
+- but avoid status claims that conflict with this verified page.

--- a/docs-site/docs/features/content-strategy/overview.md
+++ b/docs-site/docs/features/content-strategy/overview.md
@@ -3,6 +3,14 @@
 ALwrity's Content Strategy module is the brain of your content marketing efforts, providing AI-powered strategic planning, persona development, and content calendar generation to help you create a comprehensive, data-driven content marketing strategy.
 
 ## What is Content Strategy?
+## Current implementation status
+
+For the latest verified implementation state, see:
+
+- [Content Strategy Implementation Status (Verified)](./implementation-status)
+
+This overview explains capabilities; the status page is the source of truth for what is currently implemented versus planned.
+
 
 Content strategy is the planning, development, and management of content to achieve specific business objectives. ALwrity's AI-powered approach transforms complex strategic planning into an automated, intelligent process that delivers measurable results.
 

--- a/docs/Content strategy/README.md
+++ b/docs/Content strategy/README.md
@@ -1,0 +1,14 @@
+# Content Strategy Internal Docs
+
+This folder contains internal design notes, implementation plans, and historical migration artifacts.
+
+## Source of truth for current status
+
+Use docs-site first for externally consumed, up-to-date implementation status:
+- `docs-site/docs/features/content-strategy/implementation-status.md`
+
+## Guidance
+
+- Treat roadmap/phase files here as planning or historical context unless explicitly re-verified.
+- Before executing work from a plan in this folder, verify against current backend modules under:
+  - `backend/api/content_planning/services/content_strategy/`


### PR DESCRIPTION
## Summary
- Added a new public docs-site source-of-truth page for content strategy implementation status.
- Updated content strategy overview to link to the verified status page.
- Added internal docs guidance README to reduce confusion between historical plans and current implementation state.

## Changes
### docs-site (priority)
- **Added** `docs-site/docs/features/content-strategy/implementation-status.md`
  - Captures verified current implementation as of **May 26, 2026**
  - Distinguishes implemented vs partial/hardening vs planned areas
  - References concrete backend module paths
- **Updated** `docs-site/docs/features/content-strategy/overview.md`
  - Added a prominent "Current implementation status" section linking to the verified page

### internal docs
- **Added** `docs/Content strategy/README.md`
  - Clarifies this folder as internal/historical/planning context
  - Points to docs-site implementation status page as source of truth

## Why
- Existing content strategy docs had drift and mixed status claims across phase/roadmap documents.
- This change creates a single, current status reference in docs-site first (as requested), while preserving internal docs for planning context.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a158e38029c832888cfc41510dea8d1)