### PR TITLE
Remove wildcard CORS headers from credentialed SSE endpoints

### DIFF
--- a/backend/api/content_planning/api/content_strategy/endpoints/streaming_endpoints.py
+++ b/backend/api/content_planning/api/content_strategy/endpoints/streaming_endpoints.py
@@ -124,10 +124,6 @@ async def stream_enhanced_strategies(
         headers={
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",
-            "Access-Control-Allow-Origin": "*",
-            "Access-Control-Allow-Headers": "*",
-            "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-            "Access-Control-Allow-Credentials": "true"
         }
     )
 
@@ -261,10 +257,6 @@ async def stream_strategic_intelligence(
         headers={
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",
-            "Access-Control-Allow-Origin": "*",
-            "Access-Control-Allow-Headers": "*",
-            "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-            "Access-Control-Allow-Credentials": "true"
         }
     )
 


### PR DESCRIPTION
### Motivation
- Prevent streaming endpoints from returning `Access-Control-Allow-Origin: *` while credentials are enabled so browser clients receive correct, centralized CORS handling from `CORSMiddleware` rather than per-response wildcard headers.

### Description
- Remove hardcoded `Access-Control-*` headers from the `StreamingResponse` for `/stream/strategies` and `/stream/strategic-intelligence` in `backend/api/content_planning/api/content_strategy/endpoints/streaming_endpoints.py`, leaving only transport headers (`Cache-Control`, `Connection`) so the app-wide `CORSMiddleware` in `backend/main.py` (configured with `allow_origins` and `allow_credentials=True`) controls CORS behavior.

### Testing
- Confirmed header removal by searching the codebase with `rg` and inspecting the updated file with `nl` to ensure the two endpoints only include `Cache-Control` and `Connection` response headers (succeeded).
- Ran an integration-style `TestClient` check to validate CORS behavior for allowed and disallowed `Origin` values, but the test run failed due to a missing local dependency (`nltk`) during application import, preventing full verification in this environment (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17101fb1d083289513824793cfd15c)