### PR TITLE
feat(persona): merge quality + evidence accordions into one (Phase 2, flag OFF)

### DIFF
--- a/backend/services/integrations/bing_oauth.py
+++ b/backend/services/integrations/bing_oauth.py
@@ -16,9 +16,19 @@ from cryptography.fernet import Fernet, InvalidToken
 from ..analytics_cache_service import analytics_cache
 
 from services.database import get_user_db_path
+from .oauth_provider_base import OAuthProviderBase, resolve_encryption_key
 
-class BingOAuthService:
+class BingOAuthService(OAuthProviderBase):
     """Manages Bing Webmaster Tools OAuth2 authentication flow."""
+
+    # SQL fragments consumed by OAuthProviderBase._migrate_plaintext_tokens_if_needed
+    _select_plaintext_tokens_sql = (
+        "SELECT id, access_token, refresh_token FROM bing_oauth_tokens WHERE user_id = ?"
+    )
+    _update_token_sql = (
+        "UPDATE bing_oauth_tokens SET access_token = ?, refresh_token = ?, updated_at = datetime('now') "
+        "WHERE id = ? AND user_id = ?"
+    )
 
     def __init__(self):
         # Bing Webmaster OAuth2 credentials
@@ -30,74 +40,13 @@ class BingOAuthService:
 
         # Token encryption (matches the Wix/WordPress pattern; closes
         # a security gap where Bing tokens were stored in plaintext).
-        self.token_encryption_key = (
-            os.getenv("BING_TOKEN_ENCRYPTION_KEY")
-            or os.getenv("OAUTH_TOKEN_ENCRYPTION_KEY")
-        )
+        self.token_encryption_key = resolve_encryption_key("bing")
         self._fernet = self._initialize_fernet()
         self._migration_done: set = set()
 
         if not self.client_id or not self.client_secret or self.client_id == 'your_bing_client_id_here':
             logger.warning("Bing Webmaster OAuth client credentials not configured. Please set BING_CLIENT_ID and BING_CLIENT_SECRET environment variables with valid Bing Webmaster application credentials.")
             logger.warning("To get credentials: 1. Go to https://www.bing.com/webmasters/ 2. Sign in to Bing Webmaster Tools 3. Go to Settings > API Access 4. Create OAuth client")
-
-    def _initialize_fernet(self) -> Optional[Fernet]:
-        if not self.token_encryption_key:
-            logger.error("Bing token encryption key is not configured.")
-            return None
-        try:
-            return Fernet(self.token_encryption_key.encode("utf-8"))
-        except Exception:
-            logger.error("Bing token encryption key is invalid.")
-            return None
-
-    def _encrypt_token(self, token: Optional[str]) -> Optional[str]:
-        if not token:
-            return None
-        if not self._fernet:
-            raise ValueError("Token encryption is unavailable: missing/invalid managed key")
-        return self._fernet.encrypt(token.encode("utf-8")).decode("utf-8")
-
-    def _decrypt_token(self, token_blob: Optional[str]) -> Optional[str]:
-        if not token_blob:
-            return None
-        if not self._fernet:
-            raise ValueError("Token decryption is unavailable: missing/invalid managed key")
-        return self._fernet.decrypt(token_blob.encode("utf-8")).decode("utf-8")
-
-    def _is_likely_encrypted_blob(self, value: Optional[str]) -> bool:
-        return bool(value and value.startswith("gAAAAA"))
-
-    def _migrate_plaintext_tokens_if_needed(self, conn: sqlite3.Connection, user_id: str) -> None:
-        """One-time migration path: re-encrypt plaintext rows during rollout."""
-        if not self._fernet or user_id in self._migration_done:
-            return
-        cursor = conn.cursor()
-        cursor.execute(
-            "SELECT id, access_token, refresh_token FROM bing_oauth_tokens WHERE user_id = ?",
-            (user_id,),
-        )
-        rows = cursor.fetchall()
-        migrated = 0
-        for token_id, access_token, refresh_token in rows:
-            needs_access = access_token and not self._is_likely_encrypted_blob(access_token)
-            needs_refresh = refresh_token and not self._is_likely_encrypted_blob(refresh_token)
-            if not (needs_access or needs_refresh):
-                continue
-            enc_access = self._encrypt_token(access_token) if needs_access else access_token
-            enc_refresh = self._encrypt_token(refresh_token) if needs_refresh else refresh_token
-            cursor.execute(
-                "UPDATE bing_oauth_tokens SET access_token = ?, refresh_token = ?, updated_at = datetime('now') WHERE id = ? AND user_id = ?",
-                (enc_access, enc_refresh, token_id, user_id),
-            )
-            migrated += 1
-        if migrated:
-            conn.commit()
-            logger.info(f"Bing OAuth token migration completed for user {user_id}; rows migrated={migrated}")
-        self._migration_done.add(user_id)
-
-    def _get_db_path(self, user_id: str) -> str:
-        return get_user_db_path(user_id)
 
     def _init_db(self, user_id: str):
         """Initialize database tables for OAuth tokens."""

--- a/backend/services/integrations/bing_oauth.py
+++ b/backend/services/integrations/bing_oauth.py
@@ -12,13 +12,14 @@ from datetime import datetime, timedelta
 from loguru import logger
 import json
 from urllib.parse import quote
+from cryptography.fernet import Fernet, InvalidToken
 from ..analytics_cache_service import analytics_cache
 
 from services.database import get_user_db_path
 
 class BingOAuthService:
     """Manages Bing Webmaster Tools OAuth2 authentication flow."""
-    
+
     def __init__(self):
         # Bing Webmaster OAuth2 credentials
         self.client_id = os.getenv('BING_CLIENT_ID', '')
@@ -27,10 +28,74 @@ class BingOAuthService:
         self.base_url = "https://www.bing.com"
         self.api_base_url = "https://www.bing.com/webmaster/api.svc/json"
 
+        # Token encryption (matches the Wix/WordPress pattern; closes
+        # a security gap where Bing tokens were stored in plaintext).
+        self.token_encryption_key = (
+            os.getenv("BING_TOKEN_ENCRYPTION_KEY")
+            or os.getenv("OAUTH_TOKEN_ENCRYPTION_KEY")
+        )
+        self._fernet = self._initialize_fernet()
+        self._migration_done: set = set()
+
         if not self.client_id or not self.client_secret or self.client_id == 'your_bing_client_id_here':
             logger.warning("Bing Webmaster OAuth client credentials not configured. Please set BING_CLIENT_ID and BING_CLIENT_SECRET environment variables with valid Bing Webmaster application credentials.")
             logger.warning("To get credentials: 1. Go to https://www.bing.com/webmasters/ 2. Sign in to Bing Webmaster Tools 3. Go to Settings > API Access 4. Create OAuth client")
-    
+
+    def _initialize_fernet(self) -> Optional[Fernet]:
+        if not self.token_encryption_key:
+            logger.error("Bing token encryption key is not configured.")
+            return None
+        try:
+            return Fernet(self.token_encryption_key.encode("utf-8"))
+        except Exception:
+            logger.error("Bing token encryption key is invalid.")
+            return None
+
+    def _encrypt_token(self, token: Optional[str]) -> Optional[str]:
+        if not token:
+            return None
+        if not self._fernet:
+            raise ValueError("Token encryption is unavailable: missing/invalid managed key")
+        return self._fernet.encrypt(token.encode("utf-8")).decode("utf-8")
+
+    def _decrypt_token(self, token_blob: Optional[str]) -> Optional[str]:
+        if not token_blob:
+            return None
+        if not self._fernet:
+            raise ValueError("Token decryption is unavailable: missing/invalid managed key")
+        return self._fernet.decrypt(token_blob.encode("utf-8")).decode("utf-8")
+
+    def _is_likely_encrypted_blob(self, value: Optional[str]) -> bool:
+        return bool(value and value.startswith("gAAAAA"))
+
+    def _migrate_plaintext_tokens_if_needed(self, conn: sqlite3.Connection, user_id: str) -> None:
+        """One-time migration path: re-encrypt plaintext rows during rollout."""
+        if not self._fernet or user_id in self._migration_done:
+            return
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT id, access_token, refresh_token FROM bing_oauth_tokens WHERE user_id = ?",
+            (user_id,),
+        )
+        rows = cursor.fetchall()
+        migrated = 0
+        for token_id, access_token, refresh_token in rows:
+            needs_access = access_token and not self._is_likely_encrypted_blob(access_token)
+            needs_refresh = refresh_token and not self._is_likely_encrypted_blob(refresh_token)
+            if not (needs_access or needs_refresh):
+                continue
+            enc_access = self._encrypt_token(access_token) if needs_access else access_token
+            enc_refresh = self._encrypt_token(refresh_token) if needs_refresh else refresh_token
+            cursor.execute(
+                "UPDATE bing_oauth_tokens SET access_token = ?, refresh_token = ?, updated_at = datetime('now') WHERE id = ? AND user_id = ?",
+                (enc_access, enc_refresh, token_id, user_id),
+            )
+            migrated += 1
+        if migrated:
+            conn.commit()
+            logger.info(f"Bing OAuth token migration completed for user {user_id}; rows migrated={migrated}")
+        self._migration_done.add(user_id)
+
     def _get_db_path(self, user_id: str) -> str:
         return get_user_db_path(user_id)
 
@@ -213,11 +278,13 @@ class BingOAuthService:
             
             with sqlite3.connect(db_path) as conn:
                 cursor = conn.cursor()
+                encrypted_access = self._encrypt_token(access_token)
+                encrypted_refresh = self._encrypt_token(refresh_token)
                 cursor.execute('''
-                    INSERT INTO bing_oauth_tokens 
+                    INSERT INTO bing_oauth_tokens
                     (user_id, access_token, refresh_token, token_type, expires_at, scope)
                     VALUES (?, ?, ?, ?, ?, ?)
-                ''', (user_id, access_token, refresh_token, token_type, expires_at, 'webmaster.manage'))
+                ''', (user_id, encrypted_access, encrypted_refresh, token_type, expires_at, 'webmaster.manage'))
                 conn.commit()
                 logger.info(f"Bing OAuth: Token inserted into database for user {user_id}")
             
@@ -307,8 +374,9 @@ class BingOAuthService:
             db_path = self._get_db_path(user_id)
             if not os.path.exists(db_path):
                 return []
-                
+
             with sqlite3.connect(db_path) as conn:
+                self._migrate_plaintext_tokens_if_needed(conn, user_id)
                 cursor = conn.cursor()
                 cursor.execute('''
                     SELECT id, access_token, refresh_token, token_type, expires_at, scope, created_at
@@ -316,13 +384,32 @@ class BingOAuthService:
                     WHERE user_id = ? AND is_active = TRUE AND expires_at > datetime('now')
                     ORDER BY created_at DESC
                 ''', (user_id,))
-                
+
                 tokens = []
                 for row in cursor.fetchall():
+                    access_token_val = row[1]
+                    refresh_token_val = row[2]
+                    try:
+                        decrypted_access = (
+                            self._decrypt_token(access_token_val)
+                            if self._is_likely_encrypted_blob(access_token_val)
+                            else access_token_val
+                        )
+                    except InvalidToken:
+                        logger.error(f"Failed to decrypt Bing access token for user {user_id}, token_id={row[0]}")
+                        continue
+                    try:
+                        decrypted_refresh = (
+                            self._decrypt_token(refresh_token_val)
+                            if self._is_likely_encrypted_blob(refresh_token_val)
+                            else refresh_token_val
+                        )
+                    except InvalidToken:
+                        decrypted_refresh = None
                     tokens.append({
                         "id": row[0],
-                        "access_token": row[1],
-                        "refresh_token": row[2],
+                        "access_token": decrypted_access,
+                        "refresh_token": decrypted_refresh,
                         "token_type": row[3],
                         "expires_at": row[4],
                         "scope": row[5],
@@ -339,10 +426,11 @@ class BingOAuthService:
             # Ensure DB tables exist for this user before querying
             self._init_db(user_id)
             db_path = self._get_db_path(user_id)
-            
+
             with sqlite3.connect(db_path) as conn:
+                self._migrate_plaintext_tokens_if_needed(conn, user_id)
                 cursor = conn.cursor()
-                
+
                 # Get all tokens (active and expired)
                 cursor.execute('''
                     SELECT id, access_token, refresh_token, token_type, expires_at, scope, created_at, is_active
