### PR TITLE
Bug Fix: SaveToAssetLibrary for linkedin-writer

### DIFF
--- a/backend/alwrity_utils/router_manager.py
+++ b/backend/alwrity_utils/router_manager.py
@@ -58,7 +58,7 @@ OPTIONAL_ROUTER_REGISTRY = [
     {"name": "image_studio", "module": "routers.image_studio", "attr": "router", "features": {"all", "image_studio"}},
     {"name": "product_marketing", "module": "routers.product_marketing", "attr": "router", "features": {"all", "product_marketing"}},
     {"name": "campaign_creator", "module": "routers.campaign_creator", "attr": "router", "features": {"all"}},
-    {"name": "content_assets", "module": "api.content_assets.router", "attr": "router", "features": {"all"}},
+    {"name": "content_assets", "module": "api.content_assets.router", "attr": "router", "features":  {"all", "linkedin", "podcast", "blog_writer"}},
     {"name": "podcast", "module": "api.podcast.router", "attr": "router", "features": {"all", "podcast"}},
     {"name": "youtube", "module": "api.youtube.router", "attr": "router", "features": {"all", "youtube"}, "include_kwargs": {"prefix": "/api"}},
     {"name": "research_config", "module": "api.research_config", "attr": "router", "features": {"all", "research"}, "include_kwargs": {"prefix": "/api/research", "tags": ["research"]}},

--- a/frontend/src/components/LinkedInWriter/LinkedInWriter.tsx
+++ b/frontend/src/components/LinkedInWriter/LinkedInWriter.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { Button, Snackbar, Alert, CircularProgress } from '@mui/material';
 import { Save as SaveIcon } from '@mui/icons-material';
 import { CopilotSidebar } from '@copilotkit/react-ui';
@@ -14,8 +14,6 @@ import { useLinkedInWriter } from './hooks/useLinkedInWriter';
 import { useCopilotPersistence } from './utils/enhancedPersistence';
 import { PlatformPersonaProvider, usePlatformPersonaContext } from '../shared/PersonaContext/PlatformPersonaProvider';
 import { saveLinkedInToAssetLibrary } from '../../services/linkedInWriterApi';
-import { useContentPlanningStore } from '../../stores/contentPlanningStore';
-import { useWorkflowStore } from '../../stores/workflowStore';
 import { useCopilotActionTyped } from '../../hooks/useCopilotActionTyped';
 
 // Optional debug flag: set to true to enable verbose logs locally
@@ -130,8 +128,6 @@ const LinkedInWriterContent: React.FC<LinkedInWriterProps> = ({ className = '' }
   
   // Read calendar topic from navigation state (e.g. from Calendar tab)
   const location = useLocation();
-  const navigate = useNavigate();
-  const { completeTask } = useWorkflowStore();
   const locationState = location.state as { 
     calendarTopic?: string; 
     calendarDescription?: string;
@@ -152,11 +148,10 @@ const LinkedInWriterContent: React.FC<LinkedInWriterProps> = ({ className = '' }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // ── Save to Asset Library + Mark Calendar Event Complete ──────
+  // ── Save to Asset Library (podcast-maker pattern: save only, stay on page) ──
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
   const [saveErrorMessage, setSaveErrorMessage] = useState<string | null>(null);
-  const { updateEvent } = useContentPlanningStore();
-
+  
   const handleSaveToAssetLibrary = async () => {
     if (!draft) return;
     setSaveStatus('saving');
@@ -167,7 +162,7 @@ const LinkedInWriterContent: React.FC<LinkedInWriterProps> = ({ className = '' }
         : undefined;
       const title = draft.split('\n')[0].substring(0, 100) || 'LinkedIn Post';
 
-      await saveLinkedInToAssetLibrary({
+      const result = await saveLinkedInToAssetLibrary({
         title,
         content: draft,
         topic,
@@ -178,28 +173,10 @@ const LinkedInWriterContent: React.FC<LinkedInWriterProps> = ({ className = '' }
         },
       });
 
-      // Mark the originating calendar event as published
-      if (locationState?.calendarEventId) {
-        try {
-          await updateEvent(locationState.calendarEventId, { status: 'published' });
-        } catch (err) {
-          console.warn('[LinkedInWriter] Failed to update calendar event status:', err);
-        }
-      }
-
-      // Mark the workflow task as completed (for calendar-sourced tasks)
-      if (locationState?.workflowTaskId) {
-        try {
-          await completeTask(locationState.workflowTaskId);
-        } catch (err) {
-          console.warn('[LinkedInWriter] Failed to complete workflow task:', err);
-        }
-      }
+      console.log('[LinkedInWriter] Saved to Asset Library, assetId:', result.assetId);
 
       setSaveStatus('saved');
 
-      // Navigate back to dashboard after a brief delay so the user sees "saved"
-      setTimeout(() => navigate('/dashboard'), 1500);
     } catch (err: any) {
       const message = err?.response?.data?.detail || err?.message || 'Please try again.';
       console.error('[LinkedInWriter] Save failed:', err);
@@ -496,6 +473,7 @@ Always use the most appropriate tool for the user's request.`.trim();
           {draft && !isGenerating && (
             <div style={{ padding: '8px 24px', display: 'flex', justifyContent: 'flex-end' }}>
               <Button
+                type='button'
                 variant="contained"
                 color="success"
                 startIcon={saveStatus === 'saving' ? <CircularProgress size={18} color="inherit" /> : <SaveIcon />}

--- a/frontend/src/components/shared/FeatureRoute.tsx
+++ b/frontend/src/components/shared/FeatureRoute.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
-import { isFeatureEnabled } from '../../utils/demoMode';
+import { isFeatureEnabled, shouldSkipOnboarding } from '../../utils/demoMode';
 
 interface FeatureRouteProps {
   feature: string;
@@ -25,7 +25,9 @@ const FeatureRoute: React.FC<FeatureRouteProps> = ({
   children, 
   redirectTo = '/dashboard' 
 }) => {
-  if (!isFeatureEnabled(feature)) {
+  const isAssetLibraryInFeatureMode = feature === 'asset-library' && shouldSkipOnboarding();
+
+  if (!isFeatureEnabled(feature) && !isAssetLibraryInFeatureMode) {
     return <Navigate to={redirectTo} replace />;
   }
   return <>{children}</>;

--- a/frontend/src/components/shared/ProtectedRoute.tsx
+++ b/frontend/src/components/shared/ProtectedRoute.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '@clerk/clerk-react';
 import { Box, CircularProgress, Typography, Alert, Button } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { useOnboarding } from '../../contexts/OnboardingContext';
-import { shouldSkipOnboarding, getDefaultLandingRoute } from '../../utils/demoMode';
+import { shouldSkipOnboarding, isFeatureOnlyAllowedPath } from '../../utils/demoMode';
 import { useLocation } from 'react-router-dom';
 
 interface ProtectedRouteProps {
@@ -37,14 +37,14 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
     try { return localStorage.getItem('onboarding_complete') === 'true'; } catch { return false; }
   })();
   const isFeatureLimited = shouldSkipOnboarding();
-  const defaultRoute = getDefaultLandingRoute();
-  const isOnDefaultRoute = typeof location?.pathname === 'string' && location.pathname.startsWith(defaultRoute);
+  const pathname = typeof location?.pathname === 'string' ? location.pathname : '';
+  const isOnFeatureOnlyRoute = isFeatureOnlyAllowedPath(pathname);
 
   // Allow access to utility pages regardless of onboarding status
   const bypassRoutes = ['/billing', '/pricing', '/onboarding'];
-  const isBypassRoute = typeof location?.pathname === 'string' && bypassRoutes.some(route => location.pathname.startsWith(route));
+  const isBypassRoute = pathname !== '' && bypassRoutes.some(route => pathname.startsWith(route));
 
-  const allowAccess = isOnboardingComplete || localComplete || (isFeatureLimited && isOnDefaultRoute) || isBypassRoute;
+  const allowAccess = isOnboardingComplete || localComplete || (isFeatureLimited && isOnFeatureOnlyRoute) || isBypassRoute;
 
   // Wait for Clerk to load before any redirect decisions
   if (!isLoaded) {

--- a/frontend/src/services/linkedInWriterApi.ts
+++ b/frontend/src/services/linkedInWriterApi.ts
@@ -348,5 +348,7 @@ export const saveLinkedInToAssetLibrary = async (
     },
   });
 
+  console.log('[linkedInWriterApi] LinkedIn post saved to Asset Library:', response.data.id);
+  
   return { assetId: response.data.id };
 };

--- a/frontend/src/utils/demoMode.ts
+++ b/frontend/src/utils/demoMode.ts
@@ -160,3 +160,30 @@ export function shouldSkipOnboarding(): boolean {
   const enabled = getEnabledFeatures();
   return !enabled.has('all');
 }
+
+/** Shared routes allowed in feature-only mode without completing onboarding. */
+const FEATURE_ONLY_SHARED_ROUTES = ['/asset-library'];
+
+/**
+ * Whether a pathname is reachable in feature-only mode without onboarding.
+ * Includes the default landing route, shared utility routes, and any enabled feature route.
+ */
+export function isFeatureOnlyAllowedPath(pathname: string): boolean {
+  if (!pathname || !shouldSkipOnboarding()) {
+    return false;
+  }
+
+  const defaultRoute = getDefaultLandingRoute();
+  if (pathname.startsWith(defaultRoute)) {
+    return true;
+  }
+
+  if (FEATURE_ONLY_SHARED_ROUTES.some((route) => pathname.startsWith(route))) {
+    return true;
+  }
+
+  const enabled = getEnabledFeatures();
+  return FEATURE_ROUTE_PRIORITY.some(
+    ([feature, route]) => enabled.has(feature) && pathname.startsWith(route)
+  );
+}


### PR DESCRIPTION
1. Fixed  "Save to Asset Library" on linkedin-writer page:
   a. Rewrite handleSaveToAssetLibrary to match podcast maker: save only, no updateEvent/completeTask/navigate
   b. Add linkedin to content_assets router features in router_manager.py (belt-and-suspenders for feature-only deploys)
   c. Remove setTimeout navigate('/dashboard') from handleSaveToAssetLibrary in LinkedInWriter.tsx

2. Enable asset-library in feature-only mode. Asset library is blocked by the same onboarding gate as dashboard. Fixed ProtectedRoute and FeatureRoute so /asset-library is allowed in feature-only mode:
   a. frontend/src/utils/demoMode.ts — added isFeatureOnlyAllowedPath() so feature-only mode allows /asset-library (and all enabled feature routes), not just the default landing route.
   b. frontend/src/components/shared/ProtectedRoute.tsx — replaced isOnDefaultRoute with isFeatureOnlyAllowedPath(pathname).
   c. frontend/src/components/shared/FeatureRoute.tsx — allow asset-library route when shouldSkipOnboarding() is true, even if asset-library isn’t in REACT_APP_ENABLED_FEATURES.