### PR TITLE
Harden backlink outreach campaign ownership checks

### DIFF
--- a/backend/routers/backlink_outreach.py
+++ b/backend/routers/backlink_outreach.py
@@ -22,7 +22,10 @@ from services.backlink_outreach_models import (
     SuppressionAddRequest,
 )
 from services.backlink_outreach_service import backlink_outreach_service
-from services.backlink_outreach_storage import BacklinkOutreachStorageService
+from services.backlink_outreach_storage import (
+    BacklinkCampaignNotFoundError,
+    BacklinkOutreachStorageService,
+)
 from services.backlink_outreach_sender import backlink_outreach_sender
 from services.backlink_outreach_reply_monitor import backlink_outreach_reply_monitor
 from services.backlink_outreach_template_generator import (
@@ -87,9 +90,14 @@ async def discover_deep_backlink_opportunities(
 ):
     """Enhanced discovery using Exa neural search + DuckDuckGo with full-page scraping."""
     user_id = _resolve_user_id(current_user)
-    result = await backlink_outreach_service.deep_discover(payload.keyword, payload.max_results)
+    storage = None
     if payload.campaign_id:
         storage = BacklinkOutreachStorageService()
+        if not storage.get_campaign(payload.campaign_id, user_id):
+            raise HTTPException(status_code=404, detail="Campaign not found")
+
+    result = await backlink_outreach_service.deep_discover(payload.keyword, payload.max_results)
+    if payload.campaign_id:
         saved = 0
         save_failed = 0
         for opp in result.get("opportunities", []):
@@ -183,7 +191,9 @@ async def add_campaign_lead(
             notes=payload.notes,
         )
         return lead
-    except Exception as e:
+    except BacklinkCampaignNotFoundError:
+        raise HTTPException(status_code=404, detail="Campaign not found")
+    except Exception:
         raise HTTPException(status_code=500, detail="Failed to add lead")
 
 

--- a/backend/services/backlink_outreach_storage.py
+++ b/backend/services/backlink_outreach_storage.py
@@ -16,6 +16,10 @@ from models.backlink_outreach_models import (
 )
 
 
+class BacklinkCampaignNotFoundError(RuntimeError):
+    """Raised when a backlink campaign is missing or not owned by the user."""
+
+
 class BacklinkOutreachStorageService:
     _NEW_LEAD_COLUMNS = [
         "url", "page_title", "snippet", "confidence_score", "discovery_source", "notes"
@@ -120,6 +124,14 @@ class BacklinkOutreachStorageService:
 
     # -- Lead CRUD --
 
+    def _campaign_belongs_to_user(self, db, campaign_id: str, user_id: str) -> bool:
+        return (
+            db.query(BacklinkCampaign)
+            .filter(BacklinkCampaign.id == campaign_id, BacklinkCampaign.user_id == user_id)
+            .first()
+            is not None
+        )
+
     def add_lead(
         self,
         campaign_id: str,
@@ -138,6 +150,9 @@ class BacklinkOutreachStorageService:
         if not db:
             raise RuntimeError("Database session unavailable")
         try:
+            if not self._campaign_belongs_to_user(db, campaign_id, user_id):
+                raise BacklinkCampaignNotFoundError("Campaign not found")
+
             lead = BacklinkLead(
                 id=f"bl_{uuid4().hex[:16]}",
                 campaign_id=campaign_id,
@@ -164,6 +179,9 @@ class BacklinkOutreachStorageService:
         if not db:
             raise RuntimeError("Database session unavailable")
         try:
+            if not self._campaign_belongs_to_user(db, campaign_id, user_id):
+                raise BacklinkCampaignNotFoundError("Campaign not found")
+
             added = []
             for data in leads_data:
                 lead = BacklinkLead(


### PR DESCRIPTION
### Motivation
- Prevent discovery or lead creation for backlink campaigns that do not exist or are not owned by the requesting user. 
- Surface a controlled 404 when a campaign is missing instead of allowing discovery to run or persisting leads into unknown campaigns.

### Description
- Added a `BacklinkCampaignNotFoundError` exception to the storage layer for controlled error handling. 
- Implemented `_campaign_belongs_to_user(db, campaign_id, user_id)` and used it in `add_lead` and `bulk_add_leads` to verify ownership before inserting leads. 
- Updated `discover_deep_backlink_opportunities` to call `storage.get_campaign(payload.campaign_id, user_id)` and return `404` if the campaign is missing before running `deep_discover` or saving results. 
- Adjusted the single-lead API (`/campaigns/{campaign_id}/leads`) to map `BacklinkCampaignNotFoundError` to an HTTP `404` instead of a generic `500`.

### Testing
- Successfully ran Python syntax check with `python -m py_compile backend/routers/backlink_outreach.py backend/services/backlink_outreach_storage.py` (passed). 
- Ran repository checks with `git diff --check` to ensure no trailing whitespace or index issues (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2022302f6c832887b3e97c6c3ff602)