### PR TITLE
LinkedIn Video Generation + Video Script writer bug-fix

### DIFF
--- a/backend/alwrity_utils/feature_registry.py
+++ b/backend/alwrity_utils/feature_registry.py
@@ -67,6 +67,7 @@ FEATURE_GROUPS: Dict[str, FeatureGroup] = {
         routers=(
             "routers.linkedin:router",
             "api.linkedin_image_generation:router",
+            "api.linkedin_video_generation:router",
         ),
     ),
     "facebook": FeatureGroup(

--- a/backend/alwrity_utils/router_manager.py
+++ b/backend/alwrity_utils/router_manager.py
@@ -29,6 +29,7 @@ CORE_ROUTER_REGISTRY = [
     {"name": "facebook_writer", "module": "api.facebook_writer.routers", "attr": "facebook_router", "features": {"all", "core", "facebook"}},
     {"name": "linkedin", "module": "routers.linkedin", "attr": "router", "features": {"all", "core", "linkedin"}},
     {"name": "linkedin_image", "module": "api.linkedin_image_generation", "attr": "router", "features": {"all", "core", "linkedin"}},
+    {"name": "linkedin_video", "module": "api.linkedin_video_generation", "attr": "router", "features": {"all", "core", "linkedin"}},
     {"name": "brainstorm", "module": "api.brainstorm", "attr": "router", "features": {"all", "core"}},
     {"name": "hallucination_detector", "module": "api.hallucination_detector", "attr": "router", "features": {"all", "core"}},
     {"name": "writing_assistant", "module": "api.writing_assistant", "attr": "router", "features": {"all", "core", "blog_writer"}},

--- a/backend/api/linkedin_video_generation.py
+++ b/backend/api/linkedin_video_generation.py
@@ -1,0 +1,170 @@
+import os
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi.responses import FileResponse
+from pydantic import BaseModel, Field
+from loguru import logger
+
+from services.linkedin.video_generation import LinkedInVideoGenerator, LinkedInVideoStorage
+from services.linkedin.video_generation.tasks import execute_linkedin_video_generation_task
+from services.onboarding.api_key_manager import APIKeyManager
+from middleware.auth_middleware import get_current_user
+from api.story_writer.task_manager import task_manager
+
+router = APIRouter(prefix="/api/linkedin", tags=["linkedin-video-generation"])
+
+api_key_manager = APIKeyManager()
+video_generator = LinkedInVideoGenerator(api_key_manager)
+video_storage = LinkedInVideoStorage(api_key_manager=api_key_manager)
+
+
+class VideoGenerationRequest(BaseModel):
+    prompt: str
+    content_context: Dict[str, Any]
+    aspect_ratio: Optional[str] = "16:9"
+    duration: Optional[int] = Field(default=5, ge=5, le=10)
+    resolution: Optional[str] = "720p"
+    motion_preset: Optional[str] = "medium"
+
+
+class VideoGenerationStartResponse(BaseModel):
+    task_id: str
+    status: str
+    message: str
+
+
+@router.post("/generate-video", response_model=VideoGenerationStartResponse)
+async def generate_linkedin_video(
+    request: VideoGenerationRequest,
+    background_tasks: BackgroundTasks,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """Start async LinkedIn video generation from selected content context."""
+    try:
+        user_id = current_user.get("id")
+        if not user_id:
+            raise HTTPException(status_code=401, detail="Authentication required")
+
+        if not request.prompt or not request.prompt.strip():
+            raise HTTPException(status_code=400, detail="Prompt is required")
+
+        logger.info(
+            f"Starting LinkedIn video generation for user {user_id}: {request.prompt[:100]}..."
+        )
+
+        task_id = task_manager.create_task(
+            "linkedin_video_generation",
+            metadata={"owner_user_id": user_id},
+        )
+
+        background_tasks.add_task(
+            execute_linkedin_video_generation_task,
+            task_id=task_id,
+            user_id=user_id,
+            prompt=request.prompt,
+            content_context=request.content_context,
+            aspect_ratio=request.aspect_ratio or "16:9",
+            duration=request.duration or 5,
+            resolution=request.resolution or "720p",
+            motion_preset=request.motion_preset or "medium",
+        )
+
+        return VideoGenerationStartResponse(
+            task_id=task_id,
+            status="pending",
+            message=(
+                f"LinkedIn video generation started. "
+                f"Poll /api/linkedin/video-generation/{task_id}/status for updates."
+            ),
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to start LinkedIn video generation: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to start video generation: {e}",
+        )
+
+
+@router.get("/video-generation/{task_id}/status")
+async def get_video_generation_status(
+    task_id: str,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """Poll LinkedIn video generation task status."""
+    try:
+        user_id = current_user.get("id")
+        if not user_id:
+            raise HTTPException(status_code=401, detail="Authentication required")
+
+        status = task_manager.get_task_status(task_id, requester_user_id=user_id)
+        if not status:
+            raise HTTPException(status_code=404, detail="Task not found or expired")
+
+        return status
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error checking video generation status: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to get task status: {e}")
+
+
+@router.get("/videos/{video_id}")
+async def get_generated_video(
+    video_id: str,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """Retrieve a generated LinkedIn video by ID."""
+    try:
+        user_id = current_user.get("id")
+        video_result = await video_storage.retrieve_video(video_id, user_id)
+
+        if video_result.get("success") and video_result.get("video_path"):
+            return FileResponse(
+                path=video_result["video_path"],
+                media_type="video/mp4",
+                filename=f"{video_id}.mp4",
+            )
+        raise HTTPException(status_code=404, detail="Video not found")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error retrieving LinkedIn video: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to retrieve video: {e}")
+
+
+@router.get("/video-generation-health")
+async def video_generation_health_check():
+    """Lightweight health check for LinkedIn video generation services."""
+    try:
+        services: Dict[str, Any] = {}
+        all_healthy = True
+
+        video_api_key = (
+            api_key_manager.get_api_key("video_generation")
+            or os.getenv("WAVESPEED_API_KEY")
+            or os.getenv("HF_TOKEN")
+        )
+        services["video_api_key_configured"] = bool(video_api_key)
+
+        stats = await video_storage.get_storage_stats()
+        storage_ok = stats.get("success", False)
+        services["video_storage"] = "operational" if storage_ok else "unavailable"
+        if storage_ok:
+            services["storage_stats"] = {
+                "total_videos": stats.get("total_files", 0),
+                "total_size_gb": stats.get("total_size_gb", 0),
+            }
+
+        gen_ok = video_generator is not None and hasattr(video_generator, "generate_video")
+        services["video_generator"] = "operational" if gen_ok else "unavailable"
+
+        if not all(v == "operational" or v is True for v in services.values()):
+            all_healthy = False
+
+        return {"status": "healthy" if all_healthy else "degraded", "services": services}
+    except Exception as e:
+        logger.error(f"Video health check failed: {e}")
+        return {"status": "unhealthy", "error": str(e)}

--- a/backend/routers/linkedin.py
+++ b/backend/routers/linkedin.py
@@ -64,6 +64,31 @@ ERROR_CODES = {
 def error_response(code: str, message: str) -> dict:
     return {"code": code, "message": message}
 
+
+def _extract_clerk_user_id(
+    current_user: Optional[Dict[str, Any]], http_request: Request
+) -> Optional[str]:
+    if current_user:
+        return str(
+            current_user.get('clerk_user_id')
+            or current_user.get('id')
+            or current_user.get('sub')
+            or ''
+        ) or None
+    return http_request.headers.get("X-User-ID") or None
+
+
+def _require_clerk_user_id(
+    current_user: Optional[Dict[str, Any]], http_request: Request
+) -> str:
+    user_id = _extract_clerk_user_id(current_user, http_request)
+    if not user_id:
+        raise HTTPException(
+            status_code=401,
+            detail=error_response('VALIDATION', "Authentication required. Please provide Clerk user ID."),
+        )
+    return user_id
+
 # Initialize router
 router = APIRouter(
     prefix="/api/linkedin",
@@ -153,11 +178,7 @@ async def generate_post(
             raise HTTPException(status_code=422, detail=error_response(ERROR_CODES['VALIDATION'], "Industry cannot be empty"))
         
         # Extract user_id
-        user_id = None
-        if current_user:
-            user_id = str(current_user.get('id', '') or current_user.get('sub', ''))
-        if not user_id:
-            user_id = http_request.headers.get("X-User-ID") or http_request.headers.get("Authorization")
+        user_id = _require_clerk_user_id(current_user, http_request)
         
         # Rate limit check
         retry_after = check_rate_limit(user_id or 'anonymous')
@@ -169,7 +190,7 @@ async def generate_post(
             )
         
         # Generate post content
-        response = await linkedin_service.generate_linkedin_post(request)
+        response = await linkedin_service.generate_linkedin_post(request, user_id=user_id)
         
         if not response.success:
             raise HTTPException(status_code=500, detail=error_response(ERROR_CODES['GENERATION_FAILED'], response.error or "Post generation failed"))
@@ -270,11 +291,7 @@ async def generate_article(
             raise HTTPException(status_code=422, detail=error_response(ERROR_CODES['VALIDATION'], "Industry cannot be empty"))
         
         # Extract user_id
-        user_id = None
-        if current_user:
-            user_id = str(current_user.get('id', '') or current_user.get('sub', ''))
-        if not user_id:
-            user_id = http_request.headers.get("X-User-ID") or http_request.headers.get("Authorization")
+        user_id = _require_clerk_user_id(current_user, http_request)
         
         # Rate limit check
         retry_after = check_rate_limit(user_id or 'anonymous')
@@ -282,7 +299,7 @@ async def generate_article(
             raise HTTPException(status_code=429, detail=error_response(ERROR_CODES['RATE_LIMITED'], f"Rate limit exceeded. Retry after {retry_after} seconds."), headers={"Retry-After": str(retry_after)})
         
         # Generate article content
-        response = await linkedin_service.generate_linkedin_article(request)
+        response = await linkedin_service.generate_linkedin_article(request, user_id=user_id)
         
         if not response.success:
             raise HTTPException(status_code=500, detail=error_response(ERROR_CODES['GENERATION_FAILED'], response.error or "Article generation failed"))
@@ -387,11 +404,7 @@ async def generate_carousel(
             raise HTTPException(status_code=422, detail=error_response(ERROR_CODES['VALIDATION'], "Number of slides must be between 3 and 15"))
         
         # Extract user_id
-        user_id = None
-        if current_user:
-            user_id = str(current_user.get('id', '') or current_user.get('sub', ''))
-        if not user_id:
-            user_id = http_request.headers.get("X-User-ID") or http_request.headers.get("Authorization")
+        user_id = _require_clerk_user_id(current_user, http_request)
         
         # Rate limit check
         retry_after = check_rate_limit(user_id or 'anonymous')
@@ -399,7 +412,7 @@ async def generate_carousel(
             raise HTTPException(status_code=429, detail=error_response(ERROR_CODES['RATE_LIMITED'], f"Rate limit exceeded. Retry after {retry_after} seconds."), headers={"Retry-After": str(retry_after)})
         
         # Generate carousel content
-        response = await linkedin_service.generate_linkedin_carousel(request)
+        response = await linkedin_service.generate_linkedin_carousel(request, user_id=user_id)
         
         if not response.success:
             raise HTTPException(status_code=500, detail=error_response(ERROR_CODES['GENERATION_FAILED'], response.error or "Carousel generation failed"))
@@ -482,14 +495,10 @@ async def generate_carousel_pdf(
     start_time = time.time()
 
     try:
-        user_id = None
-        if current_user:
-            user_id = str(current_user.get('id', '') or current_user.get('sub', ''))
-        if not user_id:
-            user_id = http_request.headers.get("X-User-ID") or http_request.headers.get("Authorization")
+        user_id = _require_clerk_user_id(current_user, http_request)
 
         # First generate carousel content
-        content_result = await linkedin_service.generate_linkedin_carousel(request)
+        content_result = await linkedin_service.generate_linkedin_carousel(request, user_id=user_id)
 
         if not content_result.success or not content_result.data:
             raise HTTPException(status_code=500, detail=content_result.error or "Carousel generation failed")
@@ -575,11 +584,7 @@ async def generate_video_script(
             raise HTTPException(status_code=422, detail=error_response(ERROR_CODES['VALIDATION'], "Video length must be between 15 and 300 seconds"))
         
         # Extract user_id
-        user_id = None
-        if current_user:
-            user_id = str(current_user.get('id', '') or current_user.get('sub', ''))
-        if not user_id:
-            user_id = http_request.headers.get("X-User-ID") or http_request.headers.get("Authorization")
+        user_id = _require_clerk_user_id(current_user, http_request)
         
         # Rate limit check
         retry_after = check_rate_limit(user_id or 'anonymous')
@@ -587,7 +592,7 @@ async def generate_video_script(
             raise HTTPException(status_code=429, detail=error_response(ERROR_CODES['RATE_LIMITED'], f"Rate limit exceeded. Retry after {retry_after} seconds."), headers={"Retry-After": str(retry_after)})
         
         # Generate video script content
-        response = await linkedin_service.generate_linkedin_video_script(request)
+        response = await linkedin_service.generate_linkedin_video_script(request, user_id=user_id)
         
         if not response.success:
             raise HTTPException(status_code=500, detail=error_response(ERROR_CODES['GENERATION_FAILED'], response.error or "Video script generation failed"))
@@ -701,11 +706,7 @@ async def generate_comment_response(
             raise HTTPException(status_code=422, detail=error_response(ERROR_CODES['VALIDATION'], "Post context cannot be empty"))
         
         # Extract user_id
-        user_id = None
-        if current_user:
-            user_id = str(current_user.get('id', '') or current_user.get('sub', ''))
-        if not user_id:
-            user_id = http_request.headers.get("X-User-ID") or http_request.headers.get("Authorization")
+        user_id = _require_clerk_user_id(current_user, http_request)
         
         # Rate limit check
         retry_after = check_rate_limit(user_id or 'anonymous')
@@ -713,7 +714,7 @@ async def generate_comment_response(
             raise HTTPException(status_code=429, detail=error_response(ERROR_CODES['RATE_LIMITED'], f"Rate limit exceeded. Retry after {retry_after} seconds."), headers={"Retry-After": str(retry_after)})
         
         # Generate comment response
-        response = await linkedin_service.generate_linkedin_comment_response(request)
+        response = await linkedin_service.generate_linkedin_comment_response(request, user_id=user_id)
         
         if not response.success:
             raise HTTPException(status_code=500, detail=error_response(ERROR_CODES['GENERATION_FAILED'], response.error or "Comment response generation failed"))
@@ -843,9 +844,11 @@ async def edit_linkedin_content(
     """Edit LinkedIn content using AI-powered text generation."""
     try:
         # Extract user_id for subscription checking
-        user_id = None
-        if current_user:
-            user_id = str(current_user.get('id', '') or current_user.get('sub', ''))
+        user_id = _extract_clerk_user_id(current_user, http_request)
+        if not user_id:
+            return LinkedInEditContentResponse(
+                success=False, error="Authentication required", edit_type=request.edit_type
+            )
         
         if not request.content.strip():
             return LinkedInEditContentResponse(

--- a/backend/services/integrations/wix/ricos_converter.py
+++ b/backend/services/integrations/wix/ricos_converter.py
@@ -57,7 +57,8 @@ def markdown_to_html(markdown_content: str) -> str:
                     continue
                 else:
                     in_code_block = False
-                    result.append(f'<pre><code>{"\n".join(code_block_content)}</code></pre>')
+                    code_joined = "\n".join(code_block_content)
+                    result.append(f'<pre><code>{code_joined}</code></pre>')
                     code_block_content = []
                     i += 1
                     continue

--- a/backend/services/linkedin/content_generator.py
+++ b/backend/services/linkedin/content_generator.py
@@ -23,6 +23,7 @@ from services.linkedin.content_generator_prompts import (
     VideoScriptGenerator
 )
 from services.llm_providers.main_text_generation import llm_text_gen
+from services.linkedin.content_parser import parse_video_script_text
 from services.persona_analysis_service import PersonaAnalysisService
 import time
 
@@ -560,8 +561,10 @@ class ContentGenerator:
             )
             
             content_text = raw_response if isinstance(raw_response, str) else str(raw_response or "")
-            
+            parsed = parse_video_script_text(content_text)
+
             return {
+                **parsed,
                 'content': content_text,
                 'sources': [],
                 'citations': [],

--- a/backend/services/linkedin/content_generator_prompts/video_script_generator.py
+++ b/backend/services/linkedin/content_generator_prompts/video_script_generator.py
@@ -27,6 +27,10 @@ class VideoScriptGenerator:
     ):
         """Generate LinkedIn video script with all processing steps."""
         try:
+            if 'hook' not in content_result and 'content' in content_result:
+                from services.linkedin.content_parser import parse_video_script_text
+                content_result = {**content_result, **parse_video_script_text(content_result['content'])}
+
             start_time = datetime.now()
             
             # Step 3: Add citations if requested

--- a/backend/services/linkedin/content_parser.py
+++ b/backend/services/linkedin/content_parser.py
@@ -1,0 +1,246 @@
+"""
+Parse raw LLM text into structured LinkedIn content shapes.
+"""
+
+import re
+from typing import Any, Dict, List, Optional
+
+
+_SECTION_ALIASES = {
+    "hook": ("hook", "opening", "intro", "introduction", "attention grabber"),
+    "main_content": (
+        "main content",
+        "main",
+        "body",
+        "scenes",
+        "script",
+        "key insights",
+        "content",
+    ),
+    "conclusion": ("conclusion", "closing", "cta", "call to action", "outro", "wrap up"),
+    "captions": ("captions", "caption", "subtitles"),
+    "thumbnail_suggestions": (
+        "thumbnail",
+        "thumbnails",
+        "thumbnail suggestions",
+        "thumbnail design",
+    ),
+    "video_description": ("video description", "description", "summary"),
+}
+
+
+def _normalize_heading(line: str) -> str:
+    text = line.strip()
+    text = re.sub(r"^#+\s*", "", text)
+    text = re.sub(r"^\*+\s*", "", text)
+    text = re.sub(r"^[-–—]+\s*", "", text)
+    text = re.sub(r":\s*$", "", text)
+    return text.strip().lower()
+
+
+def _match_section(heading: str) -> Optional[str]:
+    normalized = _normalize_heading(heading)
+    for section_key, aliases in _SECTION_ALIASES.items():
+        if normalized in aliases or any(normalized.startswith(alias) for alias in aliases):
+            return section_key
+    return None
+
+
+def _split_into_sections(content: str) -> Dict[str, str]:
+    sections: Dict[str, str] = {}
+    current_key: Optional[str] = None
+    current_lines: List[str] = []
+
+    for line in content.splitlines():
+        stripped = line.strip()
+        is_heading = stripped.startswith("#") or (
+            stripped.endswith(":") and len(stripped) < 80 and _match_section(stripped)
+        )
+
+        if is_heading:
+            if current_key and current_lines:
+                sections[current_key] = "\n".join(current_lines).strip()
+            current_key = _match_section(stripped)
+            current_lines = []
+            continue
+
+        if current_key:
+            current_lines.append(line)
+
+    if current_key and current_lines:
+        sections[current_key] = "\n".join(current_lines).strip()
+
+    return sections
+
+
+def normalize_scene(scene: Dict[str, Any]) -> Dict[str, str]:
+    """Ensure scene fields match VideoScript.main_content Dict[str, str] contract."""
+    duration = scene.get("duration", 30)
+    duration_str = str(duration)
+    if duration_str.isdigit():
+        duration_str = f"{duration_str}s"
+    return {
+        "scene_number": str(scene.get("scene_number", "")),
+        "content": str(scene.get("content", "")),
+        "duration": duration_str,
+        "visual_notes": str(scene.get("visual_notes", "")),
+    }
+
+
+def normalize_main_content(scenes: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    return [normalize_scene(scene) for scene in scenes]
+
+
+def _split_main_content(text: str) -> List[Dict[str, str]]:
+    if not text.strip():
+        return []
+
+    scene_pattern = re.compile(
+        r"^(?:###?\s*)?(?:scene|segment|part)\s*(\d+)[:\s-]*(.*)$",
+        re.IGNORECASE,
+    )
+    scenes: List[Dict[str, Any]] = []
+    current_scene: Optional[Dict[str, Any]] = None
+    current_lines: List[str] = []
+
+    for line in text.splitlines():
+        match = scene_pattern.match(line.strip())
+        if match:
+            if current_scene is not None:
+                current_scene["content"] = "\n".join(current_lines).strip()
+                scenes.append(current_scene)
+            scene_num = int(match.group(1))
+            title = match.group(2).strip()
+            current_scene = {
+                "scene_number": scene_num,
+                "content": title,
+                "duration": 30,
+                "visual_notes": "",
+            }
+            current_lines = [] if title else []
+            continue
+
+        if current_scene is not None:
+            current_lines.append(line)
+
+    if current_scene is not None:
+        current_scene["content"] = "\n".join(current_lines).strip()
+        scenes.append(current_scene)
+
+    if scenes:
+        return normalize_main_content(scenes)
+
+    paragraphs = [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()]
+    if not paragraphs:
+        paragraphs = [text.strip()] if text.strip() else []
+
+    return normalize_main_content([
+        {
+            "scene_number": i + 1,
+            "content": paragraph,
+            "duration": 30,
+            "visual_notes": "Professional presentation style",
+        }
+        for i, paragraph in enumerate(paragraphs)
+    ])
+
+
+def _extract_hook_fallback(lines: List[str]) -> str:
+    hook_lines: List[str] = []
+    for line in lines[:5]:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            hook_lines.append(stripped)
+            if len(" ".join(hook_lines)) > 100:
+                break
+    return " ".join(hook_lines)
+
+
+def _extract_conclusion_fallback(lines: List[str]) -> str:
+    conclusion_lines: List[str] = []
+    for line in lines[-5:]:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            conclusion_lines.insert(0, stripped)
+            if len(" ".join(conclusion_lines)) > 100:
+                break
+    return " ".join(conclusion_lines)
+
+
+def _parse_list_items(text: str) -> List[str]:
+    items: List[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        stripped = re.sub(r"^[-*•]\s+", "", stripped)
+        stripped = re.sub(r"^\d+\.\s+", "", stripped)
+        if stripped:
+            items.append(stripped)
+    return items
+
+
+def parse_video_script_text(content: str) -> Dict[str, Any]:
+    """
+    Parse raw LLM video script text into structured fields for VideoScriptGenerator.
+    """
+    content = (content or "").strip()
+    if not content:
+        return {
+            "hook": "",
+            "main_content": [],
+            "conclusion": "",
+            "captions": None,
+            "thumbnail_suggestions": [],
+            "video_description": "",
+        }
+
+    sections = _split_into_sections(content)
+    lines = content.splitlines()
+
+    hook = sections.get("hook", "")
+    conclusion = sections.get("conclusion", "")
+    main_text = sections.get("main_content", "")
+
+    if not hook:
+        hook = _extract_hook_fallback(lines)
+    if not conclusion:
+        conclusion = _extract_conclusion_fallback(lines)
+    if not main_text:
+        start = len(hook)
+        end = len(content) - len(conclusion) if conclusion else len(content)
+        main_text = content[start:end].strip()
+
+    main_content = _split_main_content(main_text)
+    if not main_content and main_text:
+        main_content = normalize_main_content([
+            {
+                "scene_number": 1,
+                "content": main_text,
+                "duration": 60,
+                "visual_notes": "Professional presentation style",
+            }
+        ])
+
+    captions_text = sections.get("captions", "")
+    captions = _parse_list_items(captions_text) if captions_text else None
+
+    thumbnail_text = sections.get("thumbnail_suggestions", "")
+    thumbnail_suggestions = _parse_list_items(thumbnail_text) if thumbnail_text else [
+        "Professional thumbnail",
+        "Industry-focused image",
+    ]
+
+    video_description = sections.get("video_description", "")
+    if not video_description:
+        preview = hook or (main_content[0]["content"] if main_content else content[:100])
+        video_description = f"Professional insights on {preview[:100]}..."
+
+    return {
+        "hook": hook,
+        "main_content": main_content,
+        "conclusion": conclusion,
+        "captions": captions,
+        "thumbnail_suggestions": thumbnail_suggestions,
+        "video_description": video_description,
+    }

--- a/backend/services/linkedin/video_generation/__init__.py
+++ b/backend/services/linkedin/video_generation/__init__.py
@@ -1,0 +1,10 @@
+"""
+LinkedIn Video Generation Package
+"""
+
+from .linkedin_video_generator import LinkedInVideoGenerator
+from .linkedin_video_storage import LinkedInVideoStorage
+
+__all__ = ["LinkedInVideoGenerator", "LinkedInVideoStorage"]
+
+__version__ = "1.0.0"

--- a/backend/services/linkedin/video_generation/linkedin_video_generator.py
+++ b/backend/services/linkedin/video_generation/linkedin_video_generator.py
@@ -1,0 +1,121 @@
+"""
+LinkedIn Video Generator Service
+
+Generates LinkedIn-optimized videos using the unified video generation infrastructure.
+"""
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from ...onboarding.api_key_manager import APIKeyManager
+from ...llm_providers.main_video_generation import ai_video_generate
+
+logger = logging.getLogger(__name__)
+
+VALID_ASPECT_RATIOS = {"16:9", "1:1", "9:16"}
+DEFAULT_MODEL = "hunyuan-video-1.5"
+DEFAULT_PROVIDER = "wavespeed"
+
+
+class LinkedInVideoGenerator:
+    """Handles LinkedIn-optimized text-to-video generation."""
+
+    def __init__(self, api_key_manager: Optional[APIKeyManager] = None):
+        self.api_key_manager = api_key_manager or APIKeyManager()
+
+    def _enhance_prompt_for_linkedin(
+        self,
+        prompt: str,
+        content_context: Dict[str, Any],
+        aspect_ratio: str,
+        motion_preset: str,
+    ) -> str:
+        topic = content_context.get("topic", "business")
+        industry = content_context.get("industry", "business")
+        content_type = content_context.get("content_type", "post")
+        content_snippet = (content_context.get("content") or "")[:300]
+
+        parts = [
+            f"Create a professional LinkedIn {content_type} video for {topic}.",
+            f"Industry: {industry}.",
+            prompt.strip(),
+        ]
+        if content_snippet:
+            parts.append(f"Context from post: {content_snippet}")
+        parts.extend([
+            f"Aspect ratio: {aspect_ratio}.",
+            f"Motion style: {motion_preset}.",
+            "Professional business aesthetic, cinematic quality, mobile-optimized.",
+            "No text overlays, watermarks, or logos.",
+        ])
+        return " ".join(parts)
+
+    def _validate_aspect_ratio(self, aspect_ratio: str) -> str:
+        if aspect_ratio not in VALID_ASPECT_RATIOS:
+            logger.warning(f"Invalid aspect ratio {aspect_ratio}, defaulting to 16:9")
+            return "16:9"
+        return aspect_ratio
+
+    async def generate_video(
+        self,
+        prompt: str,
+        content_context: Dict[str, Any],
+        aspect_ratio: str = "16:9",
+        duration: int = 5,
+        resolution: str = "720p",
+        motion_preset: str = "medium",
+        user_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        try:
+            start_time = datetime.now()
+            aspect_ratio = self._validate_aspect_ratio(aspect_ratio)
+            enhanced_prompt = self._enhance_prompt_for_linkedin(
+                prompt, content_context, aspect_ratio, motion_preset
+            )
+
+            result = await ai_video_generate(
+                prompt=enhanced_prompt,
+                operation_type="text-to-video",
+                provider=DEFAULT_PROVIDER,
+                user_id=user_id,
+                model=DEFAULT_MODEL,
+                duration=duration,
+                resolution=resolution,
+                aspect_ratio=aspect_ratio,
+                motion_preset=motion_preset,
+                enable_prompt_expansion=True,
+                negative_prompt=(
+                    "blurry, low quality, distorted, deformed, ugly, bad anatomy, "
+                    "watermark, text overlay, logo, signature"
+                ),
+            )
+
+            video_bytes = result.get("video_bytes")
+            if not video_bytes:
+                return {
+                    "success": False,
+                    "error": "Video generation returned no video bytes",
+                }
+
+            generation_time = (datetime.now() - start_time).total_seconds()
+            return {
+                "success": True,
+                "video_bytes": video_bytes,
+                "metadata": {
+                    "prompt_used": enhanced_prompt,
+                    "original_prompt": prompt,
+                    "aspect_ratio": aspect_ratio,
+                    "duration": duration,
+                    "resolution": resolution,
+                    "motion_preset": motion_preset,
+                    "content_context": content_context,
+                    "generation_time": generation_time,
+                    "model_used": result.get("model_name", DEFAULT_MODEL),
+                    "provider": result.get("provider", DEFAULT_PROVIDER),
+                    "cost": result.get("cost", 0.0),
+                },
+            }
+        except Exception as e:
+            logger.error(f"LinkedIn video generation failed: {e}", exc_info=True)
+            return {"success": False, "error": f"Video generation failed: {e}"}

--- a/backend/services/linkedin/video_generation/linkedin_video_storage.py
+++ b/backend/services/linkedin/video_generation/linkedin_video_storage.py
@@ -1,0 +1,154 @@
+"""
+LinkedIn Video Storage Service
+
+Handles storage, retrieval, and management for LinkedIn generated videos.
+"""
+
+import hashlib
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from loguru import logger
+
+from ...onboarding.api_key_manager import APIKeyManager
+
+
+class LinkedInVideoStorage:
+    """Filesystem storage for LinkedIn generated videos."""
+
+    def __init__(
+        self,
+        storage_path: Optional[str] = None,
+        api_key_manager: Optional[APIKeyManager] = None,
+    ):
+        self.api_key_manager = api_key_manager or APIKeyManager()
+
+        if storage_path:
+            self.base_storage_path = Path(storage_path)
+        else:
+            root_dir = Path(__file__).parent.parent.parent.parent.parent
+            self.base_storage_path = root_dir / "data" / "media" / "linkedin_videos"
+
+        self.videos_path = self.base_storage_path / "videos"
+        self.metadata_path = self.base_storage_path / "metadata"
+        self._uuid_pattern = re.compile(r"^[a-f0-9]{16}$")
+        self.max_video_size_mb = 500
+
+        self.videos_path.mkdir(parents=True, exist_ok=True)
+        self.metadata_path.mkdir(parents=True, exist_ok=True)
+        logger.info(f"LinkedIn Video Storage initialized at {self.base_storage_path}")
+
+    def _generate_video_id(self, video_data: bytes, metadata: Dict[str, Any]) -> str:
+        hash_input = (
+            f"{video_data[:1000]}"
+            f"{metadata.get('topic', '')}"
+            f"{metadata.get('industry', '')}"
+            f"{datetime.now().isoformat()}"
+        )
+        return hashlib.sha256(hash_input.encode()).hexdigest()[:16]
+
+    def _validate_video_id(self, video_id: str) -> bool:
+        return bool(self._uuid_pattern.match(video_id))
+
+    def _get_video_path(self, video_id: str, user_id: Optional[str] = None) -> Path:
+        if user_id:
+            return self.videos_path / user_id / f"{video_id}.mp4"
+        return self.videos_path / f"{video_id}.mp4"
+
+    def _get_metadata_path(self, video_id: str, user_id: Optional[str] = None) -> Path:
+        if user_id:
+            return self.metadata_path / user_id / f"{video_id}.json"
+        return self.metadata_path / f"{video_id}.json"
+
+    async def store_video(
+        self,
+        video_data: bytes,
+        metadata: Dict[str, Any],
+        content_type: str = "post",
+        user_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        try:
+            if len(video_data) > self.max_video_size_mb * 1024 * 1024:
+                return {
+                    "success": False,
+                    "error": f"Video exceeds maximum size of {self.max_video_size_mb}MB",
+                }
+
+            video_id = self._generate_video_id(video_data, metadata)
+            video_path = self._get_video_path(video_id, user_id)
+            video_path.parent.mkdir(parents=True, exist_ok=True)
+
+            with open(video_path, "wb") as f:
+                f.write(video_data)
+
+            meta = {
+                **metadata,
+                "video_id": video_id,
+                "content_type": content_type,
+                "stored_at": datetime.now().isoformat(),
+                "file_size": len(video_data),
+                "user_id": user_id,
+            }
+            metadata_path = self._get_metadata_path(video_id, user_id)
+            metadata_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(metadata_path, "w", encoding="utf-8") as f:
+                json.dump(meta, f, indent=2)
+
+            return {
+                "success": True,
+                "video_id": video_id,
+                "storage_path": str(video_path),
+                "file_url": f"/api/linkedin/videos/{video_id}",
+            }
+        except Exception as e:
+            logger.error(f"Error storing LinkedIn video: {e}")
+            return {"success": False, "error": f"Video storage failed: {e}"}
+
+    async def retrieve_video(
+        self, video_id: str, user_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        try:
+            if not self._validate_video_id(video_id):
+                return {"success": False, "error": f"Invalid video ID: {video_id}"}
+
+            video_path = self._get_video_path(video_id, user_id)
+            if not video_path.exists() and user_id:
+                video_path = self._get_video_path(video_id, None)
+            if not video_path.exists():
+                for candidate in self.videos_path.rglob(f"{video_id}.mp4"):
+                    video_path = candidate
+                    break
+
+            if not video_path.exists():
+                return {"success": False, "error": f"Video not found: {video_id}"}
+
+            metadata_path = self._get_metadata_path(video_id, user_id)
+            metadata: Dict[str, Any] = {}
+            if metadata_path.exists():
+                with open(metadata_path, "r", encoding="utf-8") as f:
+                    metadata = json.load(f)
+
+            return {
+                "success": True,
+                "video_path": str(video_path),
+                "metadata": metadata,
+            }
+        except Exception as e:
+            logger.error(f"Error retrieving LinkedIn video {video_id}: {e}")
+            return {"success": False, "error": f"Video retrieval failed: {e}"}
+
+    async def get_storage_stats(self) -> Dict[str, Any]:
+        try:
+            video_files = list(self.videos_path.rglob("*.mp4"))
+            total_size = sum(f.stat().st_size for f in video_files)
+            return {
+                "success": True,
+                "total_files": len(video_files),
+                "total_size_gb": round(total_size / (1024 ** 3), 4),
+                "storage_limit_gb": 10,
+            }
+        except Exception as e:
+            return {"success": False, "error": str(e)}

--- a/backend/services/linkedin/video_generation/tasks.py
+++ b/backend/services/linkedin/video_generation/tasks.py
@@ -1,0 +1,167 @@
+"""
+Background task for LinkedIn async video generation.
+"""
+
+import asyncio
+from typing import Any, Dict, Optional
+
+from api.story_writer.task_manager import task_manager
+from utils.asset_tracker import save_asset_to_library
+from loguru import logger
+
+from .linkedin_video_generator import LinkedInVideoGenerator
+from .linkedin_video_storage import LinkedInVideoStorage
+
+
+def execute_linkedin_video_generation_task(
+    task_id: str,
+    user_id: str,
+    prompt: str,
+    content_context: Dict[str, Any],
+    aspect_ratio: str = "16:9",
+    duration: int = 5,
+    resolution: str = "720p",
+    motion_preset: str = "medium",
+):
+    """Background task: generate, store, save to asset library, update task status."""
+    video_generator = LinkedInVideoGenerator()
+    video_storage = LinkedInVideoStorage()
+
+    try:
+        task_manager.update_task_status(
+            task_id,
+            "processing",
+            progress=5.0,
+            message="Initializing LinkedIn video generation...",
+        )
+
+        async def _run():
+            return await video_generator.generate_video(
+                prompt=prompt,
+                content_context=content_context,
+                aspect_ratio=aspect_ratio,
+                duration=duration,
+                resolution=resolution,
+                motion_preset=motion_preset,
+                user_id=user_id,
+            )
+
+        task_manager.update_task_status(
+            task_id,
+            "processing",
+            progress=15.0,
+            message="Generating video with AI provider...",
+        )
+
+        gen_result = asyncio.run(_run())
+        if not gen_result.get("success"):
+            raise RuntimeError(gen_result.get("error", "Video generation failed"))
+
+        task_manager.update_task_status(
+            task_id,
+            "processing",
+            progress=75.0,
+            message="Saving generated video...",
+        )
+
+        metadata = gen_result.get("metadata", {})
+        store_result = await_store_video(
+            video_storage,
+            gen_result["video_bytes"],
+            {
+                **metadata,
+                "topic": content_context.get("topic"),
+                "industry": content_context.get("industry"),
+                "content_type": content_context.get("content_type", "post"),
+            },
+            content_context.get("content_type", "post"),
+            user_id,
+        )
+
+        if not store_result.get("success"):
+            raise RuntimeError(store_result.get("error", "Failed to store video"))
+
+        video_id = store_result["video_id"]
+        video_url = store_result["file_url"]
+        asset_id: Optional[int] = None
+
+        try:
+            from services.database import get_db
+
+            db = next(get_db())
+            try:
+                asset_id = save_asset_to_library(
+                    db=db,
+                    user_id=user_id,
+                    asset_type="video",
+                    source_module="linkedin_writer",
+                    filename=f"linkedin_video_{video_id}.mp4",
+                    file_url=video_url,
+                    file_path=store_result.get("storage_path"),
+                    file_size=len(gen_result["video_bytes"]),
+                    mime_type="video/mp4",
+                    title="LinkedIn Selection Video",
+                    description=f"Generated from selection: {(prompt or '')[:100]}",
+                    prompt=metadata.get("prompt_used", prompt),
+                    tags=["linkedin", "text-to-video", "selection-generated"],
+                    provider=metadata.get("provider"),
+                    model=metadata.get("model_used"),
+                    cost=metadata.get("cost", 0.0),
+                    generation_time=metadata.get("generation_time"),
+                    asset_metadata={
+                        "video_id": video_id,
+                        "aspect_ratio": aspect_ratio,
+                        "duration": duration,
+                        "resolution": resolution,
+                        "motion_preset": motion_preset,
+                        "selected_text_snippet": (content_context.get("content") or "")[:200],
+                    },
+                )
+                logger.info(
+                    f"[LinkedInVideo] Saved to asset library: asset_id={asset_id}, "
+                    f"storage_path={store_result.get('storage_path')}, "
+                    f"asset_library_path=/asset-library?source_module=linkedin_writer&asset_type=video"
+                )
+            finally:
+                db.close()
+        except Exception as e:
+            logger.warning(f"[LinkedInVideo] Failed to save to asset library: {e}")
+
+        task_manager.update_task_status(
+            task_id,
+            "completed",
+            progress=100.0,
+            message="LinkedIn video generation complete!",
+            result={
+                "video_id": video_id,
+                "video_url": video_url,
+                "asset_id": asset_id,
+                "storage_path": store_result.get("storage_path"),
+                "asset_library_path": "/asset-library?source_module=linkedin_writer&asset_type=video",
+                "cost": metadata.get("cost", 0.0),
+                "duration": duration,
+                "model": metadata.get("model_used"),
+                "provider": metadata.get("provider"),
+                "resolution": resolution,
+            },
+        )
+    except Exception as exc:
+        logger.exception(f"[LinkedInVideo] Generation failed: {exc}")
+        task_manager.update_task_status(
+            task_id,
+            "failed",
+            error=str(exc),
+            message=f"Video generation failed: {exc}",
+        )
+
+
+def await_store_video(storage, video_data, metadata, content_type, user_id):
+    """Run async store_video from sync background task."""
+    return asyncio.run(
+        storage.store_video(
+            video_data=video_data,
+            metadata=metadata,
+            content_type=content_type,
+            user_id=user_id,
+        )
+    )

--- a/backend/services/linkedin_service.py
+++ b/backend/services/linkedin_service.py
@@ -26,6 +26,13 @@ from services.citation import CitationManager
 from services.quality import ContentQualityAnalyzer
 
 
+def _effective_user_id(user_id: Optional[str], request) -> str:
+    if user_id:
+        return user_id
+    raw = getattr(request, 'user_id', '') or ''
+    return str(raw) if raw else ''
+
+
 class LinkedInService:
     """
     LinkedIn content generation service with provider-agnostic LLM access.
@@ -61,7 +68,9 @@ class LinkedInService:
                 self._quality_analyzer = None
         return self._quality_analyzer
     
-    async def generate_linkedin_post(self, request: LinkedInPostRequest) -> LinkedInPostResponse:
+    async def generate_linkedin_post(
+        self, request: LinkedInPostRequest, user_id: Optional[str] = None
+    ) -> LinkedInPostResponse:
         """
         Generate a LinkedIn post with enhanced grounding capabilities.
         
@@ -82,9 +91,9 @@ class LinkedInService:
             # Step 1: Conduct research if enabled
             from services.linkedin.research_handler import ResearchHandler
             research_handler = ResearchHandler(self)
-            user_id = str(getattr(request, 'user_id', '') or '')
+            effective_user_id = _effective_user_id(user_id, request)
             research_sources, research_time = await research_handler.conduct_research(
-                request, request.research_enabled, request.search_engine, 10, user_id=user_id
+                request, request.research_enabled, request.search_engine, 10, user_id=effective_user_id
             )
             
             # Step 2: Generate content based on grounding level
@@ -101,7 +110,7 @@ class LinkedInService:
                 content_result = await content_generator.generate_grounded_post_content(
                     request=request,
                     research_sources=research_sources,
-                    user_id=str(getattr(request, 'user_id', ''))
+                    user_id=effective_user_id
                 )
             else:
                 logger.error("Grounding not enabled, Error generating LinkedIn post")
@@ -123,7 +132,9 @@ class LinkedInService:
                 error=f"Failed to generate LinkedIn post: {str(e)}"
             )
     
-    async def generate_linkedin_article(self, request: LinkedInArticleRequest) -> LinkedInArticleResponse:
+    async def generate_linkedin_article(
+        self, request: LinkedInArticleRequest, user_id: Optional[str] = None
+    ) -> LinkedInArticleResponse:
         """
         Generate a LinkedIn article with enhanced grounding capabilities.
         
@@ -140,9 +151,9 @@ class LinkedInService:
             # Step 1: Conduct research if enabled
             from services.linkedin.research_handler import ResearchHandler
             research_handler = ResearchHandler(self)
-            user_id = str(getattr(request, 'user_id', '') or '')
+            effective_user_id = _effective_user_id(user_id, request)
             research_sources, research_time = await research_handler.conduct_research(
-                request, request.research_enabled, request.search_engine, 15, user_id=user_id
+                request, request.research_enabled, request.search_engine, 15, user_id=effective_user_id
             )
             
             # Step 2: Generate content based on grounding level
@@ -159,7 +170,7 @@ class LinkedInService:
                 content_result = await content_generator.generate_grounded_article_content(
                     request=request,
                     research_sources=research_sources,
-                    user_id=str(getattr(request, 'user_id', ''))
+                    user_id=effective_user_id
                 )
             else:
                 logger.error("Grounding not enabled - cannot generate LinkedIn article without AI provider")
@@ -181,7 +192,9 @@ class LinkedInService:
                 error=f"Failed to generate LinkedIn article: {str(e)}"
             )
     
-    async def generate_linkedin_carousel(self, request: LinkedInCarouselRequest) -> LinkedInCarouselResponse:
+    async def generate_linkedin_carousel(
+        self, request: LinkedInCarouselRequest, user_id: Optional[str] = None
+    ) -> LinkedInCarouselResponse:
         """
         Generate a LinkedIn carousel with enhanced grounding capabilities.
         
@@ -198,9 +211,9 @@ class LinkedInService:
             # Step 1: Conduct research if enabled
             from services.linkedin.research_handler import ResearchHandler
             research_handler = ResearchHandler(self)
-            user_id = str(getattr(request, 'user_id', '') or '')
+            effective_user_id = _effective_user_id(user_id, request)
             research_sources, research_time = await research_handler.conduct_research(
-                request, request.research_enabled, request.search_engine, 12, user_id=user_id
+                request, request.research_enabled, request.search_engine, 12, user_id=effective_user_id
             )
             
             # Step 2: Generate content based on grounding level
@@ -217,7 +230,7 @@ class LinkedInService:
                 content_result = await content_generator.generate_grounded_carousel_content(
                     request=request,
                     research_sources=research_sources,
-                    user_id=str(getattr(request, 'user_id', ''))
+                    user_id=effective_user_id
                 )
             else:
                 logger.error("Grounding not enabled - cannot generate LinkedIn carousel without AI provider")
@@ -274,7 +287,9 @@ class LinkedInService:
                 error=f"Failed to generate LinkedIn carousel: {str(e)}"
             )
     
-    async def generate_linkedin_video_script(self, request: LinkedInVideoScriptRequest) -> LinkedInVideoScriptResponse:
+    async def generate_linkedin_video_script(
+        self, request: LinkedInVideoScriptRequest, user_id: Optional[str] = None
+    ) -> LinkedInVideoScriptResponse:
         """
         Generate a LinkedIn video script with enhanced grounding capabilities.
         
@@ -291,9 +306,9 @@ class LinkedInService:
             # Step 1: Conduct research if enabled
             from services.linkedin.research_handler import ResearchHandler
             research_handler = ResearchHandler(self)
-            user_id = str(getattr(request, 'user_id', '') or '')
+            effective_user_id = _effective_user_id(user_id, request)
             research_sources, research_time = await research_handler.conduct_research(
-                request, request.research_enabled, request.search_engine, 8, user_id=user_id
+                request, request.research_enabled, request.search_engine, 8, user_id=effective_user_id
             )
             
             # Step 2: Generate content based on grounding level
@@ -310,7 +325,7 @@ class LinkedInService:
                 content_result = await content_generator.generate_grounded_video_script_content(
                     request=request,
                     research_sources=research_sources,
-                    user_id=str(getattr(request, 'user_id', ''))
+                    user_id=effective_user_id
                 )
             else:
                 logger.error("Grounding not enabled - cannot generate LinkedIn video script without AI provider")
@@ -329,9 +344,10 @@ class LinkedInService:
             if result['success']:
                 # Convert to LinkedInVideoScriptResponse
                 from models.linkedin_models import VideoScript
+                from services.linkedin.content_parser import normalize_main_content
                 video_script = VideoScript(
                     hook=result['data']['hook'],
-                    main_content=result['data']['main_content'],
+                    main_content=normalize_main_content(result['data']['main_content']),
                     conclusion=result['data']['conclusion'],
                     captions=result['data'].get('captions'),
                     thumbnail_suggestions=result['data'].get('thumbnail_suggestions', []),
@@ -358,7 +374,9 @@ class LinkedInService:
                 error=f"Failed to generate LinkedIn video script: {str(e)}"
             )
     
-    async def generate_linkedin_comment_response(self, request: LinkedInCommentResponseRequest) -> LinkedInCommentResponseResult:
+    async def generate_linkedin_comment_response(
+        self, request: LinkedInCommentResponseRequest, user_id: Optional[str] = None
+    ) -> LinkedInCommentResponseResult:
         """
         Generate a LinkedIn comment response with optional grounding capabilities.
         
@@ -375,9 +393,9 @@ class LinkedInService:
             # Step 1: Conduct research if enabled
             from services.linkedin.research_handler import ResearchHandler
             research_handler = ResearchHandler(self)
-            user_id = str(getattr(request, 'user_id', '') or '')
+            effective_user_id = _effective_user_id(user_id, request)
             research_sources, research_time = await research_handler.conduct_research(
-                request, request.research_enabled, request.search_engine, 5, user_id=user_id
+                request, request.research_enabled, request.search_engine, 5, user_id=effective_user_id
             )
             
             # Step 2: Generate response based on grounding level
@@ -394,7 +412,7 @@ class LinkedInService:
                 response_result = await content_generator.generate_grounded_comment_response(
                     request=request,
                     research_sources=research_sources,
-                    user_id=str(getattr(request, 'user_id', ''))
+                    user_id=effective_user_id
                 )
             else:
                 logger.error("Grounding not enabled - cannot generate LinkedIn comment response without AI provider")

--- a/frontend/src/components/LinkedInWriter/__tests__/linkedInVideoService.test.ts
+++ b/frontend/src/components/LinkedInWriter/__tests__/linkedInVideoService.test.ts
@@ -1,0 +1,128 @@
+import {
+  buildVideoPromptFromSelection,
+  resolveLinkedInVideoUrl,
+  generateLinkedInVideo,
+  pollLinkedInVideoTask,
+  mapMotionToApi,
+} from '../../../services/linkedInVideoService';
+import { aiApiClient } from '../../../api/client';
+import { checkPreflight } from '../../../services/billingService';
+
+jest.mock('../../../api/client', () => ({
+  aiApiClient: {
+    post: jest.fn(),
+    get: jest.fn(),
+  },
+}));
+
+jest.mock('../../../services/billingService', () => ({
+  checkPreflight: jest.fn(),
+}));
+
+jest.mock('../../../utils/apiUrl', () => ({
+  getApiBaseUrl: () => 'http://localhost:8000',
+}));
+
+describe('linkedInVideoService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(checkPreflight).mockResolvedValue({ can_proceed: true, operations: [] });
+  });
+
+  describe('buildVideoPromptFromSelection', () => {
+    it('includes selected text and LinkedIn context', () => {
+      const prompt = buildVideoPromptFromSelection(
+        'AI is transforming how teams collaborate.',
+        'Future of Work',
+        'Technology'
+      );
+
+      expect(prompt).toContain('AI is transforming how teams collaborate.');
+      expect(prompt).toContain('Topic: Future of Work.');
+      expect(prompt).toContain('Industry: Technology.');
+      expect(prompt).toContain('LinkedIn');
+    });
+  });
+
+  describe('resolveLinkedInVideoUrl', () => {
+    it('builds correct path for video id', () => {
+      expect(resolveLinkedInVideoUrl('abc123')).toBe(
+        'http://localhost:8000/api/linkedin/videos/abc123'
+      );
+    });
+  });
+
+  describe('mapMotionToApi', () => {
+    it('maps motion preset to lowercase API value', () => {
+      expect(mapMotionToApi('Medium')).toBe('medium');
+      expect(mapMotionToApi('Subtle')).toBe('subtle');
+    });
+  });
+
+  describe('generateLinkedInVideo', () => {
+    it('returns task_id on success', async () => {
+      jest.mocked(aiApiClient.post).mockResolvedValue({
+        data: {
+          task_id: 'task-123',
+          status: 'pending',
+          message: 'Started',
+        },
+      });
+
+      const result = await generateLinkedInVideo({
+        prompt: 'Professional business video',
+        selectedText: 'Leadership insights',
+        topic: 'Leadership',
+        industry: 'Business',
+        aspectRatio: '16:9',
+        duration: 5,
+        resolution: '720p',
+        motion: 'Medium',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.taskId).toBe('task-123');
+      expect(aiApiClient.post).toHaveBeenCalledWith('/api/linkedin/generate-video', expect.objectContaining({
+        aspect_ratio: '16:9',
+        duration: 5,
+        motion_preset: 'medium',
+      }));
+    });
+  });
+
+  describe('pollLinkedInVideoTask', () => {
+    it('maps completed status and video_url', async () => {
+      jest.mocked(aiApiClient.get).mockResolvedValue({
+        data: {
+          task_id: 'task-123',
+          status: 'completed',
+          result: {
+            video_id: 'vid-456',
+            video_url: 'http://localhost:8000/api/linkedin/videos/vid-456',
+            asset_id: 99,
+          },
+        },
+      });
+
+      const result = await pollLinkedInVideoTask('task-123');
+
+      expect(result.status).toBe('completed');
+      expect(result.result?.video_url).toContain('vid-456');
+      expect(result.result?.asset_id).toBe(99);
+    });
+
+    it('maps processing status to running', async () => {
+      jest.mocked(aiApiClient.get).mockResolvedValue({
+        data: {
+          task_id: 'task-123',
+          status: 'processing',
+          message: 'Generating video...',
+        },
+      });
+
+      const result = await pollLinkedInVideoTask('task-123');
+
+      expect(result.status).toBe('running');
+    });
+  });
+});

--- a/frontend/src/components/LinkedInWriter/components/ContentEditor.tsx
+++ b/frontend/src/components/LinkedInWriter/components/ContentEditor.tsx
@@ -9,7 +9,9 @@ import {
 } from '../../TextEditor';
 import { readPrefs } from '../utils/linkedInWriterUtils';
 import { useLinkedInSelectionImage } from '../hooks/useLinkedInSelectionImage';
+import { useLinkedInSelectionVideo } from '../hooks/useLinkedInSelectionVideo';
 import { LinkedInSelectionImageModal } from './LinkedInSelectionImageModal';
+import { LinkedInSelectionVideoModal } from './LinkedInSelectionVideoModal';
 
 interface ContentEditorProps {
   isPreviewing: boolean;
@@ -75,10 +77,17 @@ const ContentEditor: React.FC<ContentEditorProps> = ({
     industry: prefs.industry,
   });
 
+  const selectionVideo = useLinkedInSelectionVideo({
+    topic,
+    industry: prefs.industry,
+  });
+
   // Initialize text selection handler
   const textSelectionHandler = useTextSelectionHandler(contentRef, {
     onGenerateImage: selectionImage.openForSelection,
     isGeneratingImage: selectionImage.isGenerating,
+    onGenerateVideo: selectionVideo.openForSelection,
+    isGeneratingVideo: selectionVideo.isGenerating,
   });
 
   // Handle selected text replacement for quick edits
@@ -437,6 +446,16 @@ const ContentEditor: React.FC<ContentEditorProps> = ({
         isGenerating={selectionImage.isGenerating}
         generatedPreview={selectionImage.generatedPreview}
         onClosePreview={selectionImage.closePreview}
+      />
+
+      <LinkedInSelectionVideoModal
+        open={selectionVideo.modalOpen}
+        onClose={selectionVideo.closeModal}
+        onGenerate={selectionVideo.handleGenerate}
+        initialPrompt={selectionVideo.initialPrompt}
+        isGenerating={selectionVideo.isGenerating}
+        generatedPreview={selectionVideo.generatedPreview}
+        onClosePreview={selectionVideo.closePreview}
       />
     </div>
   );

--- a/frontend/src/components/LinkedInWriter/components/LinkedInSelectionVideoModal.tsx
+++ b/frontend/src/components/LinkedInWriter/components/LinkedInSelectionVideoModal.tsx
@@ -1,0 +1,218 @@
+/**
+ * LinkedIn Selection Video Modal
+ *
+ * Wrapper around the shared VideoGenerationModal with LinkedIn presets,
+ * generation loader, and result preview dialog after successful generation.
+ */
+
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Typography,
+  Link,
+  Chip,
+} from '@mui/material';
+import {
+  VideoGenerationModal,
+  VideoGenerationSettings as SharedVideoGenerationSettings,
+} from '../../shared/VideoGenerationModal';
+import {
+  LINKEDIN_VIDEO_PRESETS,
+  LINKEDIN_VIDEO_THEME,
+  LINKEDIN_VIDEO_RECOMMENDATIONS,
+} from '../../shared/VideoGenerationPresets';
+import { VideoGenerationLoader } from '../../shared/VideoGenerationLoader';
+import { downloadLinkedInVideoBlob } from '../../../services/linkedInVideoService';
+import type {
+  VideoAspectRatio,
+  VideoResolution,
+  VideoDuration,
+  VideoMotionPreset,
+} from '../../shared/VideoGenerationModal.types';
+
+export interface LinkedInVideoGenerationSettings {
+  prompt: string;
+  aspectRatio: VideoAspectRatio;
+  duration: VideoDuration;
+  resolution: VideoResolution;
+  motion: VideoMotionPreset;
+}
+
+export interface GeneratedLinkedInVideoPreview {
+  blobUrl: string;
+  videoUrl: string;
+  videoId?: string;
+  assetId?: number;
+  storagePath?: string;
+  assetLibraryPath?: string;
+}
+
+interface LinkedInSelectionVideoModalProps {
+  open: boolean;
+  onClose: () => void;
+  onGenerate: (settings: LinkedInVideoGenerationSettings) => void;
+  initialPrompt: string;
+  isGenerating?: boolean;
+  generatedPreview?: GeneratedLinkedInVideoPreview | null;
+  onClosePreview?: () => void;
+}
+
+export const LinkedInSelectionVideoModal: React.FC<LinkedInSelectionVideoModalProps> = ({
+  open,
+  onClose,
+  onGenerate,
+  initialPrompt,
+  isGenerating = false,
+  generatedPreview,
+  onClosePreview,
+}) => {
+  const navigate = useNavigate();
+
+  const handleDownload = () => {
+    if (!generatedPreview?.blobUrl) return;
+    const filename = `linkedin_video_${generatedPreview.videoId || 'generated'}.mp4`;
+    downloadLinkedInVideoBlob(generatedPreview.blobUrl, filename);
+  };
+
+  const handleGenerate = (settings: SharedVideoGenerationSettings) => {
+    onGenerate({
+      prompt: settings.prompt,
+      aspectRatio: settings.aspectRatio,
+      duration: settings.duration,
+      resolution: settings.resolution,
+      motion: settings.motion,
+    });
+  };
+
+  if (generatedPreview) {
+    return (
+      <Dialog open={open} onClose={onClosePreview || onClose} maxWidth="sm" fullWidth>
+        <DialogTitle sx={{ color: '#0A66C2', fontWeight: 600 }}>
+          Video Generated Successfully
+        </DialogTitle>
+        <DialogContent>
+          <Box sx={{ textAlign: 'center', py: 1 }}>
+            <Box
+              component="video"
+              src={generatedPreview.blobUrl}
+              controls
+              sx={{
+                maxWidth: '100%',
+                maxHeight: 360,
+                borderRadius: 2,
+                border: '1px solid #e0e0e0',
+                mb: 2,
+                backgroundColor: '#000',
+              }}
+            />
+            <Chip
+              label="Saved to asset library"
+              color="success"
+              size="small"
+              sx={{ mb: 2 }}
+            />
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              Your LinkedIn-optimized video is ready.
+            </Typography>
+            <Button
+              variant="outlined"
+              color="primary"
+              onClick={handleDownload}
+              sx={{ mb: 2 }}
+            >
+              Download video
+            </Button>
+            <Box
+              sx={{
+                textAlign: 'left',
+                mt: 1,
+                p: 1.5,
+                borderRadius: 1,
+                backgroundColor: 'action.hover',
+              }}
+            >
+              {generatedPreview.assetId != null && (
+                <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+                  <strong>Asset library ID:</strong> {generatedPreview.assetId}
+                </Typography>
+              )}
+              {generatedPreview.assetLibraryPath && (
+                <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+                  <strong>Asset library:</strong>{' '}
+                  <Link
+                    component="button"
+                    type="button"
+                    onClick={() => navigate(generatedPreview.assetLibraryPath!)}
+                    sx={{ fontSize: 'inherit', verticalAlign: 'baseline' }}
+                  >
+                    {generatedPreview.assetLibraryPath}
+                  </Link>
+                </Typography>
+              )}
+              {generatedPreview.storagePath && (
+                <Typography variant="caption" color="text.secondary" display="block" sx={{ wordBreak: 'break-all', mb: 0.5 }}>
+                  <strong>Storage path:</strong> {generatedPreview.storagePath}
+                </Typography>
+              )}
+              <Typography variant="caption" color="text.secondary" display="block" sx={{ wordBreak: 'break-all' }}>
+                <strong>API URL:</strong> {generatedPreview.videoUrl}
+              </Typography>
+            </Box>
+          </Box>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={onClosePreview || onClose} variant="contained" color="primary">
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+
+  if (isGenerating) {
+    return (
+      <Dialog open={open} maxWidth="sm" fullWidth>
+        <DialogTitle sx={{ color: '#0A66C2', fontWeight: 600 }}>
+          Generating LinkedIn Video
+        </DialogTitle>
+        <DialogContent>
+          <Box sx={{ py: 2 }}>
+            <VideoGenerationLoader />
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 2, textAlign: 'center' }}>
+              Video generation may take 1–3 minutes. Please keep this window open.
+            </Typography>
+          </Box>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <VideoGenerationModal
+      open={open}
+      onClose={onClose}
+      onGenerate={handleGenerate}
+      initialPrompt={initialPrompt}
+      isGenerating={isGenerating}
+      title="Generate LinkedIn Video"
+      promptLabel="Video Prompt"
+      promptHelp="Describe the video you want for your LinkedIn post. The selected text is used as context — refine the prompt for best results."
+      generateButtonLabel="Generate Video"
+      presets={LINKEDIN_VIDEO_PRESETS}
+      presetsLabel="LinkedIn-ready presets"
+      presetsHelp="Quickly apply a LinkedIn-friendly video look. Each preset adjusts format, duration, and motion."
+      defaultAspectRatio="16:9"
+      defaultDuration={5}
+      defaultResolution="720p"
+      defaultMotion="Medium"
+      theme={LINKEDIN_VIDEO_THEME}
+      recommendations={LINKEDIN_VIDEO_RECOMMENDATIONS}
+    />
+  );
+};

--- a/frontend/src/components/LinkedInWriter/components/index.ts
+++ b/frontend/src/components/LinkedInWriter/components/index.ts
@@ -17,6 +17,7 @@ export { default as ImageGenerationSuggestions } from './ImageGenerationSuggesti
 export { default as ImageGenerationDemo } from './ImageGenerationDemo';
 export { default as ImageGenerationTest } from './ImageGenerationTest';
 export { LinkedInSelectionImageModal } from './LinkedInSelectionImageModal';
+export { LinkedInSelectionVideoModal } from './LinkedInSelectionVideoModal';
 
 // Persona Integration Components - Now integrated into main LinkedInWriter
 

--- a/frontend/src/components/LinkedInWriter/hooks/useLinkedInSelectionVideo.ts
+++ b/frontend/src/components/LinkedInWriter/hooks/useLinkedInSelectionVideo.ts
@@ -1,0 +1,194 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { usePolling } from '../../../hooks/usePolling';
+import { showToastNotification } from '../../../utils/toastNotifications';
+import {
+  buildVideoPromptFromSelection,
+  generateLinkedInVideo,
+  pollLinkedInVideoTask,
+  fetchLinkedInVideoBlobUrl,
+  resolveLinkedInVideoUrl,
+  buildLinkedInAssetLibraryUrl,
+  type LinkedInVideoTaskResult,
+} from '../../../services/linkedInVideoService';
+import type {
+  LinkedInVideoGenerationSettings,
+  GeneratedLinkedInVideoPreview,
+} from '../components/LinkedInSelectionVideoModal';
+
+interface UseLinkedInSelectionVideoOptions {
+  topic?: string;
+  industry?: string;
+}
+
+export function useLinkedInSelectionVideo({
+  topic,
+  industry,
+}: UseLinkedInSelectionVideoOptions) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [selectedText, setSelectedText] = useState('');
+  const [initialPrompt, setInitialPrompt] = useState('');
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [generatedPreview, setGeneratedPreview] =
+    useState<GeneratedLinkedInVideoPreview | null>(null);
+  const blobUrlRef = useRef<string | null>(null);
+  const pendingSettingsRef = useRef<LinkedInVideoGenerationSettings | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current);
+      }
+    };
+  }, []);
+
+  const handlePollComplete = useCallback(
+    async (result: LinkedInVideoTaskResult) => {
+      try {
+        const videoId = result.video_id;
+        const videoUrl =
+          result.video_url || (videoId ? resolveLinkedInVideoUrl(videoId) : undefined);
+
+        if (!videoUrl) {
+          showToastNotification('Video generated but URL was not returned', 'error');
+          setIsGenerating(false);
+          return;
+        }
+
+        const assetLibraryPath =
+          result.asset_library_path || buildLinkedInAssetLibraryUrl();
+
+        console.log('[LinkedInSelectionVideo] Generated video:', {
+          videoId,
+          videoUrl,
+          assetId: result.asset_id,
+          storagePath: result.storage_path,
+          assetLibraryPath,
+        });
+
+        let blobUrl = videoUrl;
+        if (videoId) {
+          blobUrl = await fetchLinkedInVideoBlobUrl(videoId);
+        }
+
+        if (blobUrlRef.current) {
+          URL.revokeObjectURL(blobUrlRef.current);
+        }
+        blobUrlRef.current = blobUrl;
+
+        setGeneratedPreview({
+          blobUrl,
+          videoUrl,
+          videoId,
+          assetId: result.asset_id,
+          storagePath: result.storage_path,
+          assetLibraryPath,
+        });
+
+        const assetMsg = result.asset_id
+          ? ` Saved to asset library (ID: ${result.asset_id}).`
+          : '';
+        showToastNotification(`Video generated successfully.${assetMsg}`, 'success');
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Failed to load generated video';
+        showToastNotification(message, 'error');
+      } finally {
+        setIsGenerating(false);
+        pendingSettingsRef.current = null;
+      }
+    },
+    []
+  );
+
+  const handlePollError = useCallback((error: string) => {
+    showToastNotification(error || 'Video generation failed', 'error');
+    setIsGenerating(false);
+    pendingSettingsRef.current = null;
+  }, []);
+
+  const { startPolling, stopPolling } = usePolling(pollLinkedInVideoTask, {
+    onComplete: handlePollComplete,
+    onError: handlePollError,
+  });
+
+  useEffect(() => {
+    return () => {
+      stopPolling();
+    };
+  }, [stopPolling]);
+
+  const openForSelection = useCallback(
+    (text: string) => {
+      const trimmed = text.trim();
+      setSelectedText(trimmed);
+      setInitialPrompt(buildVideoPromptFromSelection(trimmed, topic, industry));
+      setGeneratedPreview(null);
+      setModalOpen(true);
+    },
+    [topic, industry]
+  );
+
+  const closeModal = useCallback(() => {
+    if (isGenerating) return;
+    stopPolling();
+    setModalOpen(false);
+    setSelectedText('');
+    setInitialPrompt('');
+  }, [isGenerating, stopPolling]);
+
+  const closePreview = useCallback(() => {
+    if (blobUrlRef.current) {
+      URL.revokeObjectURL(blobUrlRef.current);
+      blobUrlRef.current = null;
+    }
+    setGeneratedPreview(null);
+    setModalOpen(false);
+    setSelectedText('');
+    setInitialPrompt('');
+  }, []);
+
+  const handleGenerate = useCallback(
+    async (settings: LinkedInVideoGenerationSettings) => {
+      setIsGenerating(true);
+      pendingSettingsRef.current = settings;
+
+      try {
+        const result = await generateLinkedInVideo({
+          prompt: settings.prompt,
+          selectedText,
+          topic,
+          industry,
+          aspectRatio: settings.aspectRatio,
+          duration: settings.duration,
+          resolution: settings.resolution,
+          motion: settings.motion,
+        });
+
+        if (!result.success || !result.taskId) {
+          showToastNotification(result.error || 'Video generation failed to start', 'error');
+          setIsGenerating(false);
+          return;
+        }
+
+        startPolling(result.taskId);
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Video generation failed';
+        showToastNotification(message, 'error');
+        setIsGenerating(false);
+      }
+    },
+    [selectedText, topic, industry, startPolling]
+  );
+
+  return {
+    modalOpen,
+    initialPrompt,
+    isGenerating,
+    generatedPreview,
+    openForSelection,
+    closeModal,
+    closePreview,
+    handleGenerate,
+  };
+}

--- a/frontend/src/components/TextEditor/TextSelectionHandler.tsx
+++ b/frontend/src/components/TextEditor/TextSelectionHandler.tsx
@@ -5,13 +5,20 @@ import FactCheckResults from '../LinkedInWriter/components/FactCheckResults';
 interface TextSelectionHandlerOptions {
   onGenerateImage?: (text: string) => void;
   isGeneratingImage?: boolean;
+  onGenerateVideo?: (text: string) => void;
+  isGeneratingVideo?: boolean;
 }
 
 const useTextSelectionHandler = (
   contentRef: React.RefObject<HTMLDivElement>,
   options?: TextSelectionHandlerOptions
 ) => {
-  const { onGenerateImage, isGeneratingImage = false } = options || {};
+  const {
+    onGenerateImage,
+    isGeneratingImage = false,
+    onGenerateVideo,
+    isGeneratingVideo = false,
+  } = options || {};
   const [selectionMenu, setSelectionMenu] = useState<{ x: number; y: number; text: string } | null>(null);
   const [factCheckResults, setFactCheckResults] = useState<HallucinationDetectionResponse | null>(null);
   const [isFactChecking, setIsFactChecking] = useState(false);
@@ -324,7 +331,7 @@ const useTextSelectionHandler = (
                   setSelectionMenu(null);
                   onGenerateImage(text);
                 }}
-                disabled={isGeneratingImage}
+                disabled={isGeneratingImage || isGeneratingVideo}
                 style={{
                   background: isGeneratingImage ? 'rgba(255, 255, 255, 0.1)' : 'rgba(255, 255, 255, 0.2)',
                   border: '1px solid rgba(255, 255, 255, 0.3)',
@@ -367,6 +374,63 @@ const useTextSelectionHandler = (
                   </>
                 ) : (
                   <>🖼️ Generate Image</>
+                )}
+              </button>
+            )}
+
+            {/* Generate Video Button */}
+            {onGenerateVideo && (
+              <button
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  const text = selectionMenu.text;
+                  setSelectionMenu(null);
+                  onGenerateVideo(text);
+                }}
+                disabled={isGeneratingVideo || isGeneratingImage}
+                style={{
+                  background: isGeneratingVideo ? 'rgba(255, 255, 255, 0.1)' : 'rgba(255, 255, 255, 0.2)',
+                  border: '1px solid rgba(255, 255, 255, 0.3)',
+                  borderRadius: '6px',
+                  padding: '6px 12px',
+                  color: 'white',
+                  fontSize: '12px',
+                  fontWeight: '600',
+                  cursor: isGeneratingVideo ? 'not-allowed' : 'pointer',
+                  opacity: isGeneratingVideo ? 0.6 : 1,
+                  transition: 'all 0.2s ease',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '4px',
+                  width: '100%',
+                  justifyContent: 'center'
+                }}
+                onMouseEnter={(e) => {
+                  if (!isGeneratingVideo) {
+                    e.currentTarget.style.background = 'rgba(255, 255, 255, 0.3)';
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (!isGeneratingVideo) {
+                    e.currentTarget.style.background = 'rgba(255, 255, 255, 0.2)';
+                  }
+                }}
+              >
+                {isGeneratingVideo ? (
+                  <>
+                    <div style={{
+                      width: '12px',
+                      height: '12px',
+                      border: '2px solid rgba(255, 255, 255, 0.3)',
+                      borderTop: '2px solid white',
+                      borderRadius: '50%',
+                      animation: 'spin 1s linear infinite'
+                    }} />
+                    Generating...
+                  </>
+                ) : (
+                  <>🎬 Generate Video</>
                 )}
               </button>
             )}

--- a/frontend/src/components/shared/VideoGenerationModal.tsx
+++ b/frontend/src/components/shared/VideoGenerationModal.tsx
@@ -1,0 +1,441 @@
+/**
+ * Shared Video Generation Modal
+ *
+ * Reusable settings modal for text-to-video generation across modules.
+ */
+
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Stack,
+  Box,
+  Typography,
+  TextField,
+  Select,
+  MenuItem,
+  FormControl,
+  Divider,
+  alpha,
+  Tooltip,
+  IconButton,
+  Paper,
+  Button,
+  Slider,
+} from '@mui/material';
+import {
+  Info as InfoIcon,
+  HelpOutline as HelpOutlineIcon,
+  Close as CloseIcon,
+  Videocam as VideocamIcon,
+} from '@mui/icons-material';
+
+import {
+  VideoGenerationModalProps,
+  VideoGenerationSettings,
+  VideoAspectRatio,
+  VideoResolution,
+  VideoDuration,
+  VideoMotionPreset,
+  VideoPreset,
+  DEFAULT_VIDEO_THEME,
+} from './VideoGenerationModal.types';
+
+export const VideoGenerationModal: React.FC<VideoGenerationModalProps> = ({
+  open,
+  onClose,
+  onGenerate,
+  initialPrompt,
+  isGenerating = false,
+  title = 'Generate Video',
+  contextTitle,
+  promptLabel = 'Video Prompt',
+  promptHelp = 'Describe the video you want to generate. Include scene context, visual elements, mood, and motion preferences.',
+  generateButtonLabel = 'Generate Video',
+  presets = [],
+  presetsLabel = 'Quick Presets',
+  presetsHelp = 'Quickly apply a preset look. Each preset adjusts format, duration, and motion.',
+  defaultAspectRatio = '16:9',
+  defaultDuration = 5,
+  defaultResolution = '720p',
+  defaultMotion = 'Medium',
+  theme = DEFAULT_VIDEO_THEME,
+  recommendations,
+}) => {
+  const [prompt, setPrompt] = useState(initialPrompt);
+  const [aspectRatio, setAspectRatio] = useState<VideoAspectRatio>(defaultAspectRatio);
+  const [duration, setDuration] = useState<VideoDuration>(defaultDuration);
+  const [resolution, setResolution] = useState<VideoResolution>(defaultResolution);
+  const [motion, setMotion] = useState<VideoMotionPreset>(defaultMotion);
+
+  useEffect(() => {
+    setPrompt(initialPrompt);
+    setAspectRatio(defaultAspectRatio);
+    setDuration(defaultDuration);
+    setResolution(defaultResolution);
+    setMotion(defaultMotion);
+  }, [initialPrompt, defaultAspectRatio, defaultDuration, defaultResolution, defaultMotion]);
+
+  const handleGenerate = () => {
+    onGenerate({
+      prompt,
+      aspectRatio,
+      duration,
+      resolution,
+      motion,
+    });
+  };
+
+  const applyPreset = (preset: VideoPreset) => {
+    setPrompt((current) => {
+      if (!current || current.trim() === '' || current.trim() === initialPrompt.trim()) {
+        return `${initialPrompt}\n${preset.prompt}`.trim();
+      }
+      return `${current}\n${preset.prompt}`.trim();
+    });
+    setAspectRatio(preset.aspectRatio);
+    setDuration(preset.duration);
+    setResolution(preset.resolution);
+    setMotion(preset.motion);
+  };
+
+  const selectSx = {
+    backgroundColor: alpha('#ffffff', 0.05),
+    color: 'white',
+    '& .MuiOutlinedInput-notchedOutline': {
+      borderColor: 'rgba(255,255,255,0.2)',
+    },
+    '&:hover .MuiOutlinedInput-notchedOutline': {
+      borderColor: 'rgba(255,255,255,0.3)',
+    },
+    '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+      borderColor: theme.primaryAccent,
+    },
+    '& .MuiSvgIcon-root': {
+      color: 'rgba(255,255,255,0.7)',
+    },
+  };
+
+  const renderRecommendation = (
+    content: React.ReactNode | undefined,
+    accentColor: string,
+    label: string
+  ) => {
+    if (!content) return null;
+    return (
+      <Paper
+        sx={{
+          mt: 1.5,
+          p: 1.5,
+          backgroundColor: alpha(accentColor, 0.1),
+          border: `1px solid ${alpha(accentColor, 0.3)}`,
+          borderRadius: 2,
+        }}
+      >
+        <Stack direction="row" spacing={1}>
+          <InfoIcon sx={{ color: accentColor, fontSize: '1.2rem', mt: 0.1 }} />
+          <Box>
+            <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.9)', fontWeight: 500, mb: 0.5 }}>
+              {label}:
+            </Typography>
+            <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.7)', lineHeight: 1.6 }}>
+              {content}
+            </Typography>
+          </Box>
+        </Stack>
+      </Paper>
+    );
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={isGenerating ? undefined : onClose}
+      maxWidth="md"
+      fullWidth
+      PaperProps={{
+        sx: {
+          background: theme.dialogBackground,
+          backdropFilter: 'blur(20px)',
+          border: '1px solid rgba(255,255,255,0.1)',
+          borderRadius: 4,
+        },
+      }}
+    >
+      <DialogTitle>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Box>
+            <Typography variant="h6" sx={{ color: 'white', fontWeight: 600 }}>
+              {title}
+            </Typography>
+            {contextTitle && (
+              <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)', mt: 1 }}>
+                Customize video generation for &quot;{contextTitle}&quot;
+              </Typography>
+            )}
+          </Box>
+          {!isGenerating && (
+            <IconButton onClick={onClose} size="small" sx={{ color: 'rgba(255,255,255,0.7)' }}>
+              <CloseIcon />
+            </IconButton>
+          )}
+        </Stack>
+      </DialogTitle>
+
+      <DialogContent>
+        <Stack spacing={3} sx={{ mt: 1 }}>
+          {presets.length > 0 && (
+            <Box>
+              <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+                <VideocamIcon sx={{ color: 'white', fontSize: '1.2rem' }} />
+                <Typography variant="subtitle1" sx={{ color: 'white', fontWeight: 600 }}>
+                  {presetsLabel}
+                </Typography>
+                <Tooltip title={presetsHelp} arrow>
+                  <IconButton size="small" sx={{ color: 'rgba(255,255,255,0.5)' }}>
+                    <HelpOutlineIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              </Stack>
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} flexWrap="wrap">
+                {presets.map((preset) => (
+                  <Paper
+                    key={preset.key}
+                    onClick={() => !isGenerating && applyPreset(preset)}
+                    sx={{
+                      p: 1.5,
+                      flex: '1 1 45%',
+                      minWidth: 180,
+                      cursor: isGenerating ? 'not-allowed' : 'pointer',
+                      opacity: isGenerating ? 0.6 : 1,
+                      backgroundColor: alpha('#ffffff', 0.04),
+                      border: '1px solid rgba(255,255,255,0.1)',
+                      borderRadius: 2,
+                      transition: 'all 0.2s ease',
+                      '&:hover': isGenerating
+                        ? {}
+                        : {
+                            borderColor: alpha(theme.primaryAccent, 0.7),
+                            boxShadow: '0 8px 24px rgba(0,0,0,0.25)',
+                            backgroundColor: alpha(theme.primaryAccent, 0.08),
+                          },
+                    }}
+                  >
+                    <Typography variant="subtitle2" sx={{ color: 'white', fontWeight: 700 }}>
+                      {preset.title}
+                    </Typography>
+                    <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.7)', lineHeight: 1.5, mb: 0.75 }}>
+                      {preset.subtitle}
+                    </Typography>
+                    <Stack direction="row" spacing={1} sx={{ color: 'rgba(255,255,255,0.6)', fontSize: '0.8rem' }}>
+                      <Typography variant="caption">AR: {preset.aspectRatio}</Typography>
+                      <Typography variant="caption">{preset.duration}s</Typography>
+                      <Typography variant="caption">{preset.motion}</Typography>
+                    </Stack>
+                  </Paper>
+                ))}
+              </Stack>
+            </Box>
+          )}
+
+          <Box>
+            <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+              <Typography variant="subtitle1" sx={{ color: 'white', fontWeight: 600 }}>
+                {promptLabel}
+              </Typography>
+              <Tooltip title={promptHelp} arrow>
+                <IconButton size="small" sx={{ color: 'rgba(255,255,255,0.5)' }}>
+                  <HelpOutlineIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            </Stack>
+            <TextField
+              fullWidth
+              multiline
+              rows={4}
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              disabled={isGenerating}
+              placeholder="Describe the scene, visual elements, mood, and motion..."
+              sx={{
+                '& .MuiOutlinedInput-root': {
+                  backgroundColor: alpha('#ffffff', 0.05),
+                  color: 'white',
+                  '& fieldset': { borderColor: 'rgba(255,255,255,0.2)' },
+                  '&:hover fieldset': { borderColor: 'rgba(255,255,255,0.3)' },
+                  '&.Mui-focused fieldset': { borderColor: theme.primaryAccent },
+                },
+                '& .MuiInputBase-input': { color: 'white' },
+              }}
+            />
+          </Box>
+
+          <Divider sx={{ borderColor: 'rgba(255,255,255,0.1)' }} />
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <Box flex={1}>
+              <Typography variant="subtitle1" sx={{ color: 'white', fontWeight: 600, mb: 1.5 }}>
+                Video Format
+              </Typography>
+              <FormControl fullWidth>
+                <Select
+                  value={aspectRatio}
+                  onChange={(e) => setAspectRatio(e.target.value as VideoAspectRatio)}
+                  disabled={isGenerating}
+                  sx={selectSx}
+                >
+                  <MenuItem value="16:9">
+                    <Stack>
+                      <Typography sx={{ color: 'white' }}>16:9 (Landscape)</Typography>
+                      <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+                        LinkedIn feed, professional content
+                      </Typography>
+                    </Stack>
+                  </MenuItem>
+                  <MenuItem value="1:1">
+                    <Stack>
+                      <Typography sx={{ color: 'white' }}>1:1 (Square)</Typography>
+                      <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+                        Mobile feed, square posts
+                      </Typography>
+                    </Stack>
+                  </MenuItem>
+                  <MenuItem value="9:16">
+                    <Stack>
+                      <Typography sx={{ color: 'white' }}>9:16 (Vertical)</Typography>
+                      <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+                        Mobile-first vertical video
+                      </Typography>
+                    </Stack>
+                  </MenuItem>
+                </Select>
+              </FormControl>
+              {renderRecommendation(recommendations?.aspectRatio, theme.warningAccent, 'Format Recommendation')}
+            </Box>
+
+            <Box flex={1}>
+              <Typography variant="subtitle1" sx={{ color: 'white', fontWeight: 600, mb: 1.5 }}>
+                Video Quality
+              </Typography>
+              <FormControl fullWidth>
+                <Select
+                  value={resolution}
+                  onChange={(e) => setResolution(e.target.value as VideoResolution)}
+                  disabled={isGenerating}
+                  sx={selectSx}
+                >
+                  <MenuItem value="480p">
+                    <Typography sx={{ color: 'white' }}>480p — Fast &amp; Affordable</Typography>
+                  </MenuItem>
+                  <MenuItem value="720p">
+                    <Typography sx={{ color: 'white' }}>720p — Balanced (Recommended)</Typography>
+                  </MenuItem>
+                  <MenuItem value="1080p">
+                    <Typography sx={{ color: 'white' }}>1080p — Premium</Typography>
+                  </MenuItem>
+                </Select>
+              </FormControl>
+              {renderRecommendation(recommendations?.resolution, theme.primaryAccent, 'Quality Recommendation')}
+            </Box>
+          </Stack>
+
+          <Box>
+            <Typography variant="subtitle1" sx={{ color: 'white', fontWeight: 600, mb: 1.5 }}>
+              Movement Style
+            </Typography>
+            <FormControl fullWidth>
+              <Select
+                value={motion}
+                onChange={(e) => setMotion(e.target.value as VideoMotionPreset)}
+                disabled={isGenerating}
+                sx={selectSx}
+              >
+                <MenuItem value="Subtle">
+                  <Stack>
+                    <Typography sx={{ color: 'white' }}>Subtle</Typography>
+                    <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+                      Gentle movement, professional content
+                    </Typography>
+                  </Stack>
+                </MenuItem>
+                <MenuItem value="Medium">
+                  <Stack>
+                    <Typography sx={{ color: 'white' }}>Medium</Typography>
+                    <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+                      Balanced motion for most social media
+                    </Typography>
+                  </Stack>
+                </MenuItem>
+                <MenuItem value="Dynamic">
+                  <Stack>
+                    <Typography sx={{ color: 'white' }}>Dynamic</Typography>
+                    <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+                      Energetic movement, attention-grabbing
+                    </Typography>
+                  </Stack>
+                </MenuItem>
+              </Select>
+            </FormControl>
+            {renderRecommendation(recommendations?.motion, theme.secondaryAccent, 'Motion Recommendation')}
+          </Box>
+
+          <Box>
+            <Typography variant="subtitle1" sx={{ color: 'white', fontWeight: 600, mb: 1 }}>
+              Duration: {duration} seconds
+            </Typography>
+            <Slider
+              value={duration}
+              min={5}
+              max={10}
+              step={3}
+              disabled={isGenerating}
+              marks={[
+                { value: 5, label: '5s' },
+                { value: 8, label: '8s' },
+                { value: 10, label: '10s' },
+              ]}
+              onChange={(_, val) => setDuration(val as VideoDuration)}
+              sx={{
+                color: theme.primaryAccent,
+                '& .MuiSlider-markLabel': { color: 'rgba(255,255,255,0.7)' },
+              }}
+            />
+            {renderRecommendation(recommendations?.duration, theme.warningAccent, 'Duration Recommendation')}
+          </Box>
+        </Stack>
+      </DialogContent>
+
+      <DialogActions sx={{ p: 3, pt: 2 }}>
+        <Button onClick={onClose} disabled={isGenerating} sx={{ color: 'rgba(255,255,255,0.7)' }}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleGenerate}
+          disabled={isGenerating || !prompt.trim()}
+          variant="contained"
+          sx={{
+            backgroundColor: isGenerating ? 'rgba(255,255,255,0.1)' : theme.primaryAccent,
+            color: 'white',
+            '&:hover': {
+              backgroundColor: isGenerating ? 'rgba(255,255,255,0.1)' : alpha(theme.primaryAccent, 0.8),
+            },
+            '&:disabled': {
+              backgroundColor: 'rgba(255,255,255,0.1)',
+              color: 'rgba(255,255,255,0.3)',
+            },
+            px: 3,
+            py: 1,
+            borderRadius: 2,
+          }}
+        >
+          {isGenerating ? 'Generating...' : generateButtonLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export * from './VideoGenerationModal.types';
+export * from './VideoGenerationPresets';

--- a/frontend/src/components/shared/VideoGenerationModal.types.ts
+++ b/frontend/src/components/shared/VideoGenerationModal.types.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared Video Generation Modal Types
+ *
+ * Enables hyper-personalization for different use cases (LinkedIn Writer, Video Studio, etc.)
+ * while maintaining a consistent API.
+ */
+
+export type VideoAspectRatio = '9:16' | '1:1' | '16:9';
+export type VideoResolution = '480p' | '720p' | '1080p';
+export type VideoDuration = 5 | 8 | 10;
+export type VideoMotionPreset = 'Subtle' | 'Medium' | 'Dynamic';
+
+export interface VideoGenerationSettings {
+  prompt: string;
+  aspectRatio: VideoAspectRatio;
+  duration: VideoDuration;
+  resolution: VideoResolution;
+  motion: VideoMotionPreset;
+}
+
+export interface VideoPreset {
+  key: string;
+  title: string;
+  subtitle: string;
+  prompt: string;
+  aspectRatio: VideoAspectRatio;
+  duration: VideoDuration;
+  resolution: VideoResolution;
+  motion: VideoMotionPreset;
+}
+
+export interface VideoModalTheme {
+  dialogBackground: string;
+  primaryAccent: string;
+  secondaryAccent: string;
+  warningAccent: string;
+}
+
+export interface VideoCustomRecommendations {
+  aspectRatio?: React.ReactNode;
+  duration?: React.ReactNode;
+  resolution?: React.ReactNode;
+  motion?: React.ReactNode;
+}
+
+export interface VideoGenerationModalProps {
+  open: boolean;
+  onClose: () => void;
+  onGenerate: (settings: VideoGenerationSettings) => void;
+  initialPrompt: string;
+  isGenerating?: boolean;
+
+  title?: string;
+  contextTitle?: string;
+  promptLabel?: string;
+  promptHelp?: string;
+  generateButtonLabel?: string;
+
+  presets?: VideoPreset[];
+  presetsLabel?: string;
+  presetsHelp?: string;
+
+  defaultAspectRatio?: VideoAspectRatio;
+  defaultDuration?: VideoDuration;
+  defaultResolution?: VideoResolution;
+  defaultMotion?: VideoMotionPreset;
+
+  theme?: VideoModalTheme;
+  recommendations?: VideoCustomRecommendations;
+}
+
+export const DEFAULT_VIDEO_THEME: VideoModalTheme = {
+  dialogBackground: 'rgba(15, 23, 42, 0.95)',
+  primaryAccent: '#667eea',
+  secondaryAccent: '#10b981',
+  warningAccent: '#f59e0b',
+};

--- a/frontend/src/components/shared/VideoGenerationPresets.tsx
+++ b/frontend/src/components/shared/VideoGenerationPresets.tsx
@@ -1,0 +1,97 @@
+/**
+ * Video Generation Presets
+ *
+ * Domain-specific presets and themes for the shared VideoGenerationModal.
+ */
+
+import React from 'react';
+import type {
+  VideoPreset,
+  VideoModalTheme,
+  VideoCustomRecommendations,
+} from './VideoGenerationModal.types';
+
+export const LINKEDIN_VIDEO_PRESETS: VideoPreset[] = [
+  {
+    key: 'professionalLandscape',
+    title: 'Professional Landscape',
+    subtitle: '16:9 format for LinkedIn feed video',
+    prompt:
+      'Professional LinkedIn video, corporate business context, cinematic wide composition, polished corporate look, subtle camera movement, modern workplace aesthetic',
+    aspectRatio: '16:9',
+    duration: 5,
+    resolution: '720p',
+    motion: 'Medium',
+  },
+  {
+    key: 'squareFeed',
+    title: 'Square Feed',
+    subtitle: '1:1 format for LinkedIn mobile feed',
+    prompt:
+      'LinkedIn square feed video, professional business visual, centered composition, clean modern aesthetic, mobile-optimized framing',
+    aspectRatio: '1:1',
+    duration: 5,
+    resolution: '720p',
+    motion: 'Medium',
+  },
+  {
+    key: 'portraitMobile',
+    title: 'Portrait Mobile',
+    subtitle: '9:16 vertical for mobile-first posts',
+    prompt:
+      'LinkedIn portrait mobile video, vertical composition, professional business tone, engaging visual storytelling, mobile-first framing',
+    aspectRatio: '9:16',
+    duration: 5,
+    resolution: '720p',
+    motion: 'Medium',
+  },
+  {
+    key: 'thoughtLeadership',
+    title: 'Thought Leadership',
+    subtitle: 'Executive tone with subtle motion',
+    prompt:
+      'Thought leadership LinkedIn video, executive presence, minimalist design, authoritative professional tone, subtle elegant camera movement, editorial quality',
+    aspectRatio: '16:9',
+    duration: 8,
+    resolution: '1080p',
+    motion: 'Subtle',
+  },
+];
+
+export const LINKEDIN_VIDEO_THEME: VideoModalTheme = {
+  dialogBackground: 'rgba(10, 30, 60, 0.96)',
+  primaryAccent: '#0A66C2',
+  secondaryAccent: '#057642',
+  warningAccent: '#f59e0b',
+};
+
+export const LINKEDIN_VIDEO_RECOMMENDATIONS: VideoCustomRecommendations = {
+  aspectRatio: (
+    <>
+      <strong>16:9 (Landscape):</strong> Standard LinkedIn feed video format<br />
+      <strong>1:1 (Square):</strong> Mobile-friendly square feed posts<br />
+      <strong>9:16 (Portrait):</strong> Vertical video for mobile-first audiences
+    </>
+  ),
+  duration: (
+    <>
+      <strong>5s:</strong> Quick hooks and teaser clips (lowest cost)<br />
+      <strong>8s:</strong> Balanced length for most LinkedIn posts<br />
+      <strong>10s:</strong> Maximum length for richer storytelling
+    </>
+  ),
+  resolution: (
+    <>
+      <strong>720p:</strong> Recommended balance of quality and cost<br />
+      <strong>1080p:</strong> Premium quality for thought leadership content<br />
+      <strong>480p:</strong> Fast previews while refining your prompt
+    </>
+  ),
+  motion: (
+    <>
+      <strong>Subtle:</strong> Professional, minimal movement — best for executive content<br />
+      <strong>Medium:</strong> Balanced motion for most LinkedIn posts<br />
+      <strong>Dynamic:</strong> Energetic movement for attention-grabbing clips
+    </>
+  ),
+};

--- a/frontend/src/services/linkedInVideoService.ts
+++ b/frontend/src/services/linkedInVideoService.ts
@@ -1,0 +1,191 @@
+import { aiApiClient } from '../api/client';
+import { getApiBaseUrl } from '../utils/apiUrl';
+import { checkPreflight, PreflightOperation } from './billingService';
+import type { TaskStatusResponse } from './blogWriterApi';
+import type {
+  VideoAspectRatio,
+  VideoResolution,
+  VideoDuration,
+  VideoMotionPreset,
+} from '../components/shared/VideoGenerationModal.types';
+
+export interface LinkedInVideoGenerationParams {
+  prompt: string;
+  selectedText: string;
+  topic?: string;
+  industry?: string;
+  aspectRatio?: VideoAspectRatio | string;
+  duration?: VideoDuration | number;
+  resolution?: VideoResolution | string;
+  motion?: VideoMotionPreset | string;
+  contentType?: string;
+}
+
+export interface LinkedInVideoGenerationStartResult {
+  success: boolean;
+  taskId?: string;
+  status?: string;
+  message?: string;
+  error?: string;
+}
+
+export interface LinkedInVideoTaskResult {
+  video_id?: string;
+  video_url?: string;
+  asset_id?: number;
+  storage_path?: string;
+  asset_library_path?: string;
+  cost?: number;
+  duration?: number;
+  model?: string;
+  provider?: string;
+  resolution?: string;
+}
+
+/** Build a LinkedIn-optimized video prompt from selected post text. */
+export function buildVideoPromptFromSelection(
+  selectedText: string,
+  topic?: string,
+  industry?: string
+): string {
+  const snippet = selectedText.trim().slice(0, 400);
+  const topicLine = topic ? `Topic: ${topic}.` : '';
+  const industryLine = industry ? `Industry: ${industry}.` : '';
+  return [
+    'Create a professional LinkedIn video that visually supports this content:',
+    snippet,
+    topicLine,
+    industryLine,
+    'Professional business aesthetic, mobile-optimized, cinematic quality, no text overlays or watermarks.',
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+/** Map UI motion preset to API value. */
+export function mapMotionToApi(motion: VideoMotionPreset | string): string {
+  return String(motion).toLowerCase();
+}
+
+/** Build asset library URL for LinkedIn videos. */
+export function buildLinkedInAssetLibraryUrl(): string {
+  const params = new URLSearchParams({
+    source_module: 'linkedin_writer',
+    asset_type: 'video',
+  });
+  return `/asset-library?${params.toString()}`;
+}
+
+/** Trigger a browser download from an authenticated blob URL. */
+export function downloadLinkedInVideoBlob(blobUrl: string, filename: string): void {
+  const link = document.createElement('a');
+  link.href = blobUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+/** Resolve a fetchable URL for a stored LinkedIn video. */
+export function resolveLinkedInVideoUrl(videoId: string, baseUrl?: string): string {
+  const base = (baseUrl || getApiBaseUrl()).replace(/\/$/, '');
+  return `${base}/api/linkedin/videos/${videoId}`;
+}
+
+async function ensureVideoPreflight(): Promise<void> {
+  const operation: PreflightOperation = {
+    provider: 'video',
+    model: 'hunyuan-video-1.5',
+    operation_type: 'video_generation',
+    actual_provider_name: 'wavespeed',
+  };
+  const result = await checkPreflight(operation);
+  if (!result.can_proceed) {
+    const message = result.operations[0]?.message || 'Pre-flight validation failed';
+    throw new Error(message);
+  }
+}
+
+/** Start async LinkedIn video generation. Returns task_id for polling. */
+export async function generateLinkedInVideo(
+  params: LinkedInVideoGenerationParams
+): Promise<LinkedInVideoGenerationStartResult> {
+  await ensureVideoPreflight();
+
+  const response = await aiApiClient.post('/api/linkedin/generate-video', {
+    prompt: params.prompt,
+    content_context: {
+      topic: params.topic || 'LinkedIn post',
+      industry: params.industry || 'Business',
+      content_type: params.contentType || 'post',
+      content: params.selectedText,
+    },
+    aspect_ratio: params.aspectRatio || '16:9',
+    duration: params.duration || 5,
+    resolution: params.resolution || '720p',
+    motion_preset: mapMotionToApi(params.motion || 'Medium'),
+  });
+
+  const data = response.data;
+  if (!data?.task_id) {
+    return {
+      success: false,
+      error: data?.error || data?.detail || 'Video generation failed to start',
+    };
+  }
+
+  return {
+    success: true,
+    taskId: data.task_id,
+    status: data.status,
+    message: data.message,
+  };
+}
+
+/** Poll LinkedIn video generation task status (compatible with usePolling). */
+export async function pollLinkedInVideoTask(
+  taskId: string
+): Promise<TaskStatusResponse<LinkedInVideoTaskResult>> {
+  const response = await aiApiClient.get(`/api/linkedin/video-generation/${taskId}/status`);
+  const data = response.data;
+
+  let status: 'pending' | 'running' | 'completed' | 'failed' = 'pending';
+  const rawStatus = data.status || 'pending';
+  if (rawStatus === 'completed') status = 'completed';
+  else if (rawStatus === 'failed') status = 'failed';
+  else if (rawStatus === 'processing' || rawStatus === 'running') status = 'running';
+  else status = 'pending';
+
+  const progressMessages = Array.isArray(data.progress_messages)
+    ? data.progress_messages.map((msg: string | { message: string; timestamp?: string }) => {
+        if (typeof msg === 'string') {
+          return { timestamp: new Date().toISOString(), message: msg };
+        }
+        return {
+          timestamp: msg.timestamp || new Date().toISOString(),
+          message: msg.message,
+        };
+      })
+    : data.message
+      ? [{ timestamp: new Date().toISOString(), message: data.message }]
+      : [];
+
+  return {
+    task_id: data.task_id || taskId,
+    status,
+    progress_messages: progressMessages,
+    result: data.result,
+    error: data.error,
+    error_status: data.error_status,
+    error_data: data.error_data,
+    created_at: data.created_at || new Date().toISOString(),
+  };
+}
+
+/** Fetch video bytes for authenticated preview (returns blob URL). */
+export async function fetchLinkedInVideoBlobUrl(videoId: string): Promise<string> {
+  const response = await aiApiClient.get(`/api/linkedin/videos/${videoId}`, {
+    responseType: 'blob',
+  });
+  return URL.createObjectURL(response.data);
+}

--- a/frontend/src/services/linkedInWriterApi.ts
+++ b/frontend/src/services/linkedInWriterApi.ts
@@ -8,6 +8,16 @@ import {
   type LinkedInImageGenerationParams,
   type LinkedInImageGenerationResult,
 } from './linkedInImageService';
+import {
+  generateLinkedInVideo as generateLinkedInVideoService,
+  buildVideoPromptFromSelection as buildLinkedInVideoPrompt,
+  resolveLinkedInVideoUrl,
+  fetchLinkedInVideoBlobUrl,
+  pollLinkedInVideoTask,
+  mapMotionToApi,
+  type LinkedInVideoGenerationParams,
+  type LinkedInVideoGenerationStartResult,
+} from './linkedInVideoService';
 
 // LinkedIn-specific enums
 export enum LinkedInPostType {
@@ -307,10 +317,20 @@ export const linkedInWriterApi = {
     return generateLinkedInImageService(params);
   },
 
+  async generateVideo(params: LinkedInVideoGenerationParams): Promise<LinkedInVideoGenerationStartResult> {
+    return generateLinkedInVideoService(params);
+  },
+
   buildImagePromptFromSelection: buildLinkedInImagePrompt,
   resolveImageUrl: resolveLinkedInImageUrl,
   fetchImageBlobUrl: fetchLinkedInImageBlobUrl,
   mapImageAspectRatio: mapAspectRatioToLinkedIn,
+
+  buildVideoPromptFromSelection: buildLinkedInVideoPrompt,
+  resolveVideoUrl: resolveLinkedInVideoUrl,
+  fetchVideoBlobUrl: fetchLinkedInVideoBlobUrl,
+  pollVideoTask: pollLinkedInVideoTask,
+  mapVideoMotion: mapMotionToApi,
 };
 
 // ── Asset Library Save ────────────────────────────────────────────────


### PR DESCRIPTION
## 1. LinkedIn text-selection Video Generation

Adds **LinkedIn text-selection video generation**, mirroring the existing image flow. Users can select text in the Content Preview, configure video settings, generate asynchronously, preview the result, download it, and have it saved to the asset library.

---

## Important changes

### Architecture & reusability
- Introduced a **shared video generation UI layer** (`VideoGenerationModal`, types, presets) parallel to the existing image modal pattern, so LinkedIn (and future modules) can reuse the same settings UI without duplicating logic.
- LinkedIn-specific behavior is isolated in thin wrappers: `LinkedInSelectionVideoModal`, `useLinkedInSelectionVideo`, and `linkedInVideoService`.

### Async generation flow
- Video generation is **async end-to-end**:
  - `POST /api/linkedin/generate-video` → returns `task_id`
  - Frontend polls `GET /api/linkedin/video-generation/{task_id}/status`
  - Background task handles generation, storage, and asset library save
- Uses the existing `task_manager` pattern (same as Story Writer / Podcast).

### New backend surface
- **Router:** `api/linkedin_video_generation.py`
- **Services:** `LinkedInVideoGenerator`, `LinkedInVideoStorage`, `tasks.py`
- **Registration:** `router_manager.py` and `feature_registry.py` under the `linkedin` feature group
- **Endpoints:**
  - `POST /api/linkedin/generate-video`
  - `GET /api/linkedin/video-generation/{task_id}/status`
  - `GET /api/linkedin/videos/{video_id}`
  - `GET /api/linkedin/video-generation-health`

### Model & provider alignment
- Default text-to-video model set to **`hunyuan-video-1.5`** (WaveSpeed), matching platform defaults in `main_video_generation.py`.
- Initial implementation used `alibaba/wan-2.5/text-to-video`, which WaveSpeed no longer supports for text-to-video and caused 400 errors.

### Asset library integration
- Generated videos are saved via `save_asset_to_library` with:
  - `source_module: linkedin_writer`
  - `asset_type: video`
- Task result now returns **`asset_id`**, **`storage_path`**, and **`asset_library_path`** for UI display and debugging.

### Testing
- Added `linkedInVideoService.test.ts` covering prompt building, URL resolution, motion mapping, generate start, and poll/status mapping.

---

## 2. Bug Fix: LinkedIn Quick Create Video Script generation

Fixes the end-to-end **Quick Create → Video Script** flow in LinkedIn Writer. The router was not passing the authenticated Clerk user ID into LLM calls, raw LLM output was not parsed into the expected video script shape, usage tracking could fail on import, and scene fields did not match the `VideoScript` Pydantic schema.

### Problems fixed

1. **Missing `user_id` for subscription checks**  
   The video-script endpoint extracted the Clerk ID but did not pass it to `linkedin_service`, so `llm_text_gen` failed with `user_id is required for subscription checking`.

2. **Usage tracking import error**  
   Invalid f-string in `ricos_converter.py` caused a syntax error during post-LLM usage tracking.

3. **`KeyError: 'hook'`**  
   `generate_grounded_video_script_content` returned raw text only, while `VideoScriptGenerator` expected structured fields (`hook`, `main_content`, `conclusion`, etc.).

4. **`VideoScript` Pydantic validation errors**  
   Parsed scenes used integer `scene_number` and `duration`, but `VideoScript.main_content` requires `List[Dict[str, str]]`.

### Changes

- **`backend/routers/linkedin.py`**  
  Added `_extract_clerk_user_id` / `_require_clerk_user_id` and pass `user_id` into all LinkedIn generation service calls (post, article, carousel, video script, comment response).

- **`backend/services/linkedin_service.py`**  
  Added `_effective_user_id()` and optional `user_id` param on generation methods; normalize `main_content` before building `VideoScript`.

- **`backend/services/linkedin/content_parser.py`** *(new)*  
  Added `parse_video_script_text()`, `normalize_scene()`, and `normalize_main_content()` to parse LLM markdown into structured script fields with string scene values (e.g. `"1"`, `"30s"`).

- **`backend/services/linkedin/content_generator.py`**  
  Parse and return structured video script fields from raw LLM output.

- **`backend/services/linkedin/content_generator_prompts/video_script_generator.py`**  
  Defensive fallback to parse raw `content` when structured keys are missing.

- **`backend/services/integrations/wix/ricos_converter.py`**  
  Fixed invalid f-string in code-block HTML rendering.