@@ -350,16 +438,34 @@ class BingOAuthService:
                     WHERE user_id = ?
                     ORDER BY created_at DESC
                 ''', (user_id,))
-                
+
                 all_tokens = []
                 active_tokens = []
                 expired_tokens = []
-                
+
                 for row in cursor.fetchall():
+                    access_token_val = row[1]
+                    refresh_token_val = row[2]
+                    try:
+                        decrypted_access = (
+                            self._decrypt_token(access_token_val)
+                            if self._is_likely_encrypted_blob(access_token_val)
+                            else access_token_val
+                        )
+                    except InvalidToken:
+                        decrypted_access = None
+                    try:
+                        decrypted_refresh = (
+                            self._decrypt_token(refresh_token_val)
+                            if self._is_likely_encrypted_blob(refresh_token_val)
+                            else refresh_token_val
+                        )
+                    except InvalidToken:
+                        decrypted_refresh = None
                     token_data = {
                         "id": row[0],
-                        "access_token": row[1],
-                        "refresh_token": row[2],
+                        "access_token": decrypted_access,
+                        "refresh_token": decrypted_refresh,
                         "token_type": row[3],
                         "expires_at": row[4],
                         "scope": row[5],
@@ -367,7 +473,7 @@ class BingOAuthService:
                         "is_active": bool(row[7])
                     }
                     all_tokens.append(token_data)
-                    
+
                     # Determine expiry using robust parsing and is_active flag
                     is_active_flag = bool(row[7])
                     not_expired = False
@@ -482,11 +588,12 @@ class BingOAuthService:
             db_path = self._get_db_path(user_id)
             with sqlite3.connect(db_path) as conn:
                 cursor = conn.cursor()
+                encrypted_access = self._encrypt_token(access_token)
                 cursor.execute('''
-                    UPDATE bing_oauth_tokens 
+                    UPDATE bing_oauth_tokens
                     SET access_token = ?, expires_at = ?, is_active = TRUE, updated_at = datetime('now')
                     WHERE user_id = ? AND refresh_token = ?
-                ''', (access_token, expires_at, user_id, refresh_token))
+                ''', (encrypted_access, expires_at, user_id, refresh_token))
                 conn.commit()
             
             logger.info(f"Bing access token refreshed for user {user_id}")
@@ -696,12 +803,13 @@ class BingOAuthService:
                         expires_at_value = datetime.now() + timedelta(seconds=int(refreshed_token["expires_in"]))
                     except Exception:
                         expires_at_value = None
+                encrypted_access = self._encrypt_token(refreshed_token["access_token"])
                 cursor.execute('''
-                    UPDATE bing_oauth_tokens 
+                    UPDATE bing_oauth_tokens
                     SET access_token = ?, expires_at = ?, is_active = TRUE, updated_at = datetime('now')
                     WHERE id = ?
                 ''', (
-                    refreshed_token["access_token"],
+                    encrypted_access,
                     expires_at_value,
                     token_id
                 ))

--- a/backend/services/integrations/oauth_provider_base.py
+++ b/backend/services/integrations/oauth_provider_base.py
@@ -78,36 +78,52 @@ class OAuthProviderBase:
         self.token_encryption_key: str | None  (set in __init__)
     """
 
-    def _initialize_fernet(self) -> Optional[Fernet]:
+    def _initialize_fernet(self) -> Fernet:
+        """Initialize Fernet, raising on missing or invalid key.
+
+        OAuth tokens must be encrypted at rest. The user's 'no
+        fallbacks' mandate means a missing or invalid key fails
+        fast at service construction, not lazily on the first
+        token operation (where the failure mode is a confusing
+        'Fernet is None' deep in the call stack).
+
+        Subclasses inherit this behavior by default. The previous
+        'warn and return None' behavior in Wix/WordPress/Bing
+        is a step-3 change: this commit normalizes all 4
+        providers to fail-fast at construction.
+
+        To override (e.g. to fail-soft in a test fixture), set
+        self._fernet manually after __init__.
+        """
         if not self.token_encryption_key:
-            logger.error(
-                f"{type(self).__name__} token encryption key is not configured."
+            raise ValueError(
+                f"{type(self).__name__} token encryption key is not configured. "
+                f"Set the appropriate env var (BING_TOKEN_ENCRYPTION_KEY / "
+                f"WIX_TOKEN_ENCRYPTION_KEY / WORDPRESS_TOKEN_ENCRYPTION_KEY / "
+                f"YOUTUBE_TOKEN_ENCRYPTION_KEY) or the shared "
+                f"OAUTH_TOKEN_ENCRYPTION_KEY fallback. "
+                f"Generate a key: python -c \"from cryptography.fernet import Fernet; "
+                f"print(Fernet.generate_key().decode())\""
             )
-            return None
         try:
             return Fernet(self.token_encryption_key.encode("utf-8"))
-        except Exception:
-            logger.error(
-                f"{type(self).__name__} token encryption key is invalid."
+        except Exception as e:
+            raise ValueError(
+                f"{type(self).__name__} token encryption key is invalid: {e}"
             )
-            return None
 
     def _encrypt_token(self, token: Optional[str]) -> Optional[str]:
         if not token:
             return None
-        if not self._fernet:
-            raise ValueError(
-                "Token encryption is unavailable: missing/invalid managed key"
-            )
+        # _fernet is guaranteed by _initialize_fernet raising at
+        # construction. The AttributeError that would result from
+        # None is a programmer error (someone set _fernet=None
+        # directly), not a runtime condition.
         return self._fernet.encrypt(token.encode("utf-8")).decode("utf-8")
 
     def _decrypt_token(self, token_blob: Optional[str]) -> Optional[str]:
         if not token_blob:
             return None
-        if not self._fernet:
-            raise ValueError(
-                "Token decryption is unavailable: missing/invalid managed key"
-            )
         return self._fernet.decrypt(token_blob.encode("utf-8")).decode("utf-8")
 
     def _is_likely_encrypted_blob(self, value: Optional[str]) -> bool:
@@ -125,7 +141,7 @@ class OAuthProviderBase:
 
         See WixOAuthService for the canonical pattern.
         """
-        if not self._fernet or user_id in self._migration_done:
+        if user_id in self._migration_done:
             return
         cursor = conn.cursor()
         cursor.execute(self._select_plaintext_tokens_sql, (user_id,))

--- a/backend/services/integrations/oauth_provider_base.py
+++ b/backend/services/integrations/oauth_provider_base.py
@@ -1,0 +1,175 @@
+"""
+OAuth Provider Base Class
+
+Shared Fernet token encryption + plaintext migration for the four
+ALwrity OAuth providers (Bing, Wix, WordPress, YouTube).
+
+All four providers store their OAuth tokens in a per-user SQLite
+database (see services.database.get_user_db_path) and exchange
+them with remote APIs. Before this base class existed, each
+provider maintained its own copy of the Fernet init / encrypt /
+decrypt / migration logic. Bing (the only one that was storing
+plaintext) caught up with the others in commit e383d08c, but
+the actual code was still duplicated across all four files.
+
+This module extracts the shared surface:
+
+- _initialize_fernet: read BING_TOKEN_ENCRYPTION_KEY /
+  WIX_TOKEN_ENCRYPTION_KEY / WORDPRESS_TOKEN_ENCRYPTION_KEY /
+  YOUTUBE_TOKEN_ENCRYPTION_KEY (each provider class supplies
+  its key attribute name) with a shared fallback to
+  OAUTH_TOKEN_ENCRYPTION_KEY. Returns Optional[Fernet] (matches
+  the Wix/WordPress/Bing convention). YouTube overrides this to
+  raise on missing key (see oauth_provider_base / YouTube).
+- _encrypt_token / _decrypt_token: word-for-word identical
+  across providers. Raise ValueError if Fernet is unavailable
+  so the caller knows the failure mode.
+- _is_likely_encrypted_blob: Fernet ciphertext starts with
+  'gAAAAA'. Used to skip decryption for already-plaintext
+  rows during the one-time migration.
+- _migrate_plaintext_tokens_if_needed: re-encrypts any plaintext
+  rows the first time the user reads their tokens, gated by
+  the per-instance _migration_done set so the migration runs
+  at most once per user per process.
+- _get_db_path: thin wrapper over services.database.get_user_db_path
+  that honours an optional ctor-injected db_path (for tests).
+
+Subclasses (WixOAuthService, WordPressOAuthService,
+BingOAuthService, YouTubeOAuthService) keep their own:
+
+- __init__: provider-specific client_id, client_secret, scope,
+  redirect_uri, base_url
+- _init_db: provider-specific SQLite schema (CREATE TABLE
+  per provider, with different columns)
+- _get_db_path override: only if a provider needs a different
+  path resolution
+- generate_authorization_url / handle_oauth_callback:
+  provider-specific OAuth flow
+- The full Google OAuth library integration in YouTubeOAuthService
+  (uses google-auth-oauthlib instead of manual token storage)
+"""
+
+import os
+import sqlite3
+from typing import Optional
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from loguru import logger
+
+from services.database import get_user_db_path
+
+
+# Per-provider env var names, in the order they should be tried
+# (provider-specific first, shared fallback last). Subclasses
+# override the appropriate name.
+PROVIDER_ENV_VARS = {
+    "bing": "BING_TOKEN_ENCRYPTION_KEY",
+    "wix": "WIX_TOKEN_ENCRYPTION_KEY",
+    "wordpress": "WORDPRESS_TOKEN_ENCRYPTION_KEY",
+    "youtube": "YOUTUBE_TOKEN_ENCRYPTION_KEY",
+}
+
+
+class OAuthProviderBase:
+    """Shared Fernet encryption + plaintext migration for OAuth tokens.
+
+    Subclasses must define:
+        self.token_encryption_key: str | None  (set in __init__)
+    """
+
+    def _initialize_fernet(self) -> Optional[Fernet]:
+        if not self.token_encryption_key:
+            logger.error(
+                f"{type(self).__name__} token encryption key is not configured."
+            )
+            return None
+        try:
+            return Fernet(self.token_encryption_key.encode("utf-8"))
+        except Exception:
+            logger.error(
+                f"{type(self).__name__} token encryption key is invalid."
+            )
+            return None
+
+    def _encrypt_token(self, token: Optional[str]) -> Optional[str]:
+        if not token:
+            return None
+        if not self._fernet:
+            raise ValueError(
+                "Token encryption is unavailable: missing/invalid managed key"
+            )
+        return self._fernet.encrypt(token.encode("utf-8")).decode("utf-8")
+
+    def _decrypt_token(self, token_blob: Optional[str]) -> Optional[str]:
+        if not token_blob:
+            return None
+        if not self._fernet:
+            raise ValueError(
+                "Token decryption is unavailable: missing/invalid managed key"
+            )
+        return self._fernet.decrypt(token_blob.encode("utf-8")).decode("utf-8")
+
+    def _is_likely_encrypted_blob(self, value: Optional[str]) -> bool:
+        return bool(value and value.startswith("gAAAAA"))
+
+    def _migrate_plaintext_tokens_if_needed(
+        self, conn: sqlite3.Connection, user_id: str
+    ) -> None:
+        """One-time migration: re-encrypt plaintext rows during rollout.
+
+        Subclasses must define:
+            self._migration_done: set  (per-user-per-process gate)
+            self._select_plaintext_tokens_sql: str  (SELECT id, access_token, refresh_token ...)
+            self._update_token_sql: str  (UPDATE ... SET access_token = ?, refresh_token = ?, updated_at = ...)
+
+        See WixOAuthService for the canonical pattern.
+        """
+        if not self._fernet or user_id in self._migration_done:
+            return
+        cursor = conn.cursor()
+        cursor.execute(self._select_plaintext_tokens_sql, (user_id,))
+        rows = cursor.fetchall()
+        migrated = 0
+        for row in rows:
+            token_id = row[0]
+            access_token = row[1]
+            refresh_token = row[2]
+            needs_access = access_token and not self._is_likely_encrypted_blob(access_token)
+            needs_refresh = refresh_token and not self._is_likely_encrypted_blob(refresh_token)
+            if not (needs_access or needs_refresh):
+                continue
+            enc_access = self._encrypt_token(access_token) if needs_access else access_token
+            enc_refresh = self._encrypt_token(refresh_token) if needs_refresh else refresh_token
+            cursor.execute(
+                self._update_token_sql,
+                (enc_access, enc_refresh, token_id, user_id),
+            )
+            migrated += 1
+        if migrated:
+            conn.commit()
+            logger.info(
+                f"{type(self).__name__} OAuth token migration completed for user {user_id}; rows migrated={migrated}"
+            )
+        self._migration_done.add(user_id)
+
+    def _get_db_path(self, user_id: str) -> str:
+        if getattr(self, "db_path", None):
+            return self.db_path
+        return get_user_db_path(user_id)
+
+
+def resolve_encryption_key(provider_name: str) -> Optional[str]:
+    """Resolve the Fernet key for a provider, honouring the
+    provider-specific env var first, then the shared
+    OAUTH_TOKEN_ENCRYPTION_KEY fallback.
+
+    Used by subclass __init__ methods to set
+    self.token_encryption_key.
+    """
+    provider_var = PROVIDER_ENV_VARS.get(provider_name.lower())
+    if provider_var:
+        specific = os.getenv(provider_var)
+        if specific:
+            return specific
+    return os.getenv("OAUTH_TOKEN_ENCRYPTION_KEY")

--- a/backend/services/integrations/wix_oauth.py
+++ b/backend/services/integrations/wix_oauth.py
@@ -11,78 +11,26 @@ from loguru import logger
 from cryptography.fernet import Fernet, InvalidToken
 
 from services.database import get_user_db_path
+from .oauth_provider_base import OAuthProviderBase, resolve_encryption_key
 
-class WixOAuthService:
+class WixOAuthService(OAuthProviderBase):
     """Manages Wix OAuth2 authentication flow and token storage."""
-    
+
+    # SQL fragments consumed by OAuthProviderBase._migrate_plaintext_tokens_if_needed
+    _select_plaintext_tokens_sql = (
+        "SELECT id, access_token, refresh_token FROM wix_oauth_tokens WHERE user_id = ?"
+    )
+    _update_token_sql = (
+        "UPDATE wix_oauth_tokens SET access_token = ?, refresh_token = ?, updated_at = datetime('now') "
+        "WHERE id = ? AND user_id = ?"
+    )
+
     def __init__(self, db_path: Optional[str] = None):
         self.db_path = db_path
-        self.token_encryption_key = (
-            os.getenv("WIX_TOKEN_ENCRYPTION_KEY")
-            or os.getenv("OAUTH_TOKEN_ENCRYPTION_KEY")
-        )
+        self.token_encryption_key = resolve_encryption_key("wix")
         self._fernet = self._initialize_fernet()
         self._migration_done: set = set()
 
-    def _initialize_fernet(self) -> Optional[Fernet]:
-        if not self.token_encryption_key:
-            logger.error("Wix token encryption key is not configured.")
-            return None
-        try:
-            return Fernet(self.token_encryption_key.encode("utf-8"))
-        except Exception:
-            logger.error("Wix token encryption key is invalid.")
-            return None
-
-    def _encrypt_token(self, token: Optional[str]) -> Optional[str]:
-        if not token:
-            return None
-        if not self._fernet:
-            raise ValueError("Token encryption is unavailable: missing/invalid managed key")
-        return self._fernet.encrypt(token.encode("utf-8")).decode("utf-8")
-
-    def _decrypt_token(self, token_blob: Optional[str]) -> Optional[str]:
-        if not token_blob:
-            return None
-        if not self._fernet:
-            raise ValueError("Token decryption is unavailable: missing/invalid managed key")
-        return self._fernet.decrypt(token_blob.encode("utf-8")).decode("utf-8")
-
-    def _is_likely_encrypted_blob(self, value: Optional[str]) -> bool:
-        return bool(value and value.startswith("gAAAAA"))
-
-    def _migrate_plaintext_tokens_if_needed(self, conn: sqlite3.Connection, user_id: str) -> None:
-        if not self._fernet or user_id in self._migration_done:
-            return
-        cursor = conn.cursor()
-        cursor.execute(
-            "SELECT id, access_token, refresh_token FROM wix_oauth_tokens WHERE user_id = ?",
-            (user_id,),
-        )
-        rows = cursor.fetchall()
-        migrated = 0
-        for token_id, access_token, refresh_token in rows:
-            needs_access = access_token and not self._is_likely_encrypted_blob(access_token)
-            needs_refresh = refresh_token and not self._is_likely_encrypted_blob(refresh_token)
-            if not (needs_access or needs_refresh):
-                continue
-            enc_access = self._encrypt_token(access_token) if needs_access else access_token
-            enc_refresh = self._encrypt_token(refresh_token) if needs_refresh else refresh_token
-            cursor.execute(
-                "UPDATE wix_oauth_tokens SET access_token = ?, refresh_token = ?, updated_at = datetime('now') WHERE id = ? AND user_id = ?",
-                (enc_access, enc_refresh, token_id, user_id),
-            )
-            migrated += 1
-        if migrated:
-            conn.commit()
-            logger.info(f"Wix OAuth token migration completed for user {user_id}; rows migrated={migrated}")
-        self._migration_done.add(user_id)
-    
-    def _get_db_path(self, user_id: str) -> str:
-        if self.db_path:
-            return self.db_path
-        return get_user_db_path(user_id)
-    
     def _init_db(self, user_id: str):
         """Initialize database tables for OAuth tokens."""
         db_path = self._get_db_path(user_id)

--- a/backend/services/integrations/wordpress_oauth.py
+++ b/backend/services/integrations/wordpress_oauth.py
@@ -13,104 +13,46 @@ from loguru import logger
 from cryptography.fernet import Fernet, InvalidToken
 
 from services.database import get_user_db_path
+from .oauth_provider_base import OAuthProviderBase, resolve_encryption_key
 
-class WordPressOAuthService:
+class WordPressOAuthService(OAuthProviderBase):
     """Manages WordPress.com OAuth2 authentication flow."""
-    
+
+    # SQL fragments consumed by OAuthProviderBase._migrate_plaintext_tokens_if_needed
+    _select_plaintext_tokens_sql = (
+        "SELECT id, access_token, refresh_token FROM wordpress_oauth_tokens WHERE user_id = ?"
+    )
+    _update_token_sql = (
+        "UPDATE wordpress_oauth_tokens SET access_token = ?, refresh_token = ?, updated_at = datetime('now') "
+        "WHERE id = ? AND user_id = ?"
+    )
+
     def __init__(self, db_path: str = None):
         # db_path is deprecated in favor of dynamic user_id based paths
         self.db_path = db_path
         # WordPress.com OAuth2 credentials
         self.client_id = os.getenv('WORDPRESS_CLIENT_ID', '')
         self.client_secret = os.getenv('WORDPRESS_CLIENT_SECRET', '')
-        
+
         # Determine redirect URI dynamically
         default_redirect = 'https://alwrity-ai.vercel.app/wp/callback'
         frontend_url = os.getenv('FRONTEND_URL')
-        
+
         if frontend_url:
             self.redirect_uri = f"{frontend_url.rstrip('/')}/wp/callback"
         else:
             self.redirect_uri = os.getenv('WORDPRESS_REDIRECT_URI', default_redirect)
-            
+
         self.base_url = "https://public-api.wordpress.com"
-        self.token_encryption_key = (
-            os.getenv("WORDPRESS_TOKEN_ENCRYPTION_KEY")
-            or os.getenv("OAUTH_TOKEN_ENCRYPTION_KEY")
-        )
+        self.token_encryption_key = resolve_encryption_key("wordpress")
         self._fernet = self._initialize_fernet()
+        self._migration_done: set = set()
 
         # Validate configuration
         if not self.client_id or not self.client_secret or self.client_id == 'your_wordpress_com_client_id_here':
             logger.error("WordPress OAuth client credentials not configured. Please set WORDPRESS_CLIENT_ID and WORDPRESS_CLIENT_SECRET environment variables with valid WordPress.com application credentials.")
             logger.error("To get credentials: 1. Go to https://developer.wordpress.com/apps/ 2. Create a new application 3. Set redirect URI to: https://your-domain.com/wp/callback")
-    
-    def _initialize_fernet(self) -> Optional[Fernet]:
-        """Initialize token encryption using managed key from env/secret manager."""
-        if not self.token_encryption_key:
-            logger.error("WordPress token encryption key is not configured.")
-            return None
-        try:
-            return Fernet(self.token_encryption_key.encode("utf-8"))
-        except Exception:
-            logger.error("WordPress token encryption key is invalid.")
-            return None
 
-    def _encrypt_token(self, token: Optional[str]) -> Optional[str]:
-        if not token:
-            return None
-        if not self._fernet:
-            raise ValueError("Token encryption is unavailable: missing/invalid managed key")
-        return self._fernet.encrypt(token.encode("utf-8")).decode("utf-8")
-
-    def _decrypt_token(self, token_blob: Optional[str]) -> Optional[str]:
-        if not token_blob:
-            return None
-        if not self._fernet:
-            raise ValueError("Token decryption is unavailable: missing/invalid managed key")
-        return self._fernet.decrypt(token_blob.encode("utf-8")).decode("utf-8")
-
-    def _is_likely_encrypted_blob(self, value: Optional[str]) -> bool:
-        return bool(value and value.startswith("gAAAAA"))
-
-    def _migrate_plaintext_tokens_if_needed(self, conn: sqlite3.Connection, user_id: str) -> None:
-        """One-time migration path: re-encrypt plaintext rows during rollout."""
-        if not self._fernet:
-            return
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT id, access_token, refresh_token
-            FROM wordpress_oauth_tokens
-            WHERE user_id = ?
-            """,
-            (user_id,),
-        )
-        rows = cursor.fetchall()
-        migrated = 0
-        for token_id, access_token, refresh_token in rows:
-            needs_access_migration = access_token and not self._is_likely_encrypted_blob(access_token)
-            needs_refresh_migration = refresh_token and not self._is_likely_encrypted_blob(refresh_token)
-            if not (needs_access_migration or needs_refresh_migration):
-                continue
-            encrypted_access = self._encrypt_token(access_token) if needs_access_migration else access_token
-            encrypted_refresh = self._encrypt_token(refresh_token) if needs_refresh_migration else refresh_token
-            cursor.execute(
-                """
-                UPDATE wordpress_oauth_tokens
-                SET access_token = ?, refresh_token = ?, updated_at = datetime('now')
-                WHERE id = ? AND user_id = ?
-                """,
-                (encrypted_access, encrypted_refresh, token_id, user_id),
-            )
-            migrated += 1
-        if migrated:
-            conn.commit()
-            logger.info(f"WordPress OAuth token migration completed for user {user_id}; rows migrated={migrated}")
-
-    def _get_db_path(self, user_id: str) -> str:
-        return get_user_db_path(user_id)
-    
     def _init_db(self, user_id: str):
         """Initialize database tables for OAuth tokens."""
         db_path = self._get_db_path(user_id)

--- a/backend/services/youtube/youtube_oauth_service.py
+++ b/backend/services/youtube/youtube_oauth_service.py
@@ -28,15 +28,12 @@ class YouTubeOAuthService(OAuthProviderBase):
     """Manages YouTube OAuth2 authentication flow and token storage.
 
     Inherits Fernet token encryption + plaintext migration from
-    OAuthProviderBase. YouTube keeps two overrides because the
-    base class semantics differ slightly:
-    - _initialize_fernet: YouTube raises on missing key (fail-fast
-      on misconfiguration); the base class returns None (warn-and-continue).
-      Step 3 of the cs4 plan normalizes this across all 4 providers.
+    OAuthProviderBase. YouTube keeps one override because the
+    call-site contract differs from the base:
     - _decrypt_token: YouTube swallows decryption errors and returns
       None so the caller's `if not access_token` check can handle
-      a corrupted row; the base class propagates. Kept here to preserve
-      the existing call-site contract.
+      a corrupted row; the base class propagates. Kept here to
+      preserve the existing call-site contract.
     """
 
     SCOPES = [
@@ -81,20 +78,11 @@ class YouTubeOAuthService(OAuthProviderBase):
                 "YouTube upload will not work until these are configured."
             )
 
-    def _initialize_fernet(self) -> Fernet:
-        # YouTube-specific: fail fast on missing key (vs the base
-        # class's warn-and-return-None). Step 3 of the cs4 plan will
-        # pick one policy for all 4 providers.
-        if not self.token_encryption_key:
-            raise ValueError(
-                "YOUTUBE_TOKEN_ENCRYPTION_KEY (or OAUTH_TOKEN_ENCRYPTION_KEY) is not set. "
-                "OAuth tokens must be encrypted at rest. "
-                "Generate a key: python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\""
-            )
-        try:
-            return Fernet(self.token_encryption_key.encode("utf-8"))
-        except Exception as e:
-            raise ValueError(f"Invalid YOUTUBE_TOKEN_ENCRYPTION_KEY: {e}")
+    # _initialize_fernet is inherited from OAuthProviderBase. YouTube
+    # used to override it to raise on missing key; the base class
+    # now does the same thing with a unified error message that
+    # names the correct env var per provider, so the override is
+    # redundant. (Step 3 of the cs4 plan.)
 
     def _decrypt_token(self, token_blob: Optional[str]) -> Optional[str]:
         # YouTube-specific: swallow decryption errors and return None

--- a/backend/services/youtube/youtube_oauth_service.py
+++ b/backend/services/youtube/youtube_oauth_service.py
@@ -21,16 +21,38 @@ from cryptography.fernet import Fernet
 from loguru import logger
 
 from services.database import get_user_db_path
+from services.integrations.oauth_provider_base import OAuthProviderBase, resolve_encryption_key
 
 
-class YouTubeOAuthService:
-    """Manages YouTube OAuth2 authentication flow and token storage."""
+class YouTubeOAuthService(OAuthProviderBase):
+    """Manages YouTube OAuth2 authentication flow and token storage.
+
+    Inherits Fernet token encryption + plaintext migration from
+    OAuthProviderBase. YouTube keeps two overrides because the
+    base class semantics differ slightly:
+    - _initialize_fernet: YouTube raises on missing key (fail-fast
+      on misconfiguration); the base class returns None (warn-and-continue).
+      Step 3 of the cs4 plan normalizes this across all 4 providers.
+    - _decrypt_token: YouTube swallows decryption errors and returns
+      None so the caller's `if not access_token` check can handle
+      a corrupted row; the base class propagates. Kept here to preserve
+      the existing call-site contract.
+    """
 
     SCOPES = [
         "https://www.googleapis.com/auth/youtube.upload",
         "https://www.googleapis.com/auth/youtube.readonly",
         "https://www.googleapis.com/auth/youtube.force-ssl",
     ]
+
+    # SQL fragments consumed by OAuthProviderBase._migrate_plaintext_tokens_if_needed
+    _select_plaintext_tokens_sql = (
+        "SELECT id, access_token, refresh_token FROM youtube_oauth_tokens WHERE user_id = ?"
+    )
+    _update_token_sql = (
+        "UPDATE youtube_oauth_tokens SET access_token = ?, refresh_token = ?, updated_at = datetime('now') "
+        "WHERE id = ? AND user_id = ?"
+    )
 
     def __init__(self, db_path: Optional[str] = None):
         self.db_path = db_path
@@ -45,9 +67,7 @@ class YouTubeOAuthService:
         self.redirect_uri = os.getenv("YOUTUBE_REDIRECT_URI", default_redirect)
 
         # Token encryption
-        self.token_encryption_key = os.getenv(
-            "YOUTUBE_TOKEN_ENCRYPTION_KEY"
-        ) or os.getenv("OAUTH_TOKEN_ENCRYPTION_KEY")
+        self.token_encryption_key = resolve_encryption_key("youtube")
         self._fernet: Fernet = self._initialize_fernet()
         self._migration_done: set = set()
 
@@ -62,6 +82,9 @@ class YouTubeOAuthService:
             )
 
     def _initialize_fernet(self) -> Fernet:
+        # YouTube-specific: fail fast on missing key (vs the base
+        # class's warn-and-return-None). Step 3 of the cs4 plan will
+        # pick one policy for all 4 providers.
         if not self.token_encryption_key:
             raise ValueError(
                 "YOUTUBE_TOKEN_ENCRYPTION_KEY (or OAUTH_TOKEN_ENCRYPTION_KEY) is not set. "
@@ -73,12 +96,10 @@ class YouTubeOAuthService:
         except Exception as e:
             raise ValueError(f"Invalid YOUTUBE_TOKEN_ENCRYPTION_KEY: {e}")
 
-    def _encrypt_token(self, token: Optional[str]) -> Optional[str]:
-        if not token:
-            return None
-        return self._fernet.encrypt(token.encode("utf-8")).decode("utf-8")
-
     def _decrypt_token(self, token_blob: Optional[str]) -> Optional[str]:
+        # YouTube-specific: swallow decryption errors and return None
+        # so the caller's `if not access_token` check can handle a
+        # corrupted row. The base class propagates the exception.
         if not token_blob:
             return None
         try:
@@ -86,9 +107,6 @@ class YouTubeOAuthService:
         except Exception as e:
             logger.error(f"YouTube OAuth: token decryption failed: {e}")
             return None
-
-    def _is_likely_encrypted_blob(self, value: Optional[str]) -> bool:
-        return bool(value and value.startswith("gAAAAA"))
 
     def _build_client_config(self) -> Optional[Dict[str, Any]]:
         if not self.client_id or not self.client_secret:
@@ -105,9 +123,6 @@ class YouTubeOAuthService:
                 "javascript_origins": [],
             }
         }
-
-    def _get_db_path(self, user_id: str) -> str:
-        return get_user_db_path(user_id)
 
     def _init_db(self, user_id: str):
         db_path = self._get_db_path(user_id)
@@ -142,33 +157,6 @@ class YouTubeOAuthService:
             """)
             conn.commit()
             logger.debug(f"YouTube OAuth tables initialized for user {user_id}")
-
-    def _migrate_plaintext_tokens_if_needed(self, conn: sqlite3.Connection, user_id: str) -> None:
-        if not self._fernet or user_id in self._migration_done:
-            return
-        cursor = conn.cursor()
-        cursor.execute(
-            "SELECT id, access_token, refresh_token FROM youtube_oauth_tokens WHERE user_id = ?",
-            (user_id,),
-        )
-        rows = cursor.fetchall()
-        migrated = 0
-        for token_id, access_token, refresh_token in rows:
-            needs_access = access_token and not self._is_likely_encrypted_blob(access_token)
-            needs_refresh = refresh_token and not self._is_likely_encrypted_blob(refresh_token)
-            if not (needs_access or needs_refresh):
-                continue
-            enc_access = self._encrypt_token(access_token) if needs_access else access_token
-            enc_refresh = self._encrypt_token(refresh_token) if needs_refresh else refresh_token
-            cursor.execute(
-                "UPDATE youtube_oauth_tokens SET access_token = ?, refresh_token = ?, updated_at = datetime('now') WHERE id = ? AND user_id = ?",
-                (enc_access, enc_refresh, token_id, user_id),
-            )
-            migrated += 1
-        if migrated:
-            conn.commit()
-            logger.info(f"YouTube OAuth token migration completed for user {user_id}; rows={migrated}")
-        self._migration_done.add(user_id)
 
     def generate_authorization_url(self, user_id: str) -> Optional[str]:
         """Generate Google OAuth authorization URL for YouTube scopes."""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -245,6 +245,9 @@ class _PatchedUserDB:
         import services.youtube.youtube_oauth_service as yt_mod
         import services.gsc_service as gsc_mod
         import services.integrations.wordpress_service as wp_service_mod
+        # _get_db_path was moved to the OAuth provider base class in the
+        # cs4 refactor; the patch must target the base module too.
+        import services.integrations.oauth_provider_base as oauth_base_mod
 
         modules = [
             database_module,
@@ -256,6 +259,7 @@ class _PatchedUserDB:
             yt_mod,
             gsc_mod,
             wp_service_mod,
+            oauth_base_mod,
         ]
         for mod in modules:
             self._monkeypatch.setattr(

--- a/docs/cs4-oauth-base-class.md
+++ b/docs/cs4-oauth-base-class.md
@@ -1,0 +1,137 @@
+# OAuth Common Framework — Phase 4 Plan
+
+## Context
+
+The user remembered a "common OAuth framework" that was supposedly merged to
+main. **It was not.** Two attempts exist:
+
+- `c66f2c1d "Add Common OAuth Framework"` (on `common-oauth-framework`
+  branch only, never merged) — 3 frontend files, 848 lines, **does not
+  actually replace anything** despite the commit message claim. Branch is
+  3 months stale, 1,198 files diverged from main, a straight merge is
+  catastrophic.
+- `e4142c7f "OAuth framework production-ready"` (on main) — a 41-file
+  bundle that ships **partial** OAuth framework: `WordPressOAuthContentManager`
+  bearer mirror, `_check_wix_token` 1d/24h/3-attempt logic,
+  `_PLATFORM_CHECKS` dispatch in `get_connected_platforms`, 56 OAuth tests
+  passing, and the `oauth_callback_utils.py` shared callback HTML
+  generator. But the per-provider **token storage** is not common — 4
+  services each implement their own.
+
+## State of the 4 OAuth services on local main
+
+| Service | LOC | Fernet | `_is_likely_encrypted_blob` | `_migrate_plaintext_tokens_if_needed` | `_initialize_fernet` failure mode |
+|---|---|---|---|---|---|
+| `WixOAuthService` | 505 | ✅ | ✅ | ✅ | warn + return None |
+| `WordPressOAuthService` | 506 | ✅ | ✅ | ✅ | warn + return None |
+| `BingOAuthService` | 971 | **❌ plaintext** | **❌** | **❌** | n/a |
+| `YouTubeOAuthService` | 493 | ✅ | ✅ | ✅ | **raise on missing** (different) |
+
+`_initialize_fernet`, `_encrypt_token`, `_decrypt_token`, `_is_likely_encrypted_blob`,
+`_migrate_plaintext_tokens_if_needed` are **word-for-word the same** in Wix and
+WordPress, and nearly identical in YouTube. Bing lacks all of them.
+
+## Plan: 3 small commits on local main only
+
+Per the user's directive ("work on local main only, not multiple branches"),
+no new branches. Per the audit, all work lands on main directly.
+
+### Step 1 — Bing token encryption (P0, security)
+
+**File**: `backend/services/integrations/bing_oauth.py`
+
+**What**:
+- Add `_initialize_fernet`, `_encrypt_token`, `_decrypt_token`,
+  `_is_likely_encrypted_blob`, `_migrate_plaintext_tokens_if_needed`
+  matching the Wix/WordPress pattern
+- New env var: `BING_TOKEN_ENCRYPTION_KEY` (falls back to
+  `OAUTH_TOKEN_ENCRYPTION_KEY`)
+- Modify `store_tokens` and `update_tokens` to encrypt access/refresh
+  before insert
+- Modify `get_user_tokens` and `get_user_token_status` to decrypt
+  on read, with the same try/except + skip-on-InvalidToken behavior Wix uses
+- Add the `_migrate_plaintext_tokens_if_needed` call to the read paths
+
+**Net**: +60 lines, fixes real security gap.
+
+**Test**: existing Bing tests must still pass; add 1 round-trip
+encryption test.
+
+**Risk**: low — only changes internal token storage format, not the
+public API.
+
+### Step 2 — Extract `OAuthProviderBase` (P1, dedup)
+
+**New file**: `backend/services/integrations/oauth_provider_base.py` (~120 lines)
+
+**What**:
+- Pull `_initialize_fernet`, `_encrypt_token`, `_decrypt_token`,
+  `_is_likely_encrypted_blob`, `_migrate_plaintext_tokens_if_needed`,
+  `_get_db_path` into a single base class
+- `WixOAuthService`, `WordPressOAuthService`, `YouTubeOAuthService`,
+  `BingOAuthService` all inherit from it
+- Each provider keeps its own `__init__` (provider-specific client
+  config), `_init_db` (provider-specific schema), and
+  `generate_authorization_url` / `handle_oauth_callback` (provider-specific
+  OAuth flow)
+- Resolve the Fernet failure-mode inconsistency: base class returns
+  `Optional[Fernet]` (matches Wix/WordPress; YouTube currently raises).
+  This is also addressed in step 3.
+
+**Net**: -150 lines (3 services × ~50 lines duplicate removed, +120
+lines base class added).
+
+**Test**: 56 existing OAuth tests must still pass (mocking pattern
+preserved). Add 1 base-class unit test.
+
+**Risk**: low — mechanical refactor, no behavior change.
+
+### Step 3 — Normalize YouTube's `_initialize_fernet` to return None (P2, consistency)
+
+**File**: `backend/services/youtube/youtube_oauth_service.py`
+
+**What**: change `_initialize_fernet` to return `Optional[Fernet]` and
+log a warning instead of raising on missing key. Token ops then fail with
+a clearer error than "Fernet is None" deep in the call stack.
+
+**Alternative**: invert the base class to require Fernet at
+construction (constructor raises). The user's "we can't tolerate
+fallbacks" mandate suggests this. **Decision pending sign-off** — both
+options are valid. If inverted, this commit becomes a one-line change
+to the base class constructor (not YouTube-specific).
+
+## Out of scope
+
+- **Merging `c66f2c1d`**: dead scaffolding, 3 months stale, would
+  require 1,198-file merge with massive conflicts. Skip.
+- **Per-CRUD-method template-method refactor** (`store_tokens` /
+  `get_user_tokens` / `update_tokens` / `get_user_token_status` /
+  `revoke_token` / `get_connection_status`): 3 of 4 services duplicate
+  ~50 lines each, but the SQL differs per provider. Would save another
+  ~150 lines but the template-method risk is higher (~3 days work). Defer
+  to a separate phase.
+- **Frontend unification**: per-platform `wordpressOAuth.ts` /
+  `bingOAuth.ts` could become a single `oauthClient.ts`. The c66f2c1d
+  scaffolding was an attempt at this but was 3 months stale. Defer to
+  a separate phase.
+- **Deleting the `common-oauth-framework` branch**: branch still exists
+  locally. After the 3 commits ship and pass review, deleting it is
+  safe. Not part of this plan.
+
+## Verification
+
+After each step:
+- All 56 existing OAuth tests pass
+- New tests for the step's behavior pass
+- No regression in `routes/strategies.py` / `routes/wix_routes.py` /
+  `routes/wordpress_oauth.py` / `routes/bing_oauth.py` etc.
+- Manual smoke test: connect + disconnect one OAuth flow per
+  provider (Wix, WordPress, Bing, YouTube) and confirm tokens are
+  encrypted at rest in the SQLite DB
+
+## Estimated effort
+
+- Step 1: 30-60 min
+- Step 2: 2-3 hours
+- Step 3: 30 min
+- Total: ~3-4 hours, 3 commits on local main

--- a/frontend/src/components/OnboardingWizard/PersonaStep/PersonaPreviewSection.tsx
+++ b/frontend/src/components/OnboardingWizard/PersonaStep/PersonaPreviewSection.tsx
@@ -24,6 +24,19 @@ import {
 import { CorePersonaDisplay } from './sections/CorePersonaDisplay';
 import { PlatformPersonaDisplay } from './sections/PlatformPersonaDisplay';
 import { QualityMetricsDisplay } from './QualityMetricsDisplay';
+import { HowWeBuiltThisPersona } from './sections/HowWeBuiltThisPersona';
+
+/**
+ * Phase 2 (merge): when `true`, the "How well did we capture your voice?"
+ * accordion is replaced by the merged "How we built this persona"
+ * accordion (which contains all 3 sub-sections), AND the
+ * EvidenceAccordion inside CorePersonaDisplay is hidden. When `false`
+ * (default), the original 2-accordion UX is preserved.
+ *
+ * Default: `false` — old behavior. Flip to `true` to opt into the
+ * merged accordion (Phase 3 of the merge plan).
+ */
+const MERGED_PERSONA_ACCORDION = false;
 
 interface PersonaPreviewSectionProps {
   showPreview: boolean;
@@ -154,6 +167,7 @@ export const PersonaPreviewSection: React.FC<PersonaPreviewSectionProps> = ({
               }}
               completeness={completeness}
               data_sufficiency={data_sufficiency}
+              hideEvidenceAccordion={MERGED_PERSONA_ACCORDION}
             />
           </AccordionDetails>
         </Accordion>
@@ -266,79 +280,93 @@ export const PersonaPreviewSection: React.FC<PersonaPreviewSectionProps> = ({
           </AccordionDetails>
         </Accordion>
 
-        {/* Quality Metrics */}
+        {/* Phase 2 (merge): the "How well did we capture your voice?"
+            quality accordion is replaced by the merged "How we built
+            this persona" accordion when MERGED_PERSONA_ACCORDION is on.
+            Old path stays so we can flip the flag off if it breaks. */}
         {qualityMetrics && (
-          <Accordion
-            expanded={expandedAccordion === 'quality'}
-            onChange={() => setExpandedAccordion(expandedAccordion === 'quality' ? false : 'quality')}
-            sx={{
-              mb: 4,
-              background: 'linear-gradient(135deg, #ffffff 0%, #f8fafc 100%)',
-              border: '1px solid #e2e8f0',
-              borderRadius: 3,
-              boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.05)',
-              '&:before': {
-                display: 'none'
-              },
-              '&.Mui-expanded': {
-                boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1)'
-              }
-            }}
-          >
-            <AccordionSummary
-              expandIcon={<ExpandMoreIcon sx={{ color: '#64748b' }} />}
+          MERGED_PERSONA_ACCORDION ? (
+            <Box sx={{ mb: 4 }}>
+              <HowWeBuiltThisPersona
+                persona={corePersona}
+                completeness={completeness}
+                data_sufficiency={data_sufficiency}
+                qualityMetrics={qualityMetrics}
+              />
+            </Box>
+          ) : (
+            <Accordion
+              expanded={expandedAccordion === 'quality'}
+              onChange={() => setExpandedAccordion(expandedAccordion === 'quality' ? false : 'quality')}
               sx={{
-                px: 4,
-                py: 3,
-                '&:hover': {
-                  backgroundColor: '#f8fafc'
+                mb: 4,
+                background: 'linear-gradient(135deg, #ffffff 0%, #f8fafc 100%)',
+                border: '1px solid #e2e8f0',
+                borderRadius: 3,
+                boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.05)',
+                '&:before': {
+                  display: 'none'
+                },
+                '&.Mui-expanded': {
+                  boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1)'
                 }
               }}
             >
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 3, width: '100%' }}>
-                <Box
-                  sx={{
-                    p: 2,
-                    borderRadius: 2,
-                    background: 'linear-gradient(135deg, #10b981 0%, #059669 100%)',
-                    color: 'white',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center'
-                  }}
-                >
-                  <AssessmentIcon sx={{ fontSize: 24 }} />
+              <AccordionSummary
+                expandIcon={<ExpandMoreIcon sx={{ color: '#64748b' }} />}
+                sx={{
+                  px: 4,
+                  py: 3,
+                  '&:hover': {
+                    backgroundColor: '#f8fafc'
+                  }
+                }}
+              >
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 3, width: '100%' }}>
+                  <Box
+                    sx={{
+                      p: 2,
+                      borderRadius: 2,
+                      background: 'linear-gradient(135deg, #10b981 0%, #059669 100%)',
+                      color: 'white',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center'
+                    }}
+                  >
+                    <AssessmentIcon sx={{ fontSize: 24 }} />
+                  </Box>
+                  <Box sx={{ flex: 1 }}>
+                    <Typography variant="h6" sx={{ fontWeight: 600, color: '#1e293b', mb: 0.5 }}>
+                      How well did we capture your voice?
+                    </Typography>
+                    <Typography variant="body2" sx={{ color: '#64748b' }}>
+                      Plain-English breakdown of every score, plus a confidence badge and the data gaps the AI couldn't fill.
+                    </Typography>
+                  </Box>
+                  <Chip
+                    label={`${qualityMetrics.overall_score}% Quality`}
+                    sx={{
+                      background: qualityMetrics.overall_score >= 85
+                        ? 'linear-gradient(135deg, #10b981 0%, #059669 100%)'
+                        : qualityMetrics.overall_score >= 70
+                        ? 'linear-gradient(135deg, #f59e0b 0%, #d97706 100%)'
+                        : 'linear-gradient(135deg, #ef4444 0%, #dc2626 100%)',
+                      color: 'white',
+                      fontWeight: 600,
+                      '& .MuiChip-label': {
+                        px: 2
+                      }
+                    }}
+                    size="small"
+                  />
                 </Box>
-                <Box sx={{ flex: 1 }}>
-                  <Typography variant="h6" sx={{ fontWeight: 600, color: '#1e293b', mb: 0.5 }}>
-                    How well did we capture your voice?
-                  </Typography>
-                  <Typography variant="body2" sx={{ color: '#64748b' }}>
-                    Plain-English breakdown of every score, plus a confidence badge and the data gaps the AI couldn't fill.
-                  </Typography>
-                </Box>
-                <Chip
-                  label={`${qualityMetrics.overall_score}% Quality`}
-                  sx={{
-                    background: qualityMetrics.overall_score >= 85
-                      ? 'linear-gradient(135deg, #10b981 0%, #059669 100%)'
-                      : qualityMetrics.overall_score >= 70
-                      ? 'linear-gradient(135deg, #f59e0b 0%, #d97706 100%)'
-                      : 'linear-gradient(135deg, #ef4444 0%, #dc2626 100%)',
-                    color: 'white',
-                    fontWeight: 600,
-                    '& .MuiChip-label': {
-                      px: 2
-                    }
-                  }}
-                  size="small"
-                />
-              </Box>
-            </AccordionSummary>
-            <AccordionDetails sx={{ px: 4, pb: 4 }}>
-              <QualityMetricsDisplay metrics={qualityMetrics} corePersona={corePersona} />
-            </AccordionDetails>
-          </Accordion>
+              </AccordionSummary>
+              <AccordionDetails sx={{ px: 4, pb: 4 }}>
+                <QualityMetricsDisplay metrics={qualityMetrics} corePersona={corePersona} />
+              </AccordionDetails>
+            </Accordion>
+          )
         )}
       </Box>
     </Fade>

--- a/frontend/src/components/OnboardingWizard/PersonaStep/sections/CorePersonaDisplay.tsx
+++ b/frontend/src/components/OnboardingWizard/PersonaStep/sections/CorePersonaDisplay.tsx
@@ -24,6 +24,14 @@ interface CorePersonaDisplayProps {
   } | null;
   /** Phase 2: data-sufficiency (0-100) from the backend. */
   data_sufficiency?: number | null;
+  /**
+   * Phase 2 (merge): when the merged "How we built this persona"
+   * accordion is enabled at the PersonaPreviewSection level, the old
+   * EvidenceAccordion here is redundant. Pass `true` to hide it. The
+   * default is `false` (current behavior — both render) so flipping
+   * the merge flag off is risk-free.
+   */
+  hideEvidenceAccordion?: boolean;
 }
 
 /**
@@ -35,6 +43,7 @@ export const CorePersonaDisplay: React.FC<CorePersonaDisplayProps> = ({
   onChange,
   completeness,
   data_sufficiency,
+  hideEvidenceAccordion = false,
 }) => {
   // Helper function to update nested fields
   const updateField = (path: string[], value: any) => {
@@ -529,7 +538,9 @@ export const CorePersonaDisplay: React.FC<CorePersonaDisplayProps> = ({
            brand's content, what_was_missing gaps, confidence score). The
            data was already returned by the backend; the rest of the UI
            was just hiding it. */}
-      <EvidenceAccordion persona={persona} completeness={completeness} data_sufficiency={data_sufficiency} />
+      {!hideEvidenceAccordion && (
+        <EvidenceAccordion persona={persona} completeness={completeness} data_sufficiency={data_sufficiency} />
+      )}
 
       {/* 5. Persona Generation Summary */}
       <SectionAccordion

--- a/frontend/src/components/OnboardingWizard/PersonaStep/sections/HowWeBuiltThisPersona.tsx
+++ b/frontend/src/components/OnboardingWizard/PersonaStep/sections/HowWeBuiltThisPersona.tsx
@@ -1,0 +1,623 @@
+import React, { useMemo } from 'react';
+import {
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Typography,
+  Box,
+  Avatar,
+  Chip,
+  LinearProgress,
+  Stack,
+  Divider,
+  Tooltip
+} from '@mui/material';
+import {
+  ExpandMore as ExpandMoreIcon,
+  VerifiedUser as VerifiedUserIcon,
+  Lightbulb as LightbulbIcon,
+  FormatQuote as FormatQuoteIcon,
+  WarningAmber as WarningAmberIcon,
+  CheckCircleOutline as CheckCircleOutlineIcon,
+  ChatBubbleOutline as ChatBubbleOutlineIcon,
+  Theaters as TheatersIcon,
+  AutoAwesome as AutoAwesomeIcon,
+  MusicNote as MusicNoteIcon,
+  Assessment as AssessmentIcon
+} from '@mui/icons-material';
+import { QualityMetricsDisplay } from '../QualityMetricsDisplay';
+
+/**
+ * Phase 2 of the persona-accordion merge (see persona-accordion-merge.md).
+ *
+ * This component replaces the 2 separate accordions
+ *   - "How well did we capture your voice?" (quality scores)
+ *   - "How we built this persona" (evidence + gaps)
+ * with a single combined accordion titled "How we built this persona"
+ * that has 3 numbered sub-sections:
+ *   1. Output quality   (from QualityMetricsDisplay)
+ *   2. Confidence & evidence (confidence bar, Why-rows, phrases)
+ *   3. Data we didn't have   (gaps with normalized labels)
+ *
+ * Nothing is dropped — every previous block lives in exactly one of
+ * the 3 sub-sections. The header chip now shows two scores + gap
+ * count, so the user can tell at a glance which kind of score is
+ * which (output quality vs LLM self-rating vs structural completeness).
+ *
+ * Defaults: collapsed (matches existing behavior), no animation,
+ * same MUI theme tokens as the rest of the persona preview.
+ */
+
+interface HowWeBuiltThisPersonaProps {
+  /** The core persona object (the same shape passed to the old
+   *  EvidenceAccordion). */
+  persona: any;
+  /** Deterministic completeness payload from the backend. */
+  completeness?: {
+    score?: number | null;
+    structural_score?: number | null;
+    missing?: string[] | null;
+  } | null;
+  /** Data-sufficiency score (0-100) from the backend. */
+  data_sufficiency?: number | null;
+  /** Output-quality metrics (the same shape QualityMetricsDisplay
+   *  already accepts). */
+  qualityMetrics?: any;
+}
+
+/**
+ * Convert a 0-1 confidence score to a colour band.
+ *  - >= 0.7  : green   (rich, multi-source data)
+ *  - 0.4-0.7 : amber  (some gaps but usable)
+ *  - < 0.4   : red    (data-thin — needs more inputs)
+ *
+ * Lowercase labels match the post-PR-#732 casing convention.
+ */
+function confidenceTone(score: number | null | undefined): {
+  label: string;
+  color: 'success' | 'warning' | 'error';
+  bg: string;
+  pct: number;
+} {
+  if (score === null || score === undefined || isNaN(score)) {
+    return { label: 'no confidence reported', color: 'warning', bg: '#fef3c7', pct: 0 };
+  }
+  const pct = Math.max(0, Math.min(1, score));
+  if (pct >= 0.7) return { label: 'high confidence', color: 'success', bg: '#dcfce7', pct };
+  if (pct >= 0.4) return { label: 'moderate confidence', color: 'warning', bg: '#fef3c7', pct };
+  return { label: 'low confidence — data is thin', color: 'error', bg: '#fee2e2', pct };
+}
+
+/**
+ * Pick a non-empty string from a value that may be string / null / 'null' / undefined.
+ * Treats `'null'`, `'none'`, `'n/a'`, empty strings as missing — the LLM
+ * sometimes returns the literal string 'null' when it means absent.
+ */
+function clean(value: any): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const lower = trimmed.toLowerCase();
+  if (lower === 'null' || lower === 'none' || lower === 'n/a') return null;
+  return trimmed;
+}
+
+/**
+ * Normalize a single missing-data entry to a user-facing chip label.
+ * Identical logic to the helper in EvidenceAccordion.tsx (PR #732).
+ * Strips the backend's "(reported) " prefix, replaces underscores
+ * with spaces, lowercases, and prefixes "we didn't have" when
+ * the entry is a bare field name (vs. a free-form LLM sentence).
+ */
+function missingLabel(raw: string): string {
+  let s = String(raw || '').trim();
+  if (!s) return '';
+  s = s.replace(/^\(reported\)\s+/i, '');
+  s = s.replace(/_/g, ' ').replace(/\s+/g, ' ').trim().toLowerCase();
+  if (!s) return '';
+  if (/[a-zA-Z]/.test(s[0] || '') && /\s/.test(s)) {
+    if (/^(no |not |missing )/.test(s)) return s;
+    return `we didn't have ${s}`;
+  }
+  return `we didn't have ${s.toLowerCase()}`;
+}
+
+/**
+ * Dedupe + count missing-data entries. Combines the backend's
+ * structural `completeness.missing` array with the LLM's free-form
+ * `persona.what_was_missing` array. Strips the "(reported) " prefix
+ * the backend uses to mark LLM-copied strings so duplicates collapse.
+ */
+function deriveGaps(completeness: any, llmMissing: string[]): {
+  count: number;
+  labels: string[];
+} {
+  const seenNorm = new Set<string>();
+  const labels: string[] = [];
+  const add = (raw: any) => {
+    const label = missingLabel(String(raw || ''));
+    if (!label) return;
+    const norm = label.toLowerCase().trim();
+    if (seenNorm.has(norm)) return;
+    seenNorm.add(norm);
+    labels.push(label);
+  };
+  if (Array.isArray(completeness?.missing)) {
+    completeness.missing.forEach(add);
+  }
+  llmMissing.forEach(add);
+  return { count: labels.length, labels };
+}
+
+/**
+ * A "question → answer" citation row used in sub-section 2.
+ * Reused from the old EvidenceAccordion; kept here (instead of in
+ * a shared file) because it's a 20-liner and only used here now.
+ */
+const EvidenceRow: React.FC<{
+  question: string;
+  answer: string;
+  accent: string;
+  icon?: React.ReactNode;
+}> = ({ question, answer, accent, icon }) => (
+  <Box
+    sx={{
+      p: 1.5,
+      borderRadius: 1.5,
+      backgroundColor: '#f8fafc',
+      borderLeft: `3px solid ${accent}`,
+    }}
+  >
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5, color: accent }}>
+      {icon}
+      <Typography variant="body2" sx={{ fontWeight: 600, color: '#0f172a' }}>
+        {question}
+      </Typography>
+    </Box>
+    <Typography variant="body2" sx={{ color: '#475569', lineHeight: 1.55, pl: icon ? 3.25 : 0 }}>
+      {answer}
+    </Typography>
+  </Box>
+);
+
+export const HowWeBuiltThisPersona: React.FC<HowWeBuiltThisPersonaProps> = ({
+  persona,
+  completeness,
+  data_sufficiency,
+  qualityMetrics,
+}) => {
+  // -------- Sub-section 2/3 inputs (confidence, evidence, gaps) --------
+  const evidence = persona?.evidence ?? {};
+  const confidence = persona?.confidence;
+  // Wrapped in useMemo so the `gaps` useMemo below has a stable dep
+  // (otherwise the linter flags it and the cache invalidates every
+  // render anyway, which defeats the point of memoizing).
+  const missing: string[] = useMemo(
+    () => (Array.isArray(persona?.what_was_missing)
+      ? persona.what_was_missing.filter((s: any) => clean(s))
+      : []),
+    [persona?.what_was_missing],
+  );
+
+  // Phase 2: blend the LLM's self-rated confidence with the backend's
+  // structural completeness (60% LLM, 40% structural) so a confident LLM
+  // can't paper over real gaps.
+  const blendedConfidence = useMemo(() => {
+    const llm = typeof confidence === 'number' ? confidence : null;
+    const structural = typeof completeness?.structural_score === 'number'
+      ? completeness.structural_score
+      : null;
+    if (llm === null && structural === null) return null;
+    if (llm === null) return structural;
+    if (structural === null) return llm;
+    return 0.6 * llm + 0.4 * structural;
+  }, [confidence, completeness]);
+
+  const gaps = useMemo(
+    () => deriveGaps(completeness, missing),
+    [completeness, missing],
+  );
+
+  const tone = useMemo(() => confidenceTone(blendedConfidence), [blendedConfidence]);
+
+  const nameBasis = clean(evidence.persona_name_basis);
+  const archetypeBasis = clean(evidence.archetype_basis);
+  const beliefBasis = clean(evidence.core_belief_basis);
+  const toneBasis = clean(evidence.tone_basis);
+  const verbatimPhrases: string[] = Array.isArray(evidence.verbatim_phrases_used)
+    ? evidence.verbatim_phrases_used.filter((s: any) => clean(s))
+    : [];
+
+  const identity = persona?.identity ?? {};
+  const personaName = clean(identity.persona_name);
+  const archetype = clean(identity.archetype);
+
+  // -------- Header chip inputs (two scores + gap count) --------
+  const outputQualityPct = typeof qualityMetrics?.overall_score === 'number'
+    ? Math.round(qualityMetrics.overall_score)
+    : null;
+
+  const confidencePct = blendedConfidence !== null
+    ? Math.round(tone.pct * 100)
+    : null;
+
+  // Compose the header chip: "X% output quality · Y% confidence · N gaps"
+  // Each segment is rendered as a separate small chip so the user can
+  // see at a glance which number is which. We omit segments that are
+  // missing rather than showing "—%".
+  const chipSegments: { label: string; bg: string; color: string }[] = [];
+  if (outputQualityPct !== null) {
+    chipSegments.push({
+      label: `${outputQualityPct}% output quality`,
+      bg: outputQualityPct >= 85
+        ? 'linear-gradient(135deg, #10b981 0%, #059669 100%)'
+        : outputQualityPct >= 70
+        ? 'linear-gradient(135deg, #f59e0b 0%, #d97706 100%)'
+        : 'linear-gradient(135deg, #ef4444 0%, #dc2626 100%)',
+      color: 'white',
+    });
+  }
+  if (confidencePct !== null) {
+    chipSegments.push({
+      label: `${confidencePct}% confidence`,
+      bg: tone.color === 'success' ? '#dcfce7' : tone.color === 'warning' ? '#fef3c7' : '#fee2e2',
+      color: tone.color === 'success' ? '#065f46' : tone.color === 'warning' ? '#92400e' : '#991b1b',
+    });
+  }
+  if (gaps.count > 0) {
+    chipSegments.push({
+      label: `${gaps.count} gap${gaps.count === 1 ? '' : 's'}`,
+      bg: '#fde68a',
+      color: '#78350f',
+    });
+  }
+
+  // Has at least one of the 3 sub-sections got something to show?
+  const hasSub1 = !!qualityMetrics;
+  const hasSub2 = blendedConfidence !== null
+    || !!nameBasis || !!archetypeBasis || !!beliefBasis || !!toneBasis
+    || verbatimPhrases.length > 0;
+  const hasSub3 = gaps.count > 0;
+  const hasAnyContent = hasSub1 || hasSub2 || hasSub3;
+
+  return (
+    <Accordion
+      defaultExpanded={false}
+      sx={{
+        mb: 1.5,
+        borderRadius: 2,
+        background: 'linear-gradient(180deg, #f8fafc 0%, #ffffff 100%)',
+        border: '1px solid #cbd5e1',
+        width: '100%',
+        maxWidth: '100%',
+        '&:before': { display: 'none' },
+        boxShadow: '0 1px 3px rgba(0, 0, 0, 0.08)',
+        '&.Mui-expanded': { boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)' },
+      }}
+    >
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        sx={{
+          px: 2,
+          py: 1.5,
+          '&.Mui-expanded': { minHeight: 56 },
+          '& .MuiAccordionSummary-content': { my: 0, '&.Mui-expanded': { my: 0 } },
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, width: '100%' }}>
+          <Avatar sx={{ bgcolor: tone.color + '.main', width: 32, height: 32 }}>
+            <VerifiedUserIcon fontSize="small" />
+          </Avatar>
+
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography variant="h6" fontWeight="600" sx={{ fontSize: '1rem', color: '#1e293b' }}>
+              How we built this persona
+            </Typography>
+            <Typography variant="body2" sx={{ color: '#64748b', fontSize: '0.875rem' }}>
+              {hasAnyContent
+                ? 'Output quality, evidence, and data gaps from the AI'
+                : 'No evidence layer was returned for this persona'}
+            </Typography>
+          </Box>
+
+          {/* Two-scores + gap-count chip cluster */}
+          {chipSegments.length > 0 && (
+            <Stack direction="row" spacing={0.75} sx={{ flexShrink: 0, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+              {chipSegments.map((seg, i) => (
+                <Chip
+                  key={i}
+                  label={seg.label}
+                  size="small"
+                  sx={{
+                    fontWeight: 700,
+                    background: seg.bg,
+                    color: seg.color,
+                  }}
+                />
+              ))}
+            </Stack>
+          )}
+        </Box>
+      </AccordionSummary>
+
+      <AccordionDetails
+        sx={{ pt: 1, pb: 2.5, px: 2, backgroundColor: '#ffffff' }}
+      >
+        {!hasAnyContent ? (
+          <Typography variant="body2" color="text.secondary">
+            The persona you have was generated without the evidence layer (or
+            before it was added to the prompt). Regenerate to get a fully
+            cited persona.
+          </Typography>
+        ) : (
+          <Stack spacing={3}>
+            {/* ============================================================
+                Sub-section 1: Output quality
+                Reuses the existing QualityMetricsDisplay component — its
+                internal radial chart, bar chart, 4 sub-scores, and
+                recommendations are all kept. Nothing is dropped.
+                ============================================================ */}
+            {hasSub1 && (
+              <Box>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+                  <AssessmentIcon sx={{ fontSize: 18, color: '#7c3aed' }} />
+                  <Typography variant="subtitle1" sx={{ fontWeight: 700, color: '#0f172a' }}>
+                    1. Output quality
+                  </Typography>
+                  <Typography variant="caption" sx={{ color: '#64748b', ml: 1 }}>
+                    How well we generated the persona
+                  </Typography>
+                </Box>
+                <QualityMetricsDisplay metrics={qualityMetrics} corePersona={persona} />
+              </Box>
+            )}
+
+            {/* ============================================================
+                Sub-section 2: Confidence & evidence
+                ============================================================ */}
+            {(blendedConfidence !== null || !!nameBasis || !!archetypeBasis || !!beliefBasis || !!toneBasis || verbatimPhrases.length > 0) && (
+              <Box>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+                  <LightbulbIcon sx={{ fontSize: 18, color: '#7c3aed' }} />
+                  <Typography variant="subtitle1" sx={{ fontWeight: 700, color: '#0f172a' }}>
+                    2. Confidence & evidence
+                  </Typography>
+                  <Typography variant="caption" sx={{ color: '#64748b', ml: 1 }}>
+                    How grounded the claims are
+                  </Typography>
+                </Box>
+
+                {/* 2a. Confidence bar */}
+                {blendedConfidence !== null && (
+                  <Box sx={{ mb: 2.5 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.75 }}>
+                      <VerifiedUserIcon sx={{ fontSize: 18, color: tone.color + '.main' }} />
+                      <Typography variant="subtitle2" sx={{ fontWeight: 700, color: '#0f172a' }}>
+                        Persona confidence
+                      </Typography>
+                      <Tooltip
+                        arrow
+                        title={
+                          <Box>
+                            <Typography variant="caption" sx={{ fontWeight: 700, display: 'block' }}>
+                              What this means
+                            </Typography>
+                            <Typography variant="caption" sx={{ display: 'block', opacity: 0.9 }}>
+                              The AI rated its own confidence and the backend blended it
+                              with the structural completeness of the returned fields
+                              (60% LLM self-rating, 40% structural completeness). Higher
+                              = more data was available, fewer gaps, less guessing.
+                              {typeof data_sufficiency === 'number' && (
+                                <> {' '}Source-data sufficiency: {Math.round(data_sufficiency)}%.</>
+                              )}
+                            </Typography>
+                          </Box>
+                        }
+                      >
+                        <VerifiedUserIcon sx={{ fontSize: 14, color: '#9ca3af', cursor: 'help' }} />
+                      </Tooltip>
+                    </Box>
+                    <LinearProgress
+                      variant="determinate"
+                      value={tone.pct * 100}
+                      color={tone.color}
+                      sx={{ height: 8, borderRadius: 4, backgroundColor: '#e2e8f0' }}
+                    />
+                    <Typography variant="caption" sx={{ color: '#64748b', display: 'block', mt: 0.5 }}>
+                      {Math.round(tone.pct * 100)}% — {tone.label}
+                    </Typography>
+                  </Box>
+                )}
+
+                {/* 2b. Why the AI said what it said */}
+                {(nameBasis || archetypeBasis || beliefBasis || toneBasis) && (
+                  <Box sx={{ mb: 2.5 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                      <LightbulbIcon sx={{ fontSize: 16, color: '#7c3aed' }} />
+                      <Typography variant="subtitle2" sx={{ fontWeight: 700, color: '#0f172a' }}>
+                        Why the AI said what it said
+                      </Typography>
+                    </Box>
+                    <Stack spacing={1.25}>
+                      {nameBasis && (
+                        <EvidenceRow
+                          icon={<ChatBubbleOutlineIcon sx={{ fontSize: 18 }} />}
+                          question={`Why "${personaName || 'this name'}"?`}
+                          answer={nameBasis}
+                          accent="#7c3aed"
+                        />
+                      )}
+                      {archetypeBasis && (
+                        <EvidenceRow
+                          icon={<TheatersIcon sx={{ fontSize: 18 }} />}
+                          question={`Why "${archetype || 'this archetype'}"?`}
+                          answer={archetypeBasis}
+                          accent="#ec4899"
+                        />
+                      )}
+                      {beliefBasis && (
+                        <EvidenceRow
+                          icon={<AutoAwesomeIcon sx={{ fontSize: 18 }} />}
+                          question="Why this core belief?"
+                          answer={beliefBasis}
+                          accent="#0ea5e9"
+                        />
+                      )}
+                      {toneBasis && (
+                        <EvidenceRow
+                          icon={<MusicNoteIcon sx={{ fontSize: 18 }} />}
+                          question="Why this default tone?"
+                          answer={toneBasis}
+                          accent="#10b981"
+                        />
+                      )}
+                    </Stack>
+                  </Box>
+                )}
+
+                {/* 2c. Verbatim phrases lifted from brand content */}
+                {verbatimPhrases.length > 0 && (
+                  <Box>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                      <FormatQuoteIcon sx={{ fontSize: 16, color: '#0ea5e9' }} />
+                      <Typography variant="subtitle2" sx={{ fontWeight: 700, color: '#0f172a' }}>
+                        Phrases the AI lifted from your content
+                      </Typography>
+                    </Box>
+                    <Typography variant="caption" sx={{ color: '#64748b', display: 'block', mb: 1 }}>
+                      These exact strings appeared in your own writing and influenced the persona.
+                    </Typography>
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                      {verbatimPhrases.map((phrase, idx) => (
+                        <Chip
+                          key={`${phrase}-${idx}`}
+                          label={`"${phrase}"`}
+                          size="small"
+                          sx={{
+                            backgroundColor: '#e0f2fe',
+                            color: '#0c4a6e',
+                            fontWeight: 500,
+                            fontStyle: 'italic',
+                            border: '1px solid #bae6fd',
+                          }}
+                        />
+                      ))}
+                    </Box>
+                  </Box>
+                )}
+              </Box>
+            )}
+
+            {/* ============================================================
+                Sub-section 3: Data we didn't have
+                ============================================================ */}
+            {hasSub3 ? (
+              <Box
+                sx={{
+                  p: 2,
+                  borderRadius: 2,
+                  backgroundColor: '#fffbeb',
+                  border: '1px solid #fde68a',
+                }}
+              >
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                  <WarningAmberIcon sx={{ fontSize: 18, color: '#d97706' }} />
+                  <Typography variant="subtitle1" sx={{ fontWeight: 700, color: '#0f172a' }}>
+                    3. Data we didn't have
+                  </Typography>
+                  <Chip
+                    label={`${gaps.count} gap${gaps.count === 1 ? '' : 's'}`}
+                    size="small"
+                    sx={{
+                      ml: 0.5,
+                      backgroundColor: '#fde68a',
+                      color: '#78350f',
+                      fontWeight: 700,
+                      height: 22,
+                      fontSize: '0.75rem',
+                      '& .MuiChip-label': { px: 1 },
+                    }}
+                  />
+                </Box>
+                <Typography variant="caption" sx={{ color: '#92400e', display: 'block', mb: 1.25 }}>
+                  The AI told us these sections were empty or too thin to inform the persona.
+                  Add this data to improve confidence.
+                </Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75, mb: 1.5 }}>
+                  {gaps.labels.map((label, idx) => (
+                    <Chip
+                      key={`${label}-${idx}`}
+                      icon={<WarningAmberIcon sx={{ fontSize: 16 }} />}
+                      label={label}
+                      size="small"
+                      sx={{
+                        backgroundColor: '#fef3c7',
+                        color: '#78350f',
+                        fontWeight: 500,
+                        border: '1px solid #fcd34d',
+                        '& .MuiChip-icon': { color: '#d97706' },
+                      }}
+                    />
+                  ))}
+                </Box>
+                <Tooltip
+                  arrow
+                  title="Re-run Step 2 of onboarding with more complete inputs (e.g. paste more competitor research, add audience data) and regenerate to fill these gaps."
+                >
+                  <Chip
+                    label="Add this data →"
+                    size="small"
+                    color="warning"
+                    onClick={() => {
+                      try {
+                        const event = new CustomEvent('alwrity:navigate-to-step', {
+                          detail: { step: 2 },
+                        });
+                        window.dispatchEvent(event);
+                      } catch {
+                        /* no-op */
+                      }
+                    }}
+                    sx={{ fontWeight: 700, cursor: 'pointer' }}
+                  />
+                </Tooltip>
+              </Box>
+            ) : (
+              /* Positive green state — no gaps */
+              (hasSub2 || hasSub1) && (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    p: 1.5,
+                    borderRadius: 1.5,
+                    backgroundColor: '#ecfdf5',
+                    border: '1px solid #a7f3d0',
+                    color: '#047857',
+                  }}
+                >
+                  <CheckCircleOutlineIcon fontSize="small" />
+                  <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                    The persona was generated with a full data set — no gaps reported.
+                  </Typography>
+                </Box>
+              )
+            )}
+
+            {/* Footer note */}
+            <Divider sx={{ mt: 0.5, mb: 0.5 }} />
+            <Typography variant="caption" sx={{ color: '#94a3b8', display: 'block' }}>
+              The evidence layer is produced by the AI itself as part of the persona
+              generation step. It is shown here verbatim — the AI's own words about
+              why it chose this persona.
+            </Typography>
+          </Stack>
+        )}
+      </AccordionDetails>
+    </Accordion>
+  );
+};
+
+export default HowWeBuiltThisPersona;

--- a/persona-accordion-merge.md
+++ b/persona-accordion-merge.md
@@ -1,0 +1,192 @@
+# Design: Merge the Persona Quality + Evidence Accordions
+
+**Status:** Phase 1 (planning) — no code yet
+**Authors:** opencode (audit + proposal), with user review
+**Last updated:** 2026-06-20
+
+## Background
+
+The Step 4 persona preview currently surfaces three places where the user
+sees a percentage score or "quality" indicator:
+
+1. **"Identity & Brand Voice" accordion header** — chip with `X% Quality`
+   (renders `qualityMetrics.overall_score`).
+2. **"How well did we capture your voice?" accordion** — chip with the
+   same `overall_score` + a `QualityMetricsDisplay` body (4 sub-scores:
+   Brand Voice Accuracy, Platform Consistency, Platform Optimization,
+   Linguistic Quality).
+3. **"How we built this persona" accordion** — chip with `X% confidence`
+   (blended from `persona.confidence` 60% + `completeness.structural_score`
+   40%, with a gap count) + the evidence layer (Why-this-name / Why-this-
+   archetype / verbatim phrases / data gaps).
+
+Places (1) and (2) show the same number. Places (2) and (3) live
+side-by-side with different numbers, different framings, and different
+purposes — which the user finds confusing.
+
+## Why merge (and not just delete one)
+
+The evidence layer provides real value the quality score alone doesn't:
+
+- Links each persona claim to a specific data source (Why-this-name / etc.)
+- Surfaces verbatim phrases the LLM lifted from the user's own content
+- Honestly reports which data sections were empty (so the user can fill them)
+- Blends LLM self-rated confidence with structural completeness for a
+  calibrated "is this a guess or a grounded claim?" signal
+
+Dropping the evidence layer would re-introduce the black-box problem the
+"Your Core Writing Style" Phase 1 plan set out to fix.
+
+## Target shape
+
+A single accordion titled **"How we built this persona"** (name kept) with
+this structure:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ [icon] How we built this persona?                           │
+│        Output quality, evidence, and data gaps.             │
+│        85% output quality · 85% confidence · 5 gaps [chip]  │
+├─────────────────────────────────────────────────────────────┤
+│ ▼ (expanded)                                                │
+│                                                             │
+│  1. Output quality                                          │
+│     ┌─────────────────────────────────────────────────┐    │
+│     │ 4 sub-scores (cards / rows):                    │    │
+│     │   - Brand Voice Accuracy   (30% of overall)     │    │
+│     │   - Platform Consistency   (25% of overall)     │    │
+│     │   - Platform Optimization  (25% of overall)     │    │
+│     │   - Linguistic Quality     (20% of overall)     │    │
+│     │ Each with: value, weight, "what this means",     │    │
+│     │ "how derived", and a tooltip.                   │    │
+│     │ Bottom: overall_score as the section's headline  │    │
+│     └─────────────────────────────────────────────────┘    │
+│                                                             │
+│  2. Confidence & evidence                                   │
+│     ┌─────────────────────────────────────────────────┐    │
+│     │ - Persona confidence progress bar                │    │
+│     │   (blended: 60% LLM, 40% structural)            │    │
+│     │ - "Why the AI said what it said"                 │    │
+│     │   4 Why-rows: name / archetype / belief / tone  │    │
+│     │   with per-question icons                       │    │
+│     │ - "Phrases the AI lifted from your content"     │    │
+│     │   chip array (verbatim_phrases_used)            │    │
+│     └─────────────────────────────────────────────────┘    │
+│                                                             │
+│  3. Data we didn't have                                     │
+│     ┌─────────────────────────────────────────────────┐    │
+│     │ - Amber section with "N gaps" chip in header    │    │
+│     │ - Chips: "we didn't have brand voice analysis"  │    │
+│     │   (normalized via missingLabel() helper)        │    │
+│     │ - "Add this data →" CTA (custom event)          │    │
+│     │ - OR green "no gaps reported" positive state    │    │
+│     └─────────────────────────────────────────────────┘    │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Locked decisions (from user)
+
+| Decision | Value |
+|---|---|
+| Accordion title | **"How we built this persona"** (kept) |
+| Header chip format | `X% output quality · Y% confidence · N gaps` (two scores + gap count) |
+| Existing persona-header "X% Quality" chip | **Drop** (the new accordion's chip replaces it) |
+| Default expand state | **Collapsed** (matches current behavior) |
+
+## Implementation phases
+
+### Phase 1 — Plan (this doc)
+
+- Lock the merge contract above
+- No code changes
+- User review
+
+### Phase 2 — Build behind a feature flag
+
+- New file: `frontend/src/components/OnboardingWizard/PersonaStep/sections/HowWeBuiltThisPersona.tsx`
+- Move the contents of `EvidenceAccordion.tsx` and the accordion shell
+  of `QualityMetricsDisplay.tsx` into it
+- Sub-section 1 renders the existing 4 quality sub-scores (no new
+  math, just a moved shell)
+- Sub-section 2 renders the existing evidence layer (confidence bar +
+  Why-rows + phrases chips)
+- Sub-section 3 renders the existing data-gaps section (with the
+  `missingLabel()` fix from PR #732)
+- `PersonaPreviewSection.tsx` gains a `useFeatureFlag('merged-persona-evidence-accordion')` guard
+- When flag is on: render the new component
+- When flag is off: render the existing 2 accordions (current behavior)
+- Tests: render the new component with realistic persona +
+  completeness + quality metrics; assert all 3 sub-sections render, the
+  chip shows the right numbers, and the gap count is correct
+
+### Phase 3 — Migrate and clean up
+
+- Flip the feature flag on by default
+- Delete `EvidenceAccordion.tsx` (or keep as internal helper if reused)
+- Inline the `QualityMetricsDisplay` accordion shell into the new
+  component (or keep as a sub-component called from the new one)
+- Remove the persona-header "X% Quality" chip from
+  `PersonaPreviewSection.tsx`
+- Remove the `EvidenceAccordion` + `QualityMetricsDisplay` imports
+- Update tests; remove obsolete tests for the deleted components
+- Type-check + smoke-test on a regenerated persona
+
+### Phase 4 — Polish based on real usage
+
+- Add an "expand by default" toggle if the merged accordion proves
+  too hidden
+- Add a "Pin / collapse all" button so users can scan the 5+1 persona
+  accordions quickly
+- Confirm the existing `alwrity:navigate-to-step` event from the
+  "Add this data →" CTA still works in the new layout
+- Re-test: regenerate a persona with rich data, regenerate one with
+  thin data, screenshot both
+- Re-test: the green "no gaps reported" positive state from PR #732
+  still renders
+
+## Risks
+
+- **Phase 2 (feature flag)** — if the new component has a bug, the
+  flag flips off and the user is back to the old behavior. No risk
+  to production.
+- **Phase 3 (delete old code)** — if anything still imports
+  `EvidenceAccordion` or `QualityMetricsDisplay` from the deleted
+  file paths, TypeScript will catch it. The `tsc --noEmit` gate
+  is sufficient.
+- **The persona-header chip drop** — some users may be used to seeing
+  the at-a-glance number in the header. The merged accordion's
+  header chip replaces it (and shows more info), but the visual
+  position changes. Worth screenshotting before/after.
+
+## Out of scope
+
+- Renaming the persona sub-accordions (1-5) — separate concern
+- Adding more quality dimensions to the 4 sub-scores — out of scope
+- Restructuring the persona display beyond accordion 6 — separate work
+- The PR #729 (LinkedIn Unipile) work — orthogonal
+
+## Test plan
+
+- **Unit tests:** all the existing tests for `EvidenceAccordion` and
+  `QualityMetricsDisplay` should still pass after Phase 2 (the new
+  component reuses the same logic).
+- **New tests:** render the merged component with three personas
+  (rich data, thin data, no data) and assert the chip + sub-sections
+  render correctly.
+- **Manual:** regenerate a persona, expand the merged accordion,
+  verify:
+  - Chip shows two scores + gap count
+  - Output quality sub-section shows 4 sub-scores with their weights
+  - Confidence & evidence sub-section shows the progress bar + 4 Why-rows + phrases
+  - Data we didn't have sub-section shows gaps OR green "no gaps" state
+  - "Add this data →" CTA still emits `alwrity:navigate-to-step`
+- **Regression:** persona-header no longer shows the old "X% Quality"
+  chip (this is the only visual change outside the merged accordion)
+- **Accessibility:** accordion remains keyboard-navigable, focus
+  indicators intact, screen-reader labels describe all 3 sub-sections
+
+## Open questions
+
+None currently. The plan above is ready for review. If anything looks
+off, push back before Phase 2 starts.


### PR DESCRIPTION
## Summary

Phase 2 of the persona-accordion merge plan. Builds the merged `HowWeBuiltThisPersona` accordion as a new component that combines the 2 prior accordions into one with 3 numbered sub-sections. **Nothing is dropped** — every previous block lives in exactly one of the 3 sub-sections.

The component is shipped **behind a feature flag (`MERGED_PERSONA_ACCORDION = false`)** so the current 2-accordion UX is the default. Flip the flag to opt into the merge. The flag exists in one place (`PersonaPreviewSection.tsx`) and is a single-line change to flip — Phase 3 of the plan.

## What the merged accordion looks like

```
┌─────────────────────────────────────────────────────────────┐
│ [icon] How we built this persona                           │
│        Output quality, evidence, and data gaps from the AI  │
│        [85% output quality] [85% confidence] [3 gaps]       │
├─────────────────────────────────────────────────────────────┤
│ ▼ (expanded)                                                │
│                                                             │
│  1. Output quality                                          │
│     ┌─────────────────────────────────────────────────┐    │
│     │ QualityMetricsDisplay (radial, bar chart, 4     │    │
│     │ sub-scores: Brand Voice / Consistency /         │    │
│     │ Optimization / Linguistic, recommendations)     │    │
│     └─────────────────────────────────────────────────┘    │
│                                                             │
│  2. Confidence & evidence                                   │
│     ┌─────────────────────────────────────────────────┐    │
│     │ - Persona confidence progress bar               │    │
│     │   (blended 60% LLM + 40% structural)           │    │
│     │ - "Why the AI said what it said"                │    │
│     │   4 Why-rows with per-question icons            │    │
│     │ - Phrases the AI lifted from your content       │    │
│     │   chip array                                    │    │
│     └─────────────────────────────────────────────────┘    │
│                                                             │
│  3. Data we didn't have                                     │
│     ┌─────────────────────────────────────────────────┐    │
│     │ - Amber section with "N gaps" chip in header    │    │
│     │ - Chips: "we didn't have brand voice analysis"  │    │
│     │   (normalized via missingLabel() helper)        │    │
│     │ - "Add this data →" CTA (custom event)          │    │
│     │ - OR green "no gaps reported" positive state    │    │
│     └─────────────────────────────────────────────────┘    │
│                                                             │
└─────────────────────────────────────────────────────────────┘
```

## Header chip: two scores + gap count

- `X% output quality` (green/amber/red based on the 4 sub-scores weighted average)
- `Y% confidence` (lowercase label per PR #732 fix, green/amber/red based on the blend)
- `N gaps` (only shown if N > 0)

Each segment is a separate small chip so the user can tell at a glance which number is which.

## Files

- `frontend/src/components/OnboardingWizard/PersonaStep/sections/HowWeBuiltThisPersona.tsx` (new, 617 lines) — the merged accordion
- `frontend/src/components/OnboardingWizard/PersonaStep/PersonaPreviewSection.tsx` (modified) — added `MERGED_PERSONA_ACCORDION` flag, conditional render, import
- `frontend/src/components/OnboardingWizard/PersonaStep/sections/CorePersonaDisplay.tsx` (modified) — added `hideEvidenceAccordion` prop (default `false`), conditional render

## How the feature flag works

`MERGED_PERSONA_ACCORDION` is a local `const` in `PersonaPreviewSection.tsx` (line 30-ish). When `false`:
- Old `How well did we capture your voice?` accordion renders unchanged
- Old `EvidenceAccordion` (inside `CorePersonaDisplay`) renders unchanged
- Net effect: byte-for-byte identical to the pre-PR behavior

When `true`:
- `HowWeBuiltThisPersona` replaces the old quality accordion
- `EvidenceAccordion` is hidden (via the new `hideEvidenceAccordion` prop on `CorePersonaDisplay`)
- User sees one combined accordion with 3 sub-sections

Phase 3 of the plan will: flip the flag default to `true`, delete `EvidenceAccordion.tsx`, drop the old quality-accordion code path, remove the old persona-header `X% Quality` chip.

## PR-#732 fix carried forward

The new component uses the same fix logic from PR #732 (now merged into main):
- Lowercase confidence labels (`high confidence` not `High confidence`)
- `missingLabel()` helper to normalize chip text (`BRAND_VOICE_ANALYSIS` → `we didn't have brand voice analysis`)
- Dedup `completeness.missing` + LLM `what_was_missing` with the `(reported) ` prefix stripped
- Per-question icons on the 4 Why-rows (chat / theaters / auto-awesome / music-note)
- Green "no gaps reported" positive state when the user has rich data

## Test plan

- [x] 124/124 backend tests pass (no regression in OAuth / Phase 2 / Phase 3 / EvidenceAccordion-label-logic suites)
- [x] `tsc --noEmit` on touched files: 0 new errors
- [x] `eslint` on new file: 0 warnings
- [ ] **Manual QA** (gated on the feature flag — flip it locally, regenerate a persona, verify):
  - All 3 sub-sections render
  - Header chip cluster shows two scores + gap count
  - "Add this data →" CTA still emits `alwrity:navigate-to-step`
  - No regression in the existing quality sub-scores or evidence citations
- [ ] Frontend tests blocked: `@testing-library/dom` missing from the repo (same issue as the pre-existing `PollingIntegration.test.tsx`). Marked as a known issue.

## Out of scope (Phase 3+)

- Flipping the flag default to `true` (Phase 3)
- Deleting `EvidenceAccordion.tsx` (Phase 3)
- Removing the old quality-accordion code path (Phase 3)
- Dropping the persona-header `X% Quality` chip (Phase 3)
- Screenshot tests with rich / thin / no-data personas (Phase 4)
- Expand-by-default or expand-all button (Phase 4)

## Risk

- **Zero production risk by default** — flag is `false`, so nothing renders differently for end users until you flip it.
- **When you do flip the flag**, the new component has been verified by inspection + lint + type-check. Manual QA on a regenerated persona is the next step before Phase 3.
- The merged accordion reuses the existing `QualityMetricsDisplay` component unchanged — so the rich UI there (radial chart, bar chart, 4 sub-score rows with tooltips) is identical to the old behavior.

## Note on branch lineage

This is a fresh branch (`feat/merge-persona-accordion-phase2-v2`) from a rebase onto current main. Same 3 files as v1, but v1 was based on an older main tip before PR #732 landed. Use this one.
