### PR TITLE
fix(blog-writer): OutlineProgressModal hooks + frontend npm install

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/frontend/build/manifest.json
+++ b/frontend/build/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Alwrity",
-  "name": "Alwrity - AI Content Creation Platform",
+  "short_name": "ALwrity",
+  "name": "ALwrity — AI Digital Marketing Operating System",
   "icons": [
     {
       "src": "favicon.ico",
@@ -10,6 +10,6 @@
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#000000",
+  "theme_color": "#667eea",
   "background_color": "#ffffff"
-} 
+}

--- a/frontend/build/robots.txt
+++ b/frontend/build/robots.txt
@@ -1,3 +1,5 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow: 
+Disallow:
+
+Sitemap: https://www.alwrity.com/sitemap.xml

--- a/frontend/src/components/BlogWriter/OutlineProgressModal.tsx
+++ b/frontend/src/components/BlogWriter/OutlineProgressModal.tsx
@@ -146,14 +146,6 @@ export const OutlineProgressModal: React.FC<OutlineProgressModalProps> = ({
 }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-    }
-  }, [progressMessages]);
-
-  if (!isVisible) return null;
-
   const isContentGen = !!titleOverride;
   const stages = isContentGen ? contentStageDefinitions : stageDefinitions;
   const isRunning = status === 'running' || status === 'pending';
@@ -162,7 +154,6 @@ export const OutlineProgressModal: React.FC<OutlineProgressModalProps> = ({
 
   const statusInfo = statusThemes[status] || statusThemes.running;
 
-  // Determine latest stage index from messages
   const latestStageIndex = useMemo(() => {
     if (progressMessages.length === 0) return -1;
     const lastMsg = progressMessages[progressMessages.length - 1] || '';
@@ -200,7 +191,15 @@ export const OutlineProgressModal: React.FC<OutlineProgressModalProps> = ({
     const active = stagesWithState.filter(s => s.state === 'active').length;
     if (done === 0 && active === 0) return 0;
     return Math.round(((done + active * 0.5) / stages.length) * 100);
-  }, [stagesWithState, isComplete, isFailed]);
+  }, [stagesWithState, isComplete, isFailed, stages.length]);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [progressMessages]);
+
+  if (!isVisible) return null;
 
   const closeable = isComplete || isFailed;
 


### PR DESCRIPTION
## Summary

- Fix ESLint eact-hooks/rules-of-hooks errors in OutlineProgressModal by moving all hooks (useMemo, useEffect) above the isVisible early return, so they run in a consistent order every render.
- Add rontend/.npmrc with legacy-peer-deps=true so 
pm install succeeds with eact-scripts@5.0.1 and TypeScript 5 (avoids the ERESOLVE peer dependency conflict).
- Sync tracked rontend/build/manifest.json and rontend/build/robots.txt with public/ (branding, theme color, sitemap).

## Test plan

- [ ] cd frontend && npm install completes without ERESOLVE errors
- [ ] 
pm start compiles without ESLint hook errors in OutlineProgressModal.tsx
- [ ] Open Blog Writer outline/content generation flow and confirm progress modal still shows stages, progress bar, and message log when visible
- [ ] Confirm modal returns 
ull when isVisible is false (no UI flash)

Made with [Cursor](https://cursor.com)