### PR TITLE
[Issue #677] LinkedIn Image Service

### DIFF
--- a/backend/api/linkedin_image_generation.py
+++ b/backend/api/linkedin_image_generation.py
@@ -114,7 +114,7 @@ async def generate_linkedin_image(
         
         if image_result and image_result.get('success'):
             # Store the generated image
-            image_id = await image_storage.store_image(
+            store_result = await image_storage.store_image(
                 image_data=image_result['image_data'],
                 metadata={
                     'prompt': request.prompt,
@@ -124,8 +124,19 @@ async def generate_linkedin_image(
                     'topic': request.content_context.get('topic'),
                     'industry': request.content_context.get('industry')
                 },
+                content_type=request.content_context.get('content_type') or 'post',
                 user_id=user_id
             )
+
+            if not store_result.get('success'):
+                error_msg = store_result.get('error', 'Failed to store generated image')
+                logger.error(f"Image storage failed: {error_msg}")
+                return ImageGenerationResponse(
+                    success=False,
+                    error=error_msg
+                )
+
+            image_id = store_result['image_id']
             
             logger.info(f"Image generated and stored successfully with ID: {image_id}")
             

--- a/frontend/src/components/LinkedInWriter/__tests__/linkedInImageService.test.ts
+++ b/frontend/src/components/LinkedInWriter/__tests__/linkedInImageService.test.ts
@@ -1,0 +1,102 @@
+import {
+  buildPromptFromSelection,
+  resolveLinkedInImageUrl,
+  generateLinkedInImage,
+  mapAspectRatioToLinkedIn,
+} from '../../../services/linkedInImageService';
+import { aiApiClient } from '../../../api/client';
+
+jest.mock('../../../api/client', () => ({
+  aiApiClient: {
+    post: jest.fn(),
+    get: jest.fn(),
+  },
+}));
+
+jest.mock('../../../utils/apiUrl', () => ({
+  getApiBaseUrl: () => 'http://localhost:8000',
+}));
+
+describe('linkedInImageService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('buildPromptFromSelection', () => {
+    it('includes selected text and LinkedIn context', () => {
+      const prompt = buildPromptFromSelection(
+        'AI is transforming how teams collaborate.',
+        'Future of Work',
+        'Technology'
+      );
+
+      expect(prompt).toContain('AI is transforming how teams collaborate.');
+      expect(prompt).toContain('Topic: Future of Work.');
+      expect(prompt).toContain('Industry: Technology.');
+      expect(prompt).toContain('LinkedIn');
+    });
+  });
+
+  describe('resolveLinkedInImageUrl', () => {
+    it('builds correct path for image id', () => {
+      expect(resolveLinkedInImageUrl('abc123')).toBe(
+        'http://localhost:8000/api/linkedin/images/abc123'
+      );
+    });
+  });
+
+  describe('mapAspectRatioToLinkedIn', () => {
+    it('maps 16:9 to LinkedIn 1.91:1 feed ratio', () => {
+      expect(mapAspectRatioToLinkedIn('16:9')).toBe('1.91:1');
+    });
+  });
+
+  describe('generateLinkedInImage', () => {
+    it('logs URL on success', async () => {
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+      (aiApiClient.post as jest.Mock).mockResolvedValue({
+        data: {
+          success: true,
+          image_id: 'test-id-123',
+        },
+      });
+
+      const result = await generateLinkedInImage({
+        prompt: 'Professional LinkedIn visual',
+        selectedText: 'Selected post excerpt for image context.',
+        topic: 'Leadership',
+        industry: 'Business',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.imageId).toBe('test-id-123');
+      expect(result.imageUrl).toContain('test-id-123');
+
+      console.log('[LinkedInSelectionImage] Generated image URL:', result.imageUrl);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[LinkedInSelectionImage] Generated image URL:',
+        expect.stringContaining('test-id-123')
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('returns error when API reports failure', async () => {
+      (aiApiClient.post as jest.Mock).mockResolvedValue({
+        data: {
+          success: false,
+          error: 'Provider unavailable',
+        },
+      });
+
+      const result = await generateLinkedInImage({
+        prompt: 'Test prompt',
+        selectedText: 'Some selected text here.',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Provider unavailable');
+    });
+  });
+});

--- a/frontend/src/components/LinkedInWriter/components/ContentEditor.tsx
+++ b/frontend/src/components/LinkedInWriter/components/ContentEditor.tsx
@@ -7,6 +7,9 @@ import {
   ContentPreviewHeaderWithModals,
   ContentDisplayArea
 } from '../../TextEditor';
+import { readPrefs } from '../utils/linkedInWriterUtils';
+import { useLinkedInSelectionImage } from '../hooks/useLinkedInSelectionImage';
+import { LinkedInSelectionImageModal } from './LinkedInSelectionImageModal';
 
 interface ContentEditorProps {
   isPreviewing: boolean;
@@ -66,8 +69,17 @@ const ContentEditor: React.FC<ContentEditorProps> = ({
   const hasTriggeredOnceRef = useRef<boolean>(false);
   const ctaDebounceRef = useRef<NodeJS.Timeout | null>(null); // Debounce CTA appearance
 
+  const prefs = readPrefs();
+  const selectionImage = useLinkedInSelectionImage({
+    topic,
+    industry: prefs.industry,
+  });
+
   // Initialize text selection handler
-  const textSelectionHandler = useTextSelectionHandler(contentRef);
+  const textSelectionHandler = useTextSelectionHandler(contentRef, {
+    onGenerateImage: selectionImage.openForSelection,
+    isGeneratingImage: selectionImage.isGenerating,
+  });
 
   // Handle selected text replacement for quick edits
   useEffect(() => {
@@ -416,6 +428,16 @@ const ContentEditor: React.FC<ContentEditorProps> = ({
 
       {/* Citation Hover Handler */}
       <CitationHoverHandler researchSources={researchSources || []} />
+
+      <LinkedInSelectionImageModal
+        open={selectionImage.modalOpen}
+        onClose={selectionImage.closeModal}
+        onGenerate={selectionImage.handleGenerate}
+        initialPrompt={selectionImage.initialPrompt}
+        isGenerating={selectionImage.isGenerating}
+        generatedPreview={selectionImage.generatedPreview}
+        onClosePreview={selectionImage.closePreview}
+      />
     </div>
   );
 };

--- a/frontend/src/components/LinkedInWriter/components/LinkedInSelectionImageModal.tsx
+++ b/frontend/src/components/LinkedInWriter/components/LinkedInSelectionImageModal.tsx
@@ -1,0 +1,134 @@
+/**
+ * LinkedIn Selection Image Modal
+ *
+ * Wrapper around the shared ImageGenerationModal with LinkedIn presets,
+ * plus a result preview dialog after successful generation.
+ */
+
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Typography,
+  Link,
+} from '@mui/material';
+import {
+  ImageGenerationModal,
+  ImageGenerationSettings as SharedImageGenerationSettings,
+} from '../../shared/ImageGenerationModal';
+import {
+  LINKEDIN_PRESETS,
+  LINKEDIN_THEME,
+  LINKEDIN_RECOMMENDATIONS,
+} from '../../shared/ImageGenerationPresets';
+
+export interface LinkedInImageGenerationSettings {
+  prompt: string;
+  style: 'Auto' | 'Fiction' | 'Realistic';
+  renderingSpeed: 'Default' | 'Turbo' | 'Quality';
+  aspectRatio: '1:1' | '16:9' | '9:16' | '4:3' | '3:4';
+}
+
+export interface GeneratedLinkedInImagePreview {
+  blobUrl: string;
+  imageUrl: string;
+  imageId?: string;
+}
+
+interface LinkedInSelectionImageModalProps {
+  open: boolean;
+  onClose: () => void;
+  onGenerate: (settings: LinkedInImageGenerationSettings) => void;
+  initialPrompt: string;
+  isGenerating?: boolean;
+  generatedPreview?: GeneratedLinkedInImagePreview | null;
+  onClosePreview?: () => void;
+}
+
+export const LinkedInSelectionImageModal: React.FC<LinkedInSelectionImageModalProps> = ({
+  open,
+  onClose,
+  onGenerate,
+  initialPrompt,
+  isGenerating = false,
+  generatedPreview,
+  onClosePreview,
+}) => {
+  const handleGenerate = (settings: SharedImageGenerationSettings) => {
+    onGenerate({
+      prompt: settings.prompt,
+      style: settings.style,
+      renderingSpeed: settings.renderingSpeed,
+      aspectRatio: settings.aspectRatio,
+    });
+  };
+
+  if (generatedPreview) {
+    return (
+      <Dialog open={open} onClose={onClosePreview || onClose} maxWidth="sm" fullWidth>
+        <DialogTitle sx={{ color: '#0A66C2', fontWeight: 600 }}>
+          Image Generated Successfully
+        </DialogTitle>
+        <DialogContent>
+          <Box sx={{ textAlign: 'center', py: 1 }}>
+            <Box
+              component="img"
+              src={generatedPreview.blobUrl}
+              alt="Generated LinkedIn image"
+              sx={{
+                maxWidth: '100%',
+                maxHeight: 360,
+                borderRadius: 2,
+                border: '1px solid #e0e0e0',
+                mb: 2,
+              }}
+            />
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              Your LinkedIn-optimized image is ready.
+            </Typography>
+            <Link
+              href={generatedPreview.imageUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{ fontSize: '0.85rem', wordBreak: 'break-all' }}
+            >
+              {generatedPreview.imageUrl}
+            </Link>
+          </Box>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={onClosePreview || onClose} variant="contained" color="primary">
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+
+  return (
+    <ImageGenerationModal
+      open={open}
+      onClose={onClose}
+      onGenerate={handleGenerate}
+      initialPrompt={initialPrompt}
+      isGenerating={isGenerating}
+      title="Generate LinkedIn Image"
+      promptLabel="Visual Prompt"
+      promptHelp="Describe the image you want for your LinkedIn post. The selected text is used as context — refine the prompt for best results."
+      generateButtonLabel="Generate Image"
+      presets={LINKEDIN_PRESETS}
+      presetsLabel="LinkedIn-ready presets"
+      presetsHelp="Quickly apply a LinkedIn-friendly look. Each preset adjusts style, composition, and aspect ratio."
+      showModelSelection={false}
+      defaultStyle="Realistic"
+      defaultRenderingSpeed="Quality"
+      defaultAspectRatio="1:1"
+      theme={LINKEDIN_THEME}
+      recommendations={LINKEDIN_RECOMMENDATIONS}
+    />
+  );
+};

--- a/frontend/src/components/LinkedInWriter/components/index.ts
+++ b/frontend/src/components/LinkedInWriter/components/index.ts
@@ -16,6 +16,7 @@ export { CopilotRecommendationsRenderer } from './CopilotRecommendationsRenderer
 export { default as ImageGenerationSuggestions } from './ImageGenerationSuggestions';
 export { default as ImageGenerationDemo } from './ImageGenerationDemo';
 export { default as ImageGenerationTest } from './ImageGenerationTest';
+export { LinkedInSelectionImageModal } from './LinkedInSelectionImageModal';
 
 // Persona Integration Components - Now integrated into main LinkedInWriter
 

--- a/frontend/src/components/LinkedInWriter/hooks/useLinkedInSelectionImage.ts
+++ b/frontend/src/components/LinkedInWriter/hooks/useLinkedInSelectionImage.ts
@@ -1,0 +1,120 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { showToastNotification } from '../../../utils/toastNotifications';
+import {
+  buildPromptFromSelection,
+  generateLinkedInImage,
+  fetchLinkedInImageBlobUrl,
+  resolveLinkedInImageUrl,
+} from '../../../services/linkedInImageService';
+import type {
+  LinkedInImageGenerationSettings,
+  GeneratedLinkedInImagePreview,
+} from '../components/LinkedInSelectionImageModal';
+
+interface UseLinkedInSelectionImageOptions {
+  topic?: string;
+  industry?: string;
+}
+
+export function useLinkedInSelectionImage({
+  topic,
+  industry,
+}: UseLinkedInSelectionImageOptions) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [selectedText, setSelectedText] = useState('');
+  const [initialPrompt, setInitialPrompt] = useState('');
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [generatedPreview, setGeneratedPreview] =
+    useState<GeneratedLinkedInImagePreview | null>(null);
+  const blobUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current);
+      }
+    };
+  }, []);
+
+  const openForSelection = useCallback(
+    (text: string) => {
+      const trimmed = text.trim();
+      setSelectedText(trimmed);
+      setInitialPrompt(buildPromptFromSelection(trimmed, topic, industry));
+      setGeneratedPreview(null);
+      setModalOpen(true);
+    },
+    [topic, industry]
+  );
+
+  const closeModal = useCallback(() => {
+    setModalOpen(false);
+    setSelectedText('');
+    setInitialPrompt('');
+  }, []);
+
+  const closePreview = useCallback(() => {
+    if (blobUrlRef.current) {
+      URL.revokeObjectURL(blobUrlRef.current);
+      blobUrlRef.current = null;
+    }
+    setGeneratedPreview(null);
+    closeModal();
+  }, [closeModal]);
+
+  const handleGenerate = useCallback(
+    async (settings: LinkedInImageGenerationSettings) => {
+      setIsGenerating(true);
+      try {
+        const result = await generateLinkedInImage({
+          prompt: settings.prompt,
+          selectedText,
+          topic,
+          industry,
+          style: settings.style,
+          aspectRatio: settings.aspectRatio,
+        });
+
+        if (!result.success || !result.imageId) {
+          showToastNotification(result.error || 'Image generation failed', 'error');
+          return;
+        }
+
+        const imageUrl = result.imageUrl || resolveLinkedInImageUrl(result.imageId);
+        console.log('[LinkedInSelectionImage] Generated image URL:', imageUrl);
+
+        const blobUrl = await fetchLinkedInImageBlobUrl(result.imageId);
+        if (blobUrlRef.current) {
+          URL.revokeObjectURL(blobUrlRef.current);
+        }
+        blobUrlRef.current = blobUrl;
+
+        setGeneratedPreview({
+          blobUrl,
+          imageUrl,
+          imageId: result.imageId,
+        });
+
+        showToastNotification(`Image generated: ${imageUrl}`, 'success');
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Image generation failed';
+        showToastNotification(message, 'error');
+      } finally {
+        setIsGenerating(false);
+      }
+    },
+    [selectedText, topic, industry]
+  );
+
+  return {
+    modalOpen,
+    initialPrompt,
+    isGenerating,
+    generatedPreview,
+    openForSelection,
+    closeModal,
+    closePreview,
+    handleGenerate,
+  };
+}

--- a/frontend/src/components/TextEditor/TextSelectionHandler.tsx
+++ b/frontend/src/components/TextEditor/TextSelectionHandler.tsx
@@ -2,7 +2,16 @@ import React, { useState, useRef, useEffect } from 'react';
 import { hallucinationDetectorService, HallucinationDetectionResponse } from '../../services/hallucinationDetectorService';
 import FactCheckResults from '../LinkedInWriter/components/FactCheckResults';
 
-const useTextSelectionHandler = (contentRef: React.RefObject<HTMLDivElement>) => {
+interface TextSelectionHandlerOptions {
+  onGenerateImage?: (text: string) => void;
+  isGeneratingImage?: boolean;
+}
+
+const useTextSelectionHandler = (
+  contentRef: React.RefObject<HTMLDivElement>,
+  options?: TextSelectionHandlerOptions
+) => {
+  const { onGenerateImage, isGeneratingImage = false } = options || {};
   const [selectionMenu, setSelectionMenu] = useState<{ x: number; y: number; text: string } | null>(null);
   const [factCheckResults, setFactCheckResults] = useState<HallucinationDetectionResponse | null>(null);
   const [isFactChecking, setIsFactChecking] = useState(false);
@@ -304,6 +313,63 @@ const useTextSelectionHandler = (contentRef: React.RefObject<HTMLDivElement>) =>
                 </>
               )}
             </button>
+
+            {/* Generate Image Button */}
+            {onGenerateImage && (
+              <button
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  const text = selectionMenu.text;
+                  setSelectionMenu(null);
+                  onGenerateImage(text);
+                }}
+                disabled={isGeneratingImage}
+                style={{
+                  background: isGeneratingImage ? 'rgba(255, 255, 255, 0.1)' : 'rgba(255, 255, 255, 0.2)',
+                  border: '1px solid rgba(255, 255, 255, 0.3)',
+                  borderRadius: '6px',
+                  padding: '6px 12px',
+                  color: 'white',
+                  fontSize: '12px',
+                  fontWeight: '600',
+                  cursor: isGeneratingImage ? 'not-allowed' : 'pointer',
+                  opacity: isGeneratingImage ? 0.6 : 1,
+                  transition: 'all 0.2s ease',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '4px',
+                  width: '100%',
+                  justifyContent: 'center'
+                }}
+                onMouseEnter={(e) => {
+                  if (!isGeneratingImage) {
+                    e.currentTarget.style.background = 'rgba(255, 255, 255, 0.3)';
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (!isGeneratingImage) {
+                    e.currentTarget.style.background = 'rgba(255, 255, 255, 0.2)';
+                  }
+                }}
+              >
+                {isGeneratingImage ? (
+                  <>
+                    <div style={{
+                      width: '12px',
+                      height: '12px',
+                      border: '2px solid rgba(255, 255, 255, 0.3)',
+                      borderTop: '2px solid white',
+                      borderRadius: '50%',
+                      animation: 'spin 1s linear infinite'
+                    }} />
+                    Generating...
+                  </>
+                ) : (
+                  <>🖼️ Generate Image</>
+                )}
+              </button>
+            )}
 
             {/* Quick Edit Options */}
             <div style={{

--- a/frontend/src/components/shared/ImageGenerationPresets.tsx
+++ b/frontend/src/components/shared/ImageGenerationPresets.tsx
@@ -203,6 +203,74 @@ export const PODCAST_RECOMMENDATIONS: CustomRecommendations = {
 // Brand Avatar-specific Recommendations
 // ============================================
 
+// ============================================
+// LinkedIn Writer Presets
+// ============================================
+
+export const LINKEDIN_PRESETS: ImagePreset[] = [
+  {
+    key: 'professionalSquare',
+    title: 'Professional Square',
+    subtitle: 'Clean 1:1 feed image for LinkedIn posts',
+    prompt: 'Professional LinkedIn post image, corporate aesthetic, clean composition, mobile-friendly, high contrast text-safe areas, modern business visual, neutral background with subtle brand accents',
+    style: 'Realistic',
+    renderingSpeed: 'Quality',
+    aspectRatio: '1:1',
+  },
+  {
+    key: 'landscapeFeed',
+    title: 'Landscape Feed',
+    subtitle: 'Wide format optimized for LinkedIn feed',
+    prompt: 'LinkedIn landscape feed image, professional business context, cinematic wide composition, clear focal point, polished corporate look, optimized for 1.91:1 feed viewing',
+    style: 'Realistic',
+    renderingSpeed: 'Quality',
+    aspectRatio: '16:9',
+  },
+  {
+    key: 'thoughtLeadership',
+    title: 'Thought Leadership',
+    subtitle: 'Authoritative visual for executive posts',
+    prompt: 'Thought leadership LinkedIn visual, executive presence, minimalist design, data-inspired abstract elements, trustworthy professional tone, editorial quality',
+    style: 'Realistic',
+    renderingSpeed: 'Quality',
+    aspectRatio: '1:1',
+  },
+  {
+    key: 'industryVisual',
+    title: 'Industry Visual',
+    subtitle: 'Industry-specific professional imagery',
+    prompt: 'Industry-specific LinkedIn professional image, relevant business metaphors, modern workplace aesthetic, engaging but credible, suitable for B2B audience',
+    style: 'Auto',
+    renderingSpeed: 'Quality',
+    aspectRatio: '1:1',
+  },
+];
+
+export const LINKEDIN_THEME: ImageModalTheme = {
+  dialogBackground: 'rgba(10, 30, 60, 0.96)',
+  primaryAccent: '#0A66C2',
+  secondaryAccent: '#057642',
+  warningAccent: '#f59e0b',
+};
+
+export const LINKEDIN_RECOMMENDATIONS: CustomRecommendations = {
+  style: <>
+    <strong>Realistic:</strong> Best for professional LinkedIn posts and corporate content<br />
+    <strong>Auto:</strong> Balanced look for general business topics<br />
+    <strong>Fiction:</strong> Use sparingly for creative or illustrative posts
+  </>,
+  speed: <>
+    <strong>Quality:</strong> Recommended for final LinkedIn post images<br />
+    <strong>Default:</strong> Good balance for iterations<br />
+    <strong>Turbo:</strong> Quick previews while refining your prompt
+  </>,
+  aspectRatio: <>
+    <strong>1:1 (Square):</strong> Standard LinkedIn feed post image (recommended)<br />
+    <strong>16:9:</strong> Wide landscape — mapped to LinkedIn 1.91:1 feed format<br />
+    <strong>3:4:</strong> Portrait orientation for mobile-first posts
+  </>,
+};
+
 export const BRAND_AVATAR_RECOMMENDATIONS: CustomRecommendations = {
   style: <>
     <strong>Realistic:</strong> Best for professional personal brands and executive headshots.<br />

--- a/frontend/src/services/linkedInImageService.ts
+++ b/frontend/src/services/linkedInImageService.ts
@@ -1,0 +1,114 @@
+import { aiApiClient } from '../api/client';
+import { getApiBaseUrl } from '../utils/apiUrl';
+import type { AspectRatio, ImageStyle } from '../components/shared/ImageGenerationModal.types';
+
+export interface LinkedInImageGenerationParams {
+  prompt: string;
+  selectedText: string;
+  topic?: string;
+  industry?: string;
+  style?: ImageStyle | string;
+  aspectRatio?: AspectRatio | string;
+  contentType?: string;
+}
+
+export interface LinkedInImageGenerationResult {
+  success: boolean;
+  imageId?: string;
+  imageUrl?: string;
+  style?: string;
+  aspectRatio?: string;
+  error?: string;
+}
+
+/** Build a LinkedIn-optimized visual prompt from selected post text. */
+export function buildPromptFromSelection(
+  selectedText: string,
+  topic?: string,
+  industry?: string
+): string {
+  const snippet = selectedText.trim().slice(0, 400);
+  const topicLine = topic ? `Topic: ${topic}.` : '';
+  const industryLine = industry ? `Industry: ${industry}.` : '';
+  return [
+    'Create a professional LinkedIn post image that visually supports this content:',
+    snippet,
+    topicLine,
+    industryLine,
+    'Professional business aesthetic, mobile-optimized, clear visual hierarchy, no cluttered text overlays.',
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+/** Map modal aspect ratio to LinkedIn API aspect ratio values. */
+export function mapAspectRatioToLinkedIn(ratio: AspectRatio | string): string {
+  switch (ratio) {
+    case '16:9':
+      return '1.91:1';
+    case '3:4':
+      return '1:1.25';
+    default:
+      return ratio;
+  }
+}
+
+/** Resolve a fetchable URL for a stored LinkedIn image. */
+export function resolveLinkedInImageUrl(imageId: string, baseUrl?: string): string {
+  const base = (baseUrl || getApiBaseUrl()).replace(/\/$/, '');
+  return `${base}/api/linkedin/images/${imageId}`;
+}
+
+function normalizeImageId(raw: unknown): string | undefined {
+  if (typeof raw === 'string') return raw;
+  if (raw && typeof raw === 'object' && 'image_id' in raw) {
+    return String((raw as { image_id: string }).image_id);
+  }
+  return undefined;
+}
+
+/** Generate a LinkedIn image via the backend API. */
+export async function generateLinkedInImage(
+  params: LinkedInImageGenerationParams
+): Promise<LinkedInImageGenerationResult> {
+  const aspectRatio = mapAspectRatioToLinkedIn(params.aspectRatio || '1:1');
+
+  const response = await aiApiClient.post('/api/linkedin/generate-image', {
+    prompt: params.prompt,
+    content_context: {
+      topic: params.topic || 'LinkedIn post',
+      industry: params.industry || 'Business',
+      content_type: params.contentType || 'post',
+      content: params.selectedText,
+      style: params.style || 'Realistic',
+    },
+    aspect_ratio: aspectRatio,
+  });
+
+  const data = response.data;
+  if (!data?.success) {
+    return {
+      success: false,
+      error: data?.error || 'Image generation failed',
+    };
+  }
+
+  const imageId = normalizeImageId(data.image_id);
+  const imageUrl = data.image_url || (imageId ? resolveLinkedInImageUrl(imageId) : undefined);
+
+  return {
+    success: true,
+    imageId,
+    imageUrl,
+    style: data.style,
+    aspectRatio: data.aspect_ratio || aspectRatio,
+  };
+}
+
+/** Fetch image bytes for authenticated preview (returns blob URL). */
+export async function fetchLinkedInImageBlobUrl(imageId: string): Promise<string> {
+  const response = await aiApiClient.get(`/api/linkedin/images/${imageId}`, {
+    responseType: 'blob',
+  });
+  return URL.createObjectURL(response.data);
+}

--- a/frontend/src/services/linkedInWriterApi.ts
+++ b/frontend/src/services/linkedInWriterApi.ts
@@ -1,4 +1,13 @@
 import { apiClient, aiApiClient } from '../api/client';
+import {
+  generateLinkedInImage as generateLinkedInImageService,
+  buildPromptFromSelection as buildLinkedInImagePrompt,
+  resolveLinkedInImageUrl,
+  fetchLinkedInImageBlobUrl,
+  mapAspectRatioToLinkedIn,
+  type LinkedInImageGenerationParams,
+  type LinkedInImageGenerationResult,
+} from './linkedInImageService';
 
 // LinkedIn-specific enums
 export enum LinkedInPostType {
@@ -292,7 +301,16 @@ export const linkedInWriterApi = {
   async editContent(request: LinkedInEditContentRequest): Promise<LinkedInEditContentResponse> {
     const { data } = await aiApiClient.post('/api/linkedin/edit-content', request);
     return data;
-  }
+  },
+
+  async generateImage(params: LinkedInImageGenerationParams): Promise<LinkedInImageGenerationResult> {
+    return generateLinkedInImageService(params);
+  },
+
+  buildImagePromptFromSelection: buildLinkedInImagePrompt,
+  resolveImageUrl: resolveLinkedInImageUrl,
+  fetchImageBlobUrl: fetchLinkedInImageBlobUrl,
+  mapImageAspectRatio: mapAspectRatioToLinkedIn,
 };
 
 // ── Asset Library Save ────────────────────────────────────────────────


### PR DESCRIPTION
Adds **Generate Image** to the LinkedIn Writer text-selection menu on `/linkedin-writer`. Selected post text opens a LinkedIn-themed image generation modal (reusing the shared `ImageGenerationModal` pattern from Podcast Maker), calls the existing LinkedIn backend (`POST /api/linkedin/generate-image`), and shows the result in-modal plus a success toast with the image URL.

Also fixes a backend bug where `store_image()` returns a dict but `generate-image` passed the whole object as `image_id`, causing a Pydantic validation error.

## Changes

### Frontend
- **`linkedInImageService.ts`** — Testable service: prompt builder, aspect-ratio mapping, `generateLinkedInImage`, blob URL fetch for authenticated preview
- **`LinkedInSelectionImageModal.tsx`** — LinkedIn wrapper around shared `ImageGenerationModal` with presets, theme, and post-generation preview dialog
- **`useLinkedInSelectionImage.ts`** — Hook for selection → modal → generate flow (toast + `console.log` URL)
- **`TextSelectionHandler.tsx`** — Optional `onGenerateImage` / `isGeneratingImage`; **Generate Image** button between Check Facts and Quick Edit
- **`ContentEditor.tsx`** — Wires hook + modal into LinkedIn preview editor
- **`ImageGenerationPresets.tsx`** — `LINKEDIN_PRESETS`, `LINKEDIN_THEME`, `LINKEDIN_RECOMMENDATIONS`
- **`linkedInWriterApi.ts`** — Thin wrappers delegating to `linkedInImageService`
- **`linkedInImageService.test.ts`** — Unit tests for prompt builder, URL resolution, and mocked API success/error paths

### Backend
- **`linkedin_image_generation.py`** — Extract `image_id` string from `store_image()` result; handle storage failures explicitly


## Test plan

- [ ] Run frontend tests:
  ```powershell
  cd frontend
  npm test -- --testPathPattern=linkedInImageService
  ```