### PR TITLE
Feat/Unipile Connection & LinkedIn Analysis Context Pipeline (Clean Rebase)

### DIFF
--- a/backend/alwrity_utils/router_manager.py
+++ b/backend/alwrity_utils/router_manager.py
@@ -28,6 +28,8 @@ CORE_ROUTER_REGISTRY = [
     {"name": "seo_tools", "module": "routers.seo_tools", "attr": "router", "features": {"all", "core", "seo"}},
     {"name": "facebook_writer", "module": "api.facebook_writer.routers", "attr": "facebook_router", "features": {"all", "core", "facebook"}},
     {"name": "linkedin", "module": "routers.linkedin", "attr": "router", "features": {"all", "core", "linkedin"}},
+    {"name": "linkedin_social", "module": "api.linkedin_social_routes", "attr": "router", "features": {"all", "core", "linkedin"}},
+    {"name": "unipile_webhook", "module": "api.unipile_webhook_routes", "attr": "router", "features": {"all", "core", "linkedin"}},
     {"name": "linkedin_image", "module": "api.linkedin_image_generation", "attr": "router", "features": {"all", "core", "linkedin"}},
     {"name": "linkedin_video", "module": "api.linkedin_video_generation", "attr": "router", "features": {"all", "core", "linkedin"}},
     {"name": "brainstorm", "module": "api.brainstorm", "attr": "router", "features": {"all", "core"}},

--- a/backend/api/linkedin_social_routes.py
+++ b/backend/api/linkedin_social_routes.py
@@ -1,0 +1,1593 @@
+"""
+LinkedIn Social API routes (Growth Engine — connect, analytics).
+
+Separate from routers/linkedin.py (content generation / LinkedIn Writer).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse
+from fastapi.security import HTTPAuthorizationCredentials
+from loguru import logger
+from pydantic import BaseModel
+
+from middleware.auth_middleware import clerk_auth, get_current_user, security
+from models.linkedin_social_models import (
+    LinkedInAccountsListResponse,
+    LinkedInAccountResponse,
+    LinkedInAnalyticsResponse,
+    LinkedInConnectionStatusResponse,
+    LinkedInLandingAnalyticsResponse,
+    LinkedInOrganizationResponse,
+    LinkedInOrganizationsListResponse,
+    LinkedInPersonalAnalyticsResponse,
+    LinkedInProfileAcquireResponse,
+    LinkedInProfileCompleteRequest,
+    LinkedInProfileCompleteResponse,
+    LinkedInProfileContextMetaResponse,
+    LinkedInProfileMetaResponse,
+    AIProfileIntelligenceResponse,
+    CompletionQuestionResponse,
+    ProfileCompletionResponse,
+    ProfileIntelligenceMetaResponse,
+    ProfileAnalysisErrorResponse,
+    ProfileValidationResponse,
+    TopicRecommendationResponse,
+    TopicRecommendationsMetaResponse,
+)
+from services.integrations.linkedin.profile_intelligence_llm import ProfileIntelligenceLLMError
+from services.integrations.linkedin.profile_intelligence_service import (
+    ProfileIntelligenceAcquireMeta,
+    ProfileIntelligenceError,
+    get_or_generate_profile_intelligence,
+)
+from services.integrations.linkedin.profile_intelligence_validator import (
+    ProfileIntelligenceValidationError,
+)
+from services.integrations.linkedin.topic_recommendation_llm import TopicRecommendationLLMError
+from services.integrations.linkedin.topic_recommendation_service import (
+    TopicRecommendationAcquireMeta,
+    TopicRecommendationError,
+    get_or_generate_topic_recommendations,
+)
+from services.integrations.linkedin.topic_recommendation_validator import (
+    TopicRecommendationValidationError,
+)
+from services.integrations.linkedin.analytics_dates import (
+    InvalidAnalyticsDateRange,
+    parse_range_request,
+)
+from services.integrations.linkedin.factory import get_linkedin_provider
+from services.integrations.linkedin.landing_analytics import build_landing_analytics_payload
+from services.integrations.linkedin.personal_analytics import build_personal_analytics_payload
+from services.integrations.linkedin.profile_context_service import get_or_build_profile_context
+from services.integrations.linkedin.profile_context_types import ProfileContextBuildError
+from services.integrations.linkedin.profile_completion_questions import build_completion_questions
+from services.integrations.linkedin.profile_completion_service import (
+    ProfileAlreadyCompleteError,
+    ProfileCompletionError,
+    ProfileCompletionResult,
+    complete_profile,
+)
+from services.integrations.linkedin.profile_context_patcher import ProfileCompletionPatchError
+from services.integrations.linkedin.profile_repository import ProfileRepository
+from services.integrations.linkedin.profile_service import get_or_fetch_profile
+from services.integrations.linkedin.profile_validation_service import get_or_validate_profile_context
+from services.integrations.linkedin.profile_validation_types import ProfileValidationResult
+from services.integrations.linkedin.types import LinkedInNotConnectedError
+from services.integrations.linkedin.unipile_client import UnipileAPIError
+from services.integrations.linkedin.zernio_client import ZernioAPIError
+from services.integrations.linkedin_oauth import LinkedInOAuthService
+from services.integrations.oauth_callback_utils import (
+    build_oauth_callback_html,
+    sanitize_error,
+)
+
+router = APIRouter(prefix="/api/linkedin-social", tags=["LinkedIn Social"])
+
+_RECOMMENDATIONS_USER_ERROR = (
+    "We couldn't load content suggestions right now. Please try again."
+)
+
+_ANALYSIS_PHASE_LABELS: Dict[int, str] = {
+    1: "Acquire Profile Data",
+    2: "Build Profile Context",
+    3: "Validate Profile",
+    4: "Profile Completion",
+    5: "AI Profile Intelligence",
+    6: "Topic Recommendations",
+}
+
+_oauth_service = LinkedInOAuthService()
+
+
+def _make_analysis_error(
+    phase: int,
+    error_code: str,
+    user_message: str,
+    exc: Optional[Exception] = None,
+    *,
+    user_id: str = "",
+) -> ProfileAnalysisErrorResponse:
+    """Build a structured analysis error and log safe diagnostics."""
+    phase_label = _ANALYSIS_PHASE_LABELS.get(phase, f"Phase {phase}")
+    debug_message = str(exc)[:500] if exc else None
+    logger.error(
+        "[LinkedInAnalysis] phase={} ({}) code={} user_id={} user_message={} debug={}",
+        phase,
+        phase_label,
+        error_code,
+        user_id,
+        user_message,
+        debug_message,
+    )
+    return ProfileAnalysisErrorResponse(
+        failed_phase=phase,
+        phase_label=phase_label,
+        error_code=error_code,
+        user_message=user_message,
+        debug_message=debug_message,
+    )
+
+
+class LinkedInAuthCallbackRequest(BaseModel):
+    code: Optional[str] = None
+    state: Optional[str] = None
+
+
+def _user_id(current_user: dict) -> str:
+    uid = current_user.get("id") if current_user else None
+    if not uid:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return str(uid)
+
+
+async def _resolve_linkedin_callback_user(
+    request: Request,
+    alwrity_state: Optional[str] = None,
+    state: Optional[str] = None,
+    name: Optional[str] = None,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+) -> str:
+    """Resolve callback user from Clerk session, Unipile name, or validated OAuth state."""
+    if credentials and credentials.credentials:
+        user = await clerk_auth.verify_token(credentials.credentials)
+        if user and user.get("id"):
+            return str(user["id"])
+
+    unipile_user_id = (name or request.query_params.get("name") or "").strip()
+    if unipile_user_id:
+        logger.info(
+            f"[LinkedInConnect] Resolved callback user from Unipile name={unipile_user_id}"
+        )
+        return unipile_user_id
+
+    oauth_state = alwrity_state or state or request.query_params.get("alwrity_state")
+    if oauth_state:
+        if ":" in oauth_state:
+            user_id = _oauth_service.peek_oauth_state_user(oauth_state)
+            if user_id:
+                return user_id
+        if oauth_state.startswith("user_"):
+            return oauth_state
+
+    raise HTTPException(status_code=401, detail="Authentication required for LinkedIn callback")
+
+
+def _resolve_user_account_id(user_id: str, account_id: Optional[str]) -> str:
+    if account_id:
+        return account_id
+    creds = _oauth_service.resolve_credentials(user_id)
+    resolved = creds.primary_account_id
+    if not resolved:
+        raise HTTPException(
+            status_code=400,
+            detail="account_id query param is required when no default LinkedIn account is stored",
+        )
+    return resolved
+
+
+def _raise_profile_acquire_http_error(exc: Exception, *, user_id: str) -> None:
+    """Map profile acquire failures to Phase 1 HTTP status codes."""
+    if isinstance(exc, LinkedInNotConnectedError):
+        logger.warning(
+            "[LinkedInProfile] GET /profile not connected user_id={}: {}",
+            user_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=401,
+            detail="LinkedIn account not connected",
+        ) from exc
+
+    if isinstance(exc, UnipileAPIError):
+        status = exc.status_code
+        message = str(exc).lower()
+        if status == 401 or "disconnected" in message or "reconnect" in message:
+            logger.warning(
+                "[LinkedInProfile] GET /profile Unipile disconnected user_id={}: {}",
+                user_id,
+                exc,
+            )
+            raise HTTPException(status_code=401, detail="Reconnect required") from exc
+        if status == 403:
+            logger.warning(
+                "[LinkedInProfile] GET /profile Unipile forbidden user_id={}: {}",
+                user_id,
+                exc,
+            )
+            raise HTTPException(
+                status_code=502,
+                detail="Unable to fetch LinkedIn profile",
+            ) from exc
+        logger.warning(
+            "[LinkedInProfile] GET /profile Unipile error user_id={}: {}",
+            user_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=502,
+            detail="Unable to fetch LinkedIn profile",
+        ) from exc
+
+    logger.exception(
+        "[LinkedInProfile] GET /profile unexpected error user_id={}: {}",
+        user_id,
+        exc,
+    )
+    raise HTTPException(
+        status_code=500,
+        detail="Unable to fetch LinkedIn profile",
+    ) from exc
+
+
+def _raise_profile_context_http_error(exc: Exception, *, user_id: str) -> None:
+    """Map profile context build failures to Phase 2 HTTP status codes."""
+    if isinstance(exc, ProfileContextBuildError):
+        logger.exception(
+            "[LinkedInProfileContext] GET /profile context build failed user_id={}: {}",
+            user_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to build LinkedIn profile context.",
+        ) from exc
+
+    if isinstance(exc, ValueError):
+        logger.error(
+            "[LinkedInProfileContext] GET /profile context persistence error user_id={}: {}",
+            user_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to build LinkedIn profile context.",
+        ) from exc
+
+    logger.exception(
+        "[LinkedInProfileContext] GET /profile unexpected context error user_id={}: {}",
+        user_id,
+        exc,
+    )
+    raise HTTPException(
+        status_code=500,
+        detail="Unable to build LinkedIn profile context.",
+    ) from exc
+
+
+def _validation_result_to_response(
+    validation: ProfileValidationResult,
+) -> ProfileValidationResponse:
+    """Map Phase 3 validation dict to API response model."""
+    return ProfileValidationResponse(
+        is_profile_complete=bool(validation.get("is_profile_complete")),
+        completeness_score=int(validation.get("completeness_score") or 0),
+        missing_fields=list(validation.get("missing_fields") or []),
+        optional_missing_fields=list(validation.get("optional_missing_fields") or []),
+    )
+
+
+def _completion_result_to_response(
+    result: ProfileCompletionResult,
+    *,
+    ai_profile_intelligence: Optional[AIProfileIntelligenceResponse] = None,
+    ai_profile_intelligence_meta: Optional[ProfileIntelligenceMetaResponse] = None,
+) -> LinkedInProfileCompleteResponse:
+    """Map completion service result to POST /profile/complete response."""
+    return LinkedInProfileCompleteResponse(
+        profile_context=result.profile_context,
+        profile_validation=_validation_result_to_response(result.profile_validation),
+        profile_completion=ProfileCompletionResponse(
+            questions=[
+                CompletionQuestionResponse(
+                    field_key=question["field_key"],
+                    label=question["label"],
+                    input_type=question["input_type"],
+                    required=question["required"],
+                )
+                for question in result.questions
+            ]
+        ),
+        ai_profile_intelligence=ai_profile_intelligence,
+        ai_profile_intelligence_meta=ai_profile_intelligence_meta,
+    )
+
+
+def _stored_intelligence_to_response(
+    stored: dict[str, Any],
+) -> AIProfileIntelligenceResponse:
+    """Map persisted intelligence dict to API response (exclude server ``meta``)."""
+    payload = {key: value for key, value in stored.items() if key != "meta"}
+    return AIProfileIntelligenceResponse.model_validate(payload)
+
+
+def _intelligence_meta_to_response(
+    meta: ProfileIntelligenceAcquireMeta,
+) -> Optional[ProfileIntelligenceMetaResponse]:
+    """Map orchestrator meta to API response when intelligence was acquired."""
+    source = meta.get("source")
+    if source not in ("cache", "generated"):
+        return None
+    return ProfileIntelligenceMetaResponse(
+        source=source,  # type: ignore[arg-type]
+        ai_intelligence_updated_at=meta.get("ai_intelligence_updated_at"),
+    )
+
+
+def _load_profile_intelligence_for_response(
+    user_id: str,
+    profile_context: dict[str, Any],
+    profile_validation: ProfileValidationResult,
+    repository: ProfileRepository,
+    *,
+    force_regenerate: bool = False,
+) -> tuple[
+    Optional[AIProfileIntelligenceResponse],
+    Optional[ProfileIntelligenceMetaResponse],
+    Optional[ProfileAnalysisErrorResponse],
+]:
+    """
+    Generate or load AI profile intelligence for API responses.
+
+    Returns ``(None, None, analysis_error)`` on failure instead of raising HTTP errors.
+    """
+    if not profile_validation.get("is_profile_complete"):
+        logger.info(
+            "[ProfileIntelligence] API skip — profile incomplete user_id={} "
+            "missing_fields={}",
+            user_id,
+            profile_validation.get("missing_fields"),
+        )
+        return None, None, None
+
+    logger.info(
+        "[LinkedInAnalysis] Phase 5 start user_id={} force_regenerate={}",
+        user_id,
+        force_regenerate,
+    )
+    try:
+        stored, meta = get_or_generate_profile_intelligence(
+            user_id,
+            profile_context,
+            profile_validation=profile_validation,
+            repository=repository,
+            force_regenerate=force_regenerate,
+        )
+    except ProfileIntelligenceLLMError as exc:
+        error_kind = getattr(exc, "error_kind", "llm_error")
+        logger.exception(
+            "[ProfileIntelligence] LLM failure user_id={} kind={}: {}",
+            user_id,
+            error_kind,
+            exc,
+        )
+        return (
+            None,
+            None,
+            _make_analysis_error(
+                5,
+                error_kind,
+                "We couldn't analyze your LinkedIn profile right now. Please try again.",
+                exc,
+                user_id=user_id,
+            ),
+        )
+    except ProfileIntelligenceValidationError as exc:
+        validation_code = getattr(exc, "validation_code", "validation_failed")
+        logger.exception(
+            "[ProfileIntelligence] validation failure user_id={} code={}: {}",
+            user_id,
+            validation_code,
+            exc,
+        )
+        return (
+            None,
+            None,
+            _make_analysis_error(
+                5,
+                validation_code,
+                "Profile analysis returned invalid data from AI. Please try again.",
+                exc,
+                user_id=user_id,
+            ),
+        )
+    except (ProfileIntelligenceError, ValueError) as exc:
+        logger.exception(
+            "[ProfileIntelligence] orchestration failure user_id={}: {}",
+            user_id,
+            exc,
+        )
+        return (
+            None,
+            None,
+            _make_analysis_error(
+                5,
+                "orchestration_error",
+                "We couldn't analyze your LinkedIn profile right now. Please try again.",
+                exc,
+                user_id=user_id,
+            ),
+        )
+    except Exception as exc:
+        logger.exception(
+            "[ProfileIntelligence] unexpected failure user_id={}: {}",
+            user_id,
+            exc,
+        )
+        return (
+            None,
+            None,
+            _make_analysis_error(
+                5,
+                "unexpected_error",
+                "We couldn't analyze your LinkedIn profile right now. Please try again.",
+                exc,
+                user_id=user_id,
+            ),
+        )
+
+    if not stored:
+        logger.warning(
+            "[ProfileIntelligence] API load returned empty intelligence user_id={}",
+            user_id,
+        )
+        return (
+            None,
+            None,
+            _make_analysis_error(
+                5,
+                "empty_result",
+                "Profile analysis did not return any results. Please try again.",
+                user_id=user_id,
+            ),
+        )
+
+    logger.info(
+        "[LinkedInAnalysis] Phase 5 complete user_id={} source={}",
+        user_id,
+        meta.get("source"),
+    )
+    return _stored_intelligence_to_response(stored), _intelligence_meta_to_response(meta), None
+
+
+def _recommendation_dict_to_response(item: dict[str, Any]) -> TopicRecommendationResponse:
+    """Map a single recommendation dict to API response model."""
+    return TopicRecommendationResponse.model_validate(item)
+
+
+def _recommendations_meta_to_response(
+    meta: TopicRecommendationAcquireMeta,
+) -> Optional[TopicRecommendationsMetaResponse]:
+    """Map orchestrator meta to API response when recommendations were acquired."""
+    source = meta.get("source")
+    if source not in ("cache", "generated"):
+        return None
+    return TopicRecommendationsMetaResponse(
+        source=source,  # type: ignore[arg-type]
+        recommendations_updated_at=meta.get("recommendations_updated_at"),
+    )
+
+
+def _load_topic_recommendations_for_response(
+    user_id: str,
+    ai_profile_intelligence: dict[str, Any],
+    profile_validation: ProfileValidationResult,
+    repository: ProfileRepository,
+    *,
+    force_regenerate: bool = False,
+) -> tuple[
+    Optional[List[TopicRecommendationResponse]],
+    Optional[TopicRecommendationsMetaResponse],
+    Optional[str],
+    Optional[ProfileAnalysisErrorResponse],
+]:
+    """
+    Generate or load topic recommendations for API responses.
+
+    Returns user-facing ``recommendations_error`` string plus structured ``analysis_error``.
+    """
+    if not profile_validation.get("is_profile_complete"):
+        logger.info(
+            "[TopicRecommendation] API skip — profile incomplete user_id={} missing_fields={}",
+            user_id,
+            profile_validation.get("missing_fields"),
+        )
+        return None, None, None, None
+
+    if not isinstance(ai_profile_intelligence, dict) or not ai_profile_intelligence:
+        logger.info(
+            "[TopicRecommendation] API skip — intelligence missing user_id={}",
+            user_id,
+        )
+        return (
+            None,
+            None,
+            None,
+            _make_analysis_error(
+                6,
+                "missing_intelligence",
+                "Complete profile analysis before generating topic suggestions.",
+                user_id=user_id,
+            ),
+        )
+
+    logger.info(
+        "[LinkedInAnalysis] Phase 6 start user_id={} force_regenerate={}",
+        user_id,
+        force_regenerate,
+    )
+    try:
+        recommendations, meta = get_or_generate_topic_recommendations(
+            user_id,
+            ai_profile_intelligence,
+            profile_validation=profile_validation,
+            repository=repository,
+            force_regenerate=force_regenerate,
+        )
+    except TopicRecommendationLLMError as exc:
+        error_kind = getattr(exc, "error_kind", "llm_failure")
+        logger.exception(
+            "[TopicRecommendation] LLM failure user_id={} kind={}: {}",
+            user_id,
+            error_kind,
+            exc,
+        )
+        analysis_error = _make_analysis_error(
+            6,
+            error_kind,
+            _RECOMMENDATIONS_USER_ERROR,
+            exc,
+            user_id=user_id,
+        )
+        return None, None, _RECOMMENDATIONS_USER_ERROR, analysis_error
+    except TopicRecommendationValidationError as exc:
+        validation_code = getattr(exc, "validation_code", "validation_failed")
+        logger.exception(
+            "[TopicRecommendation] validation failure user_id={} code={}: {}",
+            user_id,
+            validation_code,
+            exc,
+        )
+        analysis_error = _make_analysis_error(
+            6,
+            validation_code,
+            _RECOMMENDATIONS_USER_ERROR,
+            exc,
+            user_id=user_id,
+        )
+        return None, None, _RECOMMENDATIONS_USER_ERROR, analysis_error
+    except (TopicRecommendationError, ValueError) as exc:
+        logger.exception(
+            "[TopicRecommendation] orchestration failure user_id={}: {}",
+            user_id,
+            exc,
+        )
+        analysis_error = _make_analysis_error(
+            6,
+            "orchestration_failed",
+            _RECOMMENDATIONS_USER_ERROR,
+            exc,
+            user_id=user_id,
+        )
+        return None, None, _RECOMMENDATIONS_USER_ERROR, analysis_error
+    except Exception as exc:
+        logger.exception(
+            "[TopicRecommendation] unexpected failure user_id={}: {}",
+            user_id,
+            exc,
+        )
+        analysis_error = _make_analysis_error(
+            6,
+            "unexpected_error",
+            _RECOMMENDATIONS_USER_ERROR,
+            exc,
+            user_id=user_id,
+        )
+        return None, None, _RECOMMENDATIONS_USER_ERROR, analysis_error
+
+    if not recommendations:
+        logger.warning(
+            "[TopicRecommendation] API load returned empty recommendations user_id={}",
+            user_id,
+        )
+        analysis_error = _make_analysis_error(
+            6,
+            "empty_response",
+            _RECOMMENDATIONS_USER_ERROR,
+            user_id=user_id,
+        )
+        return None, None, _RECOMMENDATIONS_USER_ERROR, analysis_error
+
+    try:
+        response_items = [
+            _recommendation_dict_to_response(item) for item in recommendations
+        ]
+    except Exception as exc:
+        logger.exception(
+            "[TopicRecommendation] response mapping failure user_id={}: {}",
+            user_id,
+            exc,
+        )
+        analysis_error = _make_analysis_error(
+            6,
+            "response_mapping_failed",
+            _RECOMMENDATIONS_USER_ERROR,
+            exc,
+            user_id=user_id,
+        )
+        return None, None, _RECOMMENDATIONS_USER_ERROR, analysis_error
+
+    logger.info(
+        "[LinkedInAnalysis] Phase 6 complete user_id={} source={} count={}",
+        user_id,
+        meta.get("source"),
+        len(response_items),
+    )
+    return response_items, _recommendations_meta_to_response(meta), None, None
+
+
+
+def _build_profile_completion_payload(
+    validation: ProfileValidationResult,
+) -> ProfileCompletionResponse:
+    """Build completion questions when profile is incomplete."""
+    if validation.get("is_profile_complete"):
+        return ProfileCompletionResponse(questions=[])
+
+    questions = build_completion_questions(list(validation.get("missing_fields") or []))
+    return ProfileCompletionResponse(
+        questions=[
+            CompletionQuestionResponse(
+                field_key=question["field_key"],
+                label=question["label"],
+                input_type=question["input_type"],
+                required=question["required"],
+            )
+            for question in questions
+        ]
+    )
+
+
+def _raise_profile_validation_http_error(exc: Exception, *, user_id: str) -> None:
+    """Map profile validation failures to HTTP status codes."""
+    if isinstance(exc, ValueError):
+        logger.error(
+            "[ProfileValidation] GET /profile validation error user_id={}: {}",
+            user_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to validate LinkedIn profile.",
+        ) from exc
+
+    logger.exception(
+        "[ProfileValidation] GET /profile unexpected validation error user_id={}: {}",
+        user_id,
+        exc,
+    )
+    raise HTTPException(
+        status_code=500,
+        detail="Unable to validate LinkedIn profile.",
+    ) from exc
+
+
+def _raise_profile_completion_http_error(exc: Exception, *, user_id: str) -> None:
+    """Map profile completion failures to HTTP status codes."""
+    if isinstance(exc, ProfileAlreadyCompleteError):
+        logger.info(
+            "[ProfileCompletion] POST /profile/complete already complete user_id={}",
+            user_id,
+        )
+        raise HTTPException(
+            status_code=409,
+            detail="Profile is already complete.",
+        ) from exc
+
+    if isinstance(exc, ProfileCompletionError):
+        logger.warning(
+            "[ProfileCompletion] POST /profile/complete bad request user_id={}: {}",
+            user_id,
+            exc,
+        )
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if isinstance(exc, ProfileCompletionPatchError):
+        logger.exception(
+            "[ProfileCompletion] POST /profile/complete patch failed user_id={}: {}",
+            user_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to complete LinkedIn profile.",
+        ) from exc
+
+    if isinstance(exc, ValueError):
+        logger.error(
+            "[ProfileCompletion] POST /profile/complete persistence error user_id={}: {}",
+            user_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to complete LinkedIn profile.",
+        ) from exc
+
+    logger.exception(
+        "[ProfileCompletion] POST /profile/complete unexpected error user_id={}: {}",
+        user_id,
+        exc,
+    )
+    raise HTTPException(
+        status_code=500,
+        detail="Unable to complete LinkedIn profile.",
+    ) from exc
+
+
+@router.get("/profile", response_model=LinkedInProfileAcquireResponse)
+async def get_linkedin_profile(
+    refresh: bool = Query(
+        False,
+        description="Force Unipile fetch, update DB, and invalidate downstream on hash change",
+    ),
+    refresh_intelligence: bool = Query(
+        False,
+        description="Force regeneration of AI profile intelligence (Phase 5)",
+    ),
+    refresh_recommendations: bool = Query(
+        False,
+        description="Force regeneration of topic recommendations (Phase 6)",
+    ),
+    current_user: dict = Depends(get_current_user),
+) -> LinkedInProfileAcquireResponse:
+    """
+    Return the connected user's normalized LinkedIn profile and profile context.
+
+    Phase 1: cache-first normalized profile from ``linkedin_analysis_context``.
+    Phase 2: cache-first ``profile_context`` built from the normalized profile.
+    Phase 3/4: ``profile_validation`` and completion questions when incomplete.
+    Phase 5: ``ai_profile_intelligence`` when profile is complete.
+    Phase 6: ``recommendations`` when profile is complete and intelligence exists.
+    """
+    user_id = _user_id(current_user)
+    logger.info(
+        "[LinkedInAnalysis] pipeline start user_id={} refresh={} refresh_intelligence={} "
+        "refresh_recommendations={}",
+        user_id,
+        refresh,
+        refresh_intelligence,
+        refresh_recommendations,
+    )
+
+    last_completed_phase = 0
+    analysis_error: Optional[ProfileAnalysisErrorResponse] = None
+
+    logger.info("[LinkedInAnalysis] Phase 1 start user_id={}", user_id)
+    try:
+        profile, meta = await get_or_fetch_profile(
+            user_id,
+            refresh=refresh,
+            oauth=_oauth_service,
+        )
+    except (LinkedInNotConnectedError, UnipileAPIError) as exc:
+        _raise_profile_acquire_http_error(exc, user_id=user_id)
+    except Exception as exc:
+        _raise_profile_acquire_http_error(exc, user_id=user_id)
+    last_completed_phase = 1
+    logger.info(
+        "[LinkedInAnalysis] Phase 1 complete user_id={} source={}",
+        user_id,
+        meta.get("source"),
+    )
+
+    repository = ProfileRepository(oauth=_oauth_service)
+    logger.info("[LinkedInAnalysis] Phase 2 start user_id={}", user_id)
+    try:
+        profile_context, context_meta = get_or_build_profile_context(
+            user_id,
+            profile,
+            profile_content_hash=meta.get("profile_content_hash"),
+            repository=repository,
+        )
+    except (ProfileContextBuildError, ValueError) as exc:
+        _raise_profile_context_http_error(exc, user_id=user_id)
+    except Exception as exc:
+        _raise_profile_context_http_error(exc, user_id=user_id)
+    last_completed_phase = 2
+    logger.info(
+        "[LinkedInAnalysis] Phase 2 complete user_id={} source={}",
+        user_id,
+        context_meta.get("source"),
+    )
+
+    logger.info("[LinkedInAnalysis] Phase 3 start user_id={}", user_id)
+    try:
+        profile_validation, _validation_meta = get_or_validate_profile_context(
+            user_id,
+            profile_context,
+            repository=repository,
+        )
+        profile_completion = _build_profile_completion_payload(profile_validation)
+    except ValueError as exc:
+        _raise_profile_validation_http_error(exc, user_id=user_id)
+    except Exception as exc:
+        _raise_profile_validation_http_error(exc, user_id=user_id)
+    last_completed_phase = 3
+    if not profile_validation.get("is_profile_complete"):
+        last_completed_phase = 4
+        logger.info(
+            "[LinkedInAnalysis] Phase 4 required user_id={} missing_fields={}",
+            user_id,
+            profile_validation.get("missing_fields"),
+        )
+    else:
+        logger.info("[LinkedInAnalysis] Phase 3 complete user_id={} profile_complete=true", user_id)
+
+    ai_profile_intelligence: Optional[AIProfileIntelligenceResponse] = None
+    ai_profile_intelligence_meta: Optional[ProfileIntelligenceMetaResponse] = None
+    intelligence_error: Optional[ProfileAnalysisErrorResponse] = None
+    if profile_validation.get("is_profile_complete"):
+        (
+            ai_profile_intelligence,
+            ai_profile_intelligence_meta,
+            intelligence_error,
+        ) = _load_profile_intelligence_for_response(
+            user_id,
+            profile_context,
+            profile_validation,
+            repository,
+            force_regenerate=refresh_intelligence,
+        )
+        if intelligence_error:
+            analysis_error = intelligence_error
+        elif ai_profile_intelligence is not None:
+            last_completed_phase = 5
+    else:
+        logger.info(
+            "[ProfileIntelligence] GET /profile skipping intelligence — incomplete "
+            "user_id={} missing_fields={}",
+            user_id,
+            profile_validation.get("missing_fields"),
+        )
+
+    recommendations: Optional[List[TopicRecommendationResponse]] = None
+    recommendations_meta: Optional[TopicRecommendationsMetaResponse] = None
+    recommendations_error: Optional[str] = None
+    if ai_profile_intelligence is not None:
+        intelligence_dict = ai_profile_intelligence.model_dump()
+        (
+            recommendations,
+            recommendations_meta,
+            recommendations_error,
+            recommendations_analysis_error,
+        ) = _load_topic_recommendations_for_response(
+            user_id,
+            intelligence_dict,
+            profile_validation,
+            repository,
+            force_regenerate=refresh_recommendations,
+        )
+        if recommendations_analysis_error:
+            analysis_error = recommendations_analysis_error
+        elif recommendations:
+            last_completed_phase = 6
+    elif profile_validation.get("is_profile_complete") and intelligence_error is None:
+        logger.info(
+            "[TopicRecommendation] GET /profile skipping recommendations — no intelligence "
+            "user_id={}",
+            user_id,
+        )
+
+    logger.info(
+        "[LinkedInAnalysis] pipeline complete user_id={} last_completed_phase={} "
+        "profile_source={} context_source={} is_profile_complete={} "
+        "intelligence_source={} recommendations_source={} recommendations_count={} "
+        "recommendations_error={} analysis_error_phase={}",
+        user_id,
+        last_completed_phase,
+        meta.get("source"),
+        context_meta.get("source"),
+        profile_validation.get("is_profile_complete"),
+        (
+            ai_profile_intelligence_meta.source
+            if ai_profile_intelligence_meta
+            else None
+        ),
+        recommendations_meta.source if recommendations_meta else None,
+        len(recommendations) if recommendations else 0,
+        bool(recommendations_error),
+        analysis_error.failed_phase if analysis_error else None,
+    )
+    return LinkedInProfileAcquireResponse(
+        profile=profile,
+        meta=LinkedInProfileMetaResponse(
+            source=meta["source"],  # type: ignore[arg-type]
+            fetched_at=meta.get("fetched_at"),
+            profile_content_hash=meta.get("profile_content_hash"),
+        ),
+        profile_context=profile_context,
+        profile_context_meta=LinkedInProfileContextMetaResponse(
+            source=context_meta["source"],  # type: ignore[arg-type]
+            profile_context_updated_at=context_meta.get("profile_context_updated_at"),
+        ),
+        profile_validation=_validation_result_to_response(profile_validation),
+        profile_completion=profile_completion,
+        ai_profile_intelligence=ai_profile_intelligence,
+        ai_profile_intelligence_meta=ai_profile_intelligence_meta,
+        recommendations=recommendations,
+        recommendations_meta=recommendations_meta,
+        recommendations_error=recommendations_error,
+        last_completed_phase=last_completed_phase or None,
+        analysis_error=analysis_error,
+    )
+
+
+@router.post("/profile/complete", response_model=LinkedInProfileCompleteResponse)
+async def complete_linkedin_profile(
+    body: LinkedInProfileCompleteRequest,
+    current_user: dict = Depends(get_current_user),
+) -> LinkedInProfileCompleteResponse:
+    """
+    Apply user completion answers, patch profile context, and re-validate.
+
+    Returns updated context, validation, and any remaining completion questions.
+    """
+    user_id = _user_id(current_user)
+    logger.info(
+        "[ProfileCompletion] POST /profile/complete user_id={} answer_keys={}",
+        user_id,
+        sorted(body.answers.keys()),
+    )
+
+    if not body.answers:
+        logger.warning(
+            "[ProfileCompletion] POST /profile/complete empty answers user_id={}",
+            user_id,
+        )
+        raise HTTPException(status_code=400, detail="No completion answers provided.")
+
+    repository = ProfileRepository(oauth=_oauth_service)
+    try:
+        result = complete_profile(
+            user_id,
+            body.answers,
+            repository=repository,
+        )
+    except (ProfileAlreadyCompleteError, ProfileCompletionError) as exc:
+        _raise_profile_completion_http_error(exc, user_id=user_id)
+    except (ProfileCompletionPatchError, ValueError) as exc:
+        _raise_profile_completion_http_error(exc, user_id=user_id)
+    except Exception as exc:
+        _raise_profile_completion_http_error(exc, user_id=user_id)
+
+    logger.info(
+        "[ProfileCompletion] POST /profile/complete success user_id={} "
+        "is_profile_complete={}",
+        user_id,
+        result.profile_validation.get("is_profile_complete"),
+    )
+
+    ai_profile_intelligence: Optional[AIProfileIntelligenceResponse] = None
+    ai_profile_intelligence_meta: Optional[ProfileIntelligenceMetaResponse] = None
+    if result.profile_validation.get("is_profile_complete"):
+        (
+            ai_profile_intelligence,
+            ai_profile_intelligence_meta,
+            _intelligence_error,
+        ) = _load_profile_intelligence_for_response(
+            user_id,
+            result.profile_context,
+            result.profile_validation,
+            repository,
+        )
+        if _intelligence_error:
+            logger.warning(
+                "[ProfileCompletion] POST /profile/complete intelligence failed user_id={} "
+                "phase={} code={}",
+                user_id,
+                _intelligence_error.failed_phase,
+                _intelligence_error.error_code,
+            )
+
+    return _completion_result_to_response(
+        result,
+        ai_profile_intelligence=ai_profile_intelligence,
+        ai_profile_intelligence_meta=ai_profile_intelligence_meta,
+    )
+
+
+@router.get("/connection/status", response_model=LinkedInConnectionStatusResponse)
+async def get_connection_status(
+    current_user: dict = Depends(get_current_user),
+) -> LinkedInConnectionStatusResponse:
+    """Return LinkedIn connection state for the authenticated user."""
+    user_id = _user_id(current_user)
+    status = _oauth_service.get_connection_status(user_id)
+    if status.get("connected"):
+        if status.get("provider") == "zernio":
+            _oauth_service.try_sync_zernio_accounts(user_id)
+            status = _oauth_service.get_connection_status(user_id)
+    elif status.get("provider") == "unipile":
+        if await _oauth_service.try_sync_unipile_accounts(user_id):
+            status = _oauth_service.get_connection_status(user_id)
+
+    organizations: List[Dict[str, Any]] = []
+    if status.get("connected") and status.get("accounts"):
+        primary_account = status["accounts"][0].get("account_id")
+        if primary_account:
+            try:
+                provider = get_linkedin_provider()
+                orgs = await provider.list_organizations(user_id, primary_account)
+                organizations = [
+                    {
+                        "organization_id": o.organization_id,
+                        "name": o.name,
+                        "urn": o.urn,
+                    }
+                    for o in orgs
+                ]
+            except Exception as e:
+                logger.warning(f"Could not load organizations for status: {e}")
+
+    status["organizations"] = organizations
+    return LinkedInConnectionStatusResponse(**status)
+
+
+@router.get("/auth/url")
+async def get_authorization_url(
+    state: Optional[str] = None,
+    current_user: dict = Depends(get_current_user),
+) -> Dict[str, str]:
+    """Return OAuth authorization URL for Zernio, Unipile, or native LinkedIn connect."""
+    user_id = _user_id(current_user)
+    logger.info(f"[LinkedInConnect] auth URL requested user_id={user_id}")
+    try:
+        oauth_state = state or str(uuid.uuid4())
+        payload = await _oauth_service.generate_authorization_url(user_id, oauth_state)
+        logger.info(
+            f"[LinkedInConnect] auth URL generated user_id={user_id} provider={payload.get('provider')}"
+        )
+        return {
+            "authorization_url": payload["auth_url"],
+            "state": payload["state"],
+            "provider": payload["provider"],
+        }
+    except ValueError as e:
+        error_str = str(e).lower()
+        if "zernio_api_key is not configured" in error_str:
+            logger.error(f"[LinkedInConnect] missing ZERNIO_API_KEY user_id={user_id}")
+        elif "unipile_api_key is not configured" in error_str:
+            logger.error(f"[LinkedInConnect] missing UNIPILE_API_KEY user_id={user_id}")
+        else:
+            logger.warning(f"[LinkedInConnect] configuration error user_id={user_id}: {e}")
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except ZernioAPIError as e:
+        status = e.status_code or 502
+        logger.warning(f"[LinkedInConnect] auth URL Zernio error user_id={user_id}: {e}")
+        raise HTTPException(status_code=status, detail=str(e)) from e
+    except UnipileAPIError as e:
+        status = e.status_code or 502
+        logger.warning(f"[LinkedInConnect] auth URL Unipile error user_id={user_id}: {e}")
+        raise HTTPException(status_code=status, detail=str(e)) from e
+    except Exception as e:
+        logger.exception(f"[LinkedInConnect] auth URL failed user_id={user_id}: {e}")
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/sync")
+async def sync_linkedin_accounts(
+    current_user: dict = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """Refresh personal + organization account IDs from Zernio (no new OAuth)."""
+    user_id = _user_id(current_user)
+    try:
+        accounts = _oauth_service.sync_zernio_accounts(user_id)
+        return {"success": True, "accounts": accounts}
+    except LinkedInNotConnectedError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        logger.exception(f"[LinkedInConnect] manual sync failed user_id={user_id}: {e}")
+        raise HTTPException(status_code=502, detail=str(e)) from e
+
+
+@router.get("/callback")
+async def handle_oauth_callback_get(
+    request: Request,
+    code: Optional[str] = None,
+    state: Optional[str] = None,
+    connected: Optional[str] = None,
+    accountId: Optional[str] = None,
+    account_id: Optional[str] = None,
+    username: Optional[str] = None,
+    alwrity_state: Optional[str] = None,
+    provider: Optional[str] = Query(None, description="OAuth provider (unipile, zernio, native)"),
+    status: Optional[str] = Query(None, description="Connection status (success, error)"),
+    message: Optional[str] = Query(None, description="Error message if status is error"),
+    name: Optional[str] = Query(None, description="User ID passed to Unipile as 'name' param"),
+    user_id: str = Depends(_resolve_linkedin_callback_user),
+) -> HTMLResponse:
+    """HTML OAuth callback that stores credentials and notifies opener via postMessage.
+
+    Handles callbacks from:
+    - Zernio (legacy): connected, accountId, tempToken params
+    - Unipile (Phase 2): provider=unipile, status=success|error, account_id, name
+    - Native LinkedIn: code, state params
+    """
+    try:
+        resolved_account_id = accountId or account_id
+        temp_token = request.query_params.get("tempToken") or request.query_params.get(
+            "temp_token"
+        )
+
+        # Detect Unipile callback (Phase 2)
+        is_unipile_redirect = provider == "unipile"
+        if is_unipile_redirect:
+            logger.info(
+                f"[LinkedInConnect] Unipile callback user_id={user_id} "
+                f"status={status} account_id_present={bool(resolved_account_id)}"
+            )
+
+            if status == "error":
+                error_msg = message or "Unipile authentication failed"
+                logger.error(f"[LinkedInConnect] Unipile callback error user_id={user_id}: {error_msg}")
+                html = build_oauth_callback_html(
+                    payload={
+                        "type": "LINKEDIN_OAUTH_ERROR",
+                        "success": False,
+                        "provider": "unipile",
+                        "error": error_msg,
+                    },
+                    title="LinkedIn Connection Failed",
+                    heading="Connection Failed",
+                    message=f"LinkedIn connection failed: {error_msg}. You can close this window and try again.",
+                )
+                return HTMLResponse(content=html)
+
+            # Success case - store credentials (account_id may arrive via notify_url only)
+            if resolved_account_id:
+                ok = await _oauth_service.handle_unipile_callback(
+                    user_id=user_id,
+                    account_id=resolved_account_id,
+                    status="success",
+                )
+                if not ok:
+                    raise HTTPException(
+                        status_code=400, detail="Failed to store Unipile credentials"
+                    )
+            else:
+                logger.warning(
+                    f"[LinkedInConnect] Unipile callback missing account_id user_id={user_id}; "
+                    "attempting account sync (notify_url may have already stored credentials)"
+                )
+                await _oauth_service.try_sync_unipile_accounts(user_id)
+
+            status_after = _oauth_service.get_connection_status(user_id)
+            if not status_after.get("connected"):
+                logger.warning(
+                    f"[LinkedInConnect] Unipile browser callback complete but not connected yet "
+                    f"user_id={user_id}; client will poll status or wait for webhook"
+                )
+
+            logger.info(f"[LinkedInConnect] Unipile callback succeeded user_id={user_id}")
+            payload = {
+                "type": "LINKEDIN_OAUTH_SUCCESS",
+                "success": True,
+                "provider": "unipile",
+            }
+            html = build_oauth_callback_html(
+                payload=payload,
+                title="LinkedIn Connected",
+                heading="Connection Successful",
+                message="Your LinkedIn account was connected via Unipile. You can close this window.",
+            )
+            return HTMLResponse(
+                content=html,
+                headers={
+                    "Cross-Origin-Opener-Policy": "unsafe-none",
+                    "Cross-Origin-Embedder-Policy": "unsafe-none",
+                },
+            )
+
+        # Detect Zernio callback (legacy)
+        is_zernio_redirect = (
+            connected == "linkedin"
+            or bool(resolved_account_id and not provider)
+            or bool(temp_token)
+        )
+
+        if is_zernio_redirect:
+            logger.info(
+                f"[LinkedInConnect] Zernio callback user_id={user_id} "
+                f"account_id_present={bool(resolved_account_id)} "
+                f"headless={bool(temp_token)}"
+            )
+            query_params = dict(request.query_params)
+            ok = _oauth_service.handle_zernio_connect_callback(user_id, query_params)
+            if not ok:
+                raise HTTPException(status_code=400, detail="Zernio connect callback failed")
+            logger.info(f"[LinkedInConnect] Zernio callback succeeded user_id={user_id}")
+            payload = {
+                "type": "LINKEDIN_OAUTH_SUCCESS",
+                "success": True,
+                "provider": "zernio",
+            }
+            html = build_oauth_callback_html(
+                payload=payload,
+                title="LinkedIn Connected",
+                heading="Connection Successful",
+                message="Your LinkedIn account was connected. You can close this window.",
+            )
+            return HTMLResponse(
+                content=html,
+                headers={
+                    "Cross-Origin-Opener-Policy": "unsafe-none",
+                    "Cross-Origin-Embedder-Policy": "unsafe-none",
+                },
+            )
+
+        # Native LinkedIn OAuth
+        if not code or not state:
+            raise HTTPException(status_code=400, detail="Missing OAuth code or state")
+
+        token_result = _oauth_service.handle_native_oauth_callback(user_id, code, state)
+        if not token_result:
+            raise HTTPException(status_code=400, detail="LinkedIn OAuth token exchange failed")
+
+        payload = {
+            "type": "LINKEDIN_OAUTH_SUCCESS",
+            "success": True,
+            "provider": "native",
+        }
+        html = build_oauth_callback_html(
+            payload=payload,
+            title="LinkedIn Connected",
+            heading="Connection Successful",
+            message="Your LinkedIn account was connected. You can close this window.",
+        )
+        return HTMLResponse(
+            content=html,
+            headers={
+                "Cross-Origin-Opener-Policy": "unsafe-none",
+                "Cross-Origin-Embedder-Policy": "unsafe-none",
+            },
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"[LinkedInConnect] OAuth GET callback failed user_id={user_id}: {e}")
+        html = build_oauth_callback_html(
+            payload={
+                "type": "LINKEDIN_OAUTH_ERROR",
+                "success": False,
+                "error": sanitize_error(e),
+            },
+            title="LinkedIn Connection Failed",
+            heading="Connection Failed",
+            message="LinkedIn connection failed. You can close this window and try again.",
+        )
+        return HTMLResponse(content=html)
+
+
+@router.post("/auth/callback")
+async def handle_oauth_callback_post(
+    body: LinkedInAuthCallbackRequest,
+    current_user: dict = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """SPA fallback for native LinkedIn OAuth code exchange."""
+    user_id = _user_id(current_user)
+    if not body.code or not body.state:
+        raise HTTPException(status_code=400, detail="Missing OAuth code or state")
+    token_result = _oauth_service.handle_native_oauth_callback(
+        user_id, body.code, body.state
+    )
+    if not token_result:
+        raise HTTPException(status_code=400, detail="LinkedIn OAuth token exchange failed")
+    status = _oauth_service.get_connection_status(user_id)
+    return {"success": True, "connected": status.get("connected", False)}
+
+
+@router.post("/disconnect")
+async def disconnect_linkedin(
+    current_user: dict = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """Disconnect per-user LinkedIn credentials (soft-delete tokens)."""
+    user_id = _user_id(current_user)
+    logger.info(f"[LinkedInConnect] disconnect requested user_id={user_id}")
+    try:
+        result = await _oauth_service.disconnect_user(user_id)
+        logger.info(
+            f"[LinkedInConnect] disconnect completed user_id={user_id} "
+            f"revoked={result.get('revoked')} zernio_account_deleted={result.get('zernio_account_deleted')}"
+        )
+        return {
+            "success": result.get("success", False),
+            "connected": result.get("connected", False),
+            "has_env_fallback": False,
+            "message": "LinkedIn account disconnected successfully",
+        }
+    except Exception as e:
+        logger.exception(f"[LinkedInConnect] disconnect failed user_id={user_id}: {e}")
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.get("/accounts", response_model=LinkedInAccountsListResponse)
+async def list_accounts(
+    current_user: dict = Depends(get_current_user),
+) -> LinkedInAccountsListResponse:
+    """List LinkedIn accounts available to the user via the configured provider."""
+    user_id = _user_id(current_user)
+    provider = get_linkedin_provider()
+    try:
+        accounts = await provider.list_accounts(user_id)
+    except LinkedInNotConnectedError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    except Exception as e:
+        logger.error(f"list_accounts failed for user {user_id}: {e}")
+        raise HTTPException(status_code=502, detail=str(e)) from e
+
+    return LinkedInAccountsListResponse(
+        accounts=[
+            LinkedInAccountResponse(
+                account_id=a.account_id,
+                account_type=a.account_type,
+                username=a.username,
+                avatar_url=a.avatar_url,
+                platform=a.platform,
+            )
+            for a in accounts
+        ],
+        provider=provider.provider_name,
+    )
+
+
+@router.get("/organizations", response_model=LinkedInOrganizationsListResponse)
+async def list_organizations(
+    account_id: str = Query(..., description="Zernio LinkedIn account id"),
+    current_user: dict = Depends(get_current_user),
+) -> LinkedInOrganizationsListResponse:
+    """List LinkedIn company pages for an account."""
+    user_id = _user_id(current_user)
+    provider = get_linkedin_provider()
+    try:
+        orgs = await provider.list_organizations(user_id, account_id)
+    except LinkedInNotConnectedError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    except Exception as e:
+        logger.error(f"list_organizations failed for user {user_id}: {e}")
+        raise HTTPException(status_code=502, detail=str(e)) from e
+
+    return LinkedInOrganizationsListResponse(
+        account_id=account_id,
+        organizations=[
+            LinkedInOrganizationResponse(
+                organization_id=o.organization_id,
+                name=o.name,
+                urn=o.urn,
+            )
+            for o in orgs
+        ],
+    )
+
+
+@router.get("/analytics/landing", response_model=LinkedInLandingAnalyticsResponse)
+async def get_landing_analytics(
+    current_user: dict = Depends(get_current_user),
+) -> LinkedInLandingAnalyticsResponse:
+    """Rolling last-7-day personal + org analytics for the LinkedIn Writer landing page."""
+    user_id = _user_id(current_user)
+    provider = get_linkedin_provider()
+    try:
+        payload = await build_landing_analytics_payload(
+            user_id, provider, _oauth_service
+        )
+        return LinkedInLandingAnalyticsResponse(**payload)
+    except LinkedInNotConnectedError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    except ZernioAPIError as e:
+        status = e.status_code or 502
+        if status in (402, 403, 412):
+            raise HTTPException(status_code=status, detail=str(e)) from e
+        logger.warning(f"[LinkedInAnalytics] landing Zernio error user_id={user_id}: {e}")
+        raise HTTPException(status_code=502, detail=str(e)) from e
+    except Exception as e:
+        logger.exception(f"[LinkedInAnalytics] landing failed user_id={user_id}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to load LinkedIn analytics") from e
+
+
+@router.get("/analytics/personal", response_model=LinkedInPersonalAnalyticsResponse)
+async def get_personal_analytics(
+    preset_days: Optional[int] = Query(
+        None,
+        alias="presetDays",
+        description="Preset window: 7, 14, 28, 90, or 365 days",
+    ),
+    start_date: Optional[str] = Query(
+        None,
+        alias="startDate",
+        description="Custom range start (YYYY-MM-DD, inclusive)",
+    ),
+    end_date: Optional[str] = Query(
+        None,
+        alias="endDate",
+        description="Custom range end (YYYY-MM-DD, inclusive in UI)",
+    ),
+    current_user: dict = Depends(get_current_user),
+) -> LinkedInPersonalAnalyticsResponse:
+    """Normalized personal profile aggregate analytics for a date range."""
+    user_id = _user_id(current_user)
+    provider = get_linkedin_provider()
+    try:
+        if preset_days is not None and preset_days not in (7, 14, 28, 90, 365):
+            raise InvalidAnalyticsDateRange(
+                "presetDays must be one of 7, 14, 28, 90, or 365."
+            )
+        date_range = parse_range_request(
+            today=date.today(),
+            preset_days=preset_days,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        if preset_days is not None:
+            logger.warning(
+                f"[LinkedInAnalytics] personal range user_id={user_id} preset={preset_days}"
+            )
+        elif start_date and end_date:
+            logger.warning(
+                f"[LinkedInAnalytics] personal range user_id={user_id} "
+                f"custom start={start_date} end={end_date}"
+            )
+        payload = await build_personal_analytics_payload(
+            user_id, provider, _oauth_service, date_range
+        )
+        return LinkedInPersonalAnalyticsResponse(**payload)
+    except InvalidAnalyticsDateRange as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except LinkedInNotConnectedError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    except ZernioAPIError as e:
+        status = e.status_code or 502
+        if status in (402, 403, 412):
+            raise HTTPException(status_code=status, detail=str(e)) from e
+        logger.warning(
+            f"[LinkedInAnalytics] personal Zernio error user_id={user_id}: {e}"
+        )
+        raise HTTPException(status_code=502, detail=str(e)) from e
+    except Exception as e:
+        logger.exception(
+            f"[LinkedInAnalytics] personal failed user_id={user_id}: {e}"
+        )
+        raise HTTPException(
+            status_code=500, detail="Failed to load personal LinkedIn analytics"
+        ) from e
+
+
+@router.get("/analytics/profile", response_model=LinkedInAnalyticsResponse)
+async def get_profile_analytics(
+    account_id: Optional[str] = Query(None, description="Defaults to connected personal account"),
+    aggregation: str = Query("TOTAL", pattern="^(TOTAL|DAILY)$"),
+    start_date: Optional[str] = Query(None, description="YYYY-MM-DD"),
+    end_date: Optional[str] = Query(None, description="YYYY-MM-DD (exclusive)"),
+    metrics: Optional[str] = Query(None, description="Comma-separated metrics"),
+    current_user: dict = Depends(get_current_user),
+) -> LinkedInAnalyticsResponse:
+    """Fetch LinkedIn personal profile aggregate analytics."""
+    user_id = _user_id(current_user)
+    provider = get_linkedin_provider()
+    metric_list = [m.strip().upper() for m in metrics.split(",")] if metrics else None
+    try:
+        resolved_account = _resolve_user_account_id(user_id, account_id)
+    except LinkedInNotConnectedError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    try:
+        data = await provider.get_profile_aggregate_analytics(
+            user_id,
+            resolved_account,
+            aggregation=aggregation,  # type: ignore[arg-type]
+            start_date=start_date,
+            end_date=end_date,
+            metrics=metric_list,
+        )
+    except LinkedInNotConnectedError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    except Exception as e:
+        logger.error(f"profile analytics failed for user {user_id}: {e}")
+        raise HTTPException(status_code=502, detail=str(e)) from e
+
+    return LinkedInAnalyticsResponse(data=data, provider=provider.provider_name)
+
+
+@router.get("/analytics/org", response_model=LinkedInAnalyticsResponse)
+async def get_org_analytics(
+    account_id: Optional[str] = Query(None, description="Defaults to connected org account"),
+    since: Optional[str] = Query(None, description="YYYY-MM-DD"),
+    until: Optional[str] = Query(None, description="YYYY-MM-DD"),
+    metric_type: str = Query("total_value", pattern="^(total_value|time_series)$"),
+    metrics: Optional[str] = Query(None, description="Comma-separated org metrics"),
+    current_user: dict = Depends(get_current_user),
+) -> LinkedInAnalyticsResponse:
+    """Fetch LinkedIn organization page aggregate analytics."""
+    user_id = _user_id(current_user)
+    provider = get_linkedin_provider()
+    metric_list = [m.strip().lower() for m in metrics.split(",")] if metrics else None
+    try:
+        creds = _oauth_service.resolve_credentials(user_id)
+        resolved_account = account_id or creds.zernio_org_account_id
+        if not resolved_account:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "No LinkedIn organization account is connected. "
+                    "Connect a company page before requesting org analytics."
+                ),
+            )
+    except LinkedInNotConnectedError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    try:
+        data = await provider.get_org_aggregate_analytics(
+            user_id,
+            resolved_account,
+            since=since,
+            until=until,
+            metric_type=metric_type,  # type: ignore[arg-type]
+            metrics=metric_list,
+        )
+    except LinkedInNotConnectedError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    except Exception as e:
+        logger.error(f"org analytics failed for user {user_id}: {e}")
+        raise HTTPException(status_code=502, detail=str(e)) from e
+
+    return LinkedInAnalyticsResponse(data=data, provider=provider.provider_name)
+
+
+@router.get("/analytics/post", response_model=LinkedInAnalyticsResponse)
+async def get_post_analytics(
+    urn: str = Query(..., description="LinkedIn post URN"),
+    account_id: Optional[str] = Query(None, description="Defaults to connected personal account"),
+    current_user: dict = Depends(get_current_user),
+) -> LinkedInAnalyticsResponse:
+    """Fetch analytics for a single LinkedIn post by URN."""
+    user_id = _user_id(current_user)
+    provider = get_linkedin_provider()
+    try:
+        resolved_account = _resolve_user_account_id(user_id, account_id)
+    except LinkedInNotConnectedError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    try:
+        data = await provider.get_post_analytics(user_id, resolved_account, urn)
+    except LinkedInNotConnectedError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    except Exception as e:
+        logger.error(f"post analytics failed for user {user_id}: {e}")
+        raise HTTPException(status_code=502, detail=str(e)) from e
+
+    return LinkedInAnalyticsResponse(data=data, provider=provider.provider_name)

--- a/backend/api/unipile_webhook_routes.py
+++ b/backend/api/unipile_webhook_routes.py
@@ -1,0 +1,102 @@
+"""
+Unipile webhook routes for Hosted Auth account notifications.
+
+Unipile calls notify_url server-to-server when a user completes Hosted Auth.
+This provides a fallback when the browser success redirect fails.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Request
+from loguru import logger
+
+from services.integrations.linkedin_oauth import LinkedInOAuthService
+
+router = APIRouter(prefix="/api/unipile", tags=["Unipile"])
+_oauth_service = LinkedInOAuthService()
+
+_SUCCESS_STATUSES = frozenset(
+    {
+        "OK",
+        "RUNNING",
+        "CONNECTED",
+        "CREATION_SUCCESS",
+        "SYNC_SUCCESS",
+        "SUCCESS",
+    }
+)
+
+
+def _extract_webhook_fields(payload: Dict[str, Any]) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Parse account_id, ALwrity user id (name), and status from Unipile webhook payloads."""
+    account_id = payload.get("account_id") or payload.get("accountId")
+    user_id = payload.get("name")
+    status = payload.get("status") or payload.get("message")
+
+    account_status = payload.get("AccountStatus")
+    if isinstance(account_status, dict):
+        account_id = account_id or account_status.get("account_id")
+        status = status or account_status.get("message") or account_status.get("status")
+
+    account = payload.get("account")
+    if isinstance(account, dict):
+        account_id = account_id or account.get("id") or account.get("account_id")
+        user_id = user_id or account.get("name")
+        status = status or account.get("status")
+
+    return (
+        str(account_id) if account_id else None,
+        str(user_id) if user_id else None,
+        str(status) if status else None,
+    )
+
+
+@router.post("/webhook")
+async def handle_unipile_webhook(request: Request) -> Dict[str, bool]:
+    """
+    Receive Unipile Hosted Auth / account status notifications.
+
+    Unipile requires HTTP 200 within 30 seconds; always return 200 when parsed.
+    """
+    try:
+        payload = await request.json()
+    except Exception as exc:
+        logger.warning(f"[UnipileWebhook] Invalid JSON body: {exc}")
+        return {"ok": True}
+
+    if not isinstance(payload, dict):
+        logger.warning("[UnipileWebhook] Payload is not a JSON object")
+        return {"ok": True}
+
+    account_id, user_id, status = _extract_webhook_fields(payload)
+    logger.info(
+        f"[UnipileWebhook] Received notification account_id={account_id} "
+        f"user_id={user_id} status={status} keys={list(payload.keys())}"
+    )
+
+    if not account_id or not user_id:
+        logger.warning(
+            "[UnipileWebhook] Missing account_id or name; skipping credential storage"
+        )
+        return {"ok": True}
+
+    normalized_status = (status or "OK").upper()
+    if normalized_status not in _SUCCESS_STATUSES:
+        logger.info(
+            f"[UnipileWebhook] Non-success status={normalized_status} for user_id={user_id}; "
+            "skipping credential storage"
+        )
+        return {"ok": True}
+
+    stored = await _oauth_service.handle_unipile_callback(
+        user_id=user_id,
+        account_id=account_id,
+        status="success",
+    )
+    logger.info(
+        f"[UnipileWebhook] Credential storage user_id={user_id} "
+        f"account_id={account_id} stored={stored}"
+    )
+    return {"ok": stored}

--- a/backend/main.py
+++ b/backend/main.py
@@ -185,11 +185,7 @@ rate_limiter = RateLimiter(window_seconds=60, max_requests=200)
 frontend_serving = FrontendServing(app)
 router_manager = RouterManager(app)
 
-onboarding_manager = None
-if OnboardingManager is not None:
-    onboarding_manager = OnboardingManager(app)
-else:
-    logger.info("OnboardingManager is disabled due to feature mode configuration")
+onboarding_manager = OnboardingManager(app)
 
 # Middleware Order (FastAPI executes in REVERSE order of registration - LIFO):
 # Registration order:  1. Monitoring  2. Rate Limit  3. API Key Injection
@@ -259,12 +255,6 @@ async def feature_profile_status():
 @app.get("/api/onboarding/status")
 async def onboarding_status():
     """Get onboarding manager status."""
-    if onboarding_manager is None:
-        return {
-            "enabled": False,
-            "status": "disabled",
-            "message": "Onboarding manager is disabled in this runtime configuration.",
-        }
     return onboarding_manager.get_onboarding_status()
 
 # Include routers using modular utilities

--- a/backend/main.py
+++ b/backend/main.py
@@ -185,7 +185,11 @@ rate_limiter = RateLimiter(window_seconds=60, max_requests=200)
 frontend_serving = FrontendServing(app)
 router_manager = RouterManager(app)
 
-onboarding_manager = OnboardingManager(app)
+onboarding_manager = None
+if OnboardingManager is not None:
+    onboarding_manager = OnboardingManager(app)
+else:
+    logger.info("OnboardingManager is disabled due to feature mode configuration")
 
 # Middleware Order (FastAPI executes in REVERSE order of registration - LIFO):
 # Registration order:  1. Monitoring  2. Rate Limit  3. API Key Injection
@@ -255,6 +259,12 @@ async def feature_profile_status():
 @app.get("/api/onboarding/status")
 async def onboarding_status():
     """Get onboarding manager status."""
+    if onboarding_manager is None:
+        return {
+            "enabled": False,
+            "status": "disabled",
+            "message": "Onboarding manager is disabled in this runtime configuration.",
+        }
     return onboarding_manager.get_onboarding_status()
 
 # Include routers using modular utilities

--- a/backend/models/linkedin_social_models.py
+++ b/backend/models/linkedin_social_models.py
@@ -1,0 +1,215 @@
+"""
+Pydantic models for LinkedIn Social API (Growth Engine).
+Separate from linkedin_models.py (Writer content generation).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class LinkedInConnectionStatusResponse(BaseModel):
+    connected: bool
+    provider: str
+    has_per_user_token: bool = False
+    has_env_fallback: bool = False
+    accounts: List[Dict[str, Any]] = Field(default_factory=list)
+    organizations: List[Dict[str, Any]] = Field(default_factory=list)
+    account_name: Optional[str] = None
+
+
+class LinkedInAccountResponse(BaseModel):
+    account_id: str
+    account_type: Optional[str] = None
+    username: Optional[str] = None
+    avatar_url: Optional[str] = None
+    platform: str = "linkedin"
+
+
+class LinkedInAccountsListResponse(BaseModel):
+    accounts: List[LinkedInAccountResponse]
+    provider: str
+
+
+class LinkedInOrganizationResponse(BaseModel):
+    organization_id: str
+    name: Optional[str] = None
+    urn: Optional[str] = None
+
+
+class LinkedInOrganizationsListResponse(BaseModel):
+    organizations: List[LinkedInOrganizationResponse]
+    account_id: str
+
+
+class LinkedInAnalyticsResponse(BaseModel):
+    success: bool = True
+    data: Dict[str, Any] = Field(default_factory=dict)
+    provider: str
+
+
+class LinkedInAnalyticsDateRangeResponse(BaseModel):
+    start: str
+    endExclusive: str
+    label: str
+    dataLagDays: int = 2
+
+
+class LinkedInLandingPersonalAnalyticsResponse(BaseModel):
+    accountId: str
+    avatarUrl: Optional[str] = None
+    analytics: Dict[str, Any] = Field(default_factory=dict)
+    error: Optional[str] = None
+
+
+class LinkedInLandingOrgAnalyticsResponse(BaseModel):
+    accountId: Optional[str] = None
+    orgId: Optional[str] = None
+    orgName: Optional[str] = None
+    avatarUrl: Optional[str] = None
+    analytics: Dict[str, Any] = Field(default_factory=dict)
+    error: Optional[str] = None
+
+
+class LinkedInLandingAnalyticsResponse(BaseModel):
+    dateRange: LinkedInAnalyticsDateRangeResponse
+    personal: LinkedInLandingPersonalAnalyticsResponse
+    organization: Optional[LinkedInLandingOrgAnalyticsResponse] = None
+    dataDelayNote: Optional[str] = None
+    provider: str
+
+
+class LinkedInPersonalAnalyticsResponse(BaseModel):
+    dateRange: LinkedInAnalyticsDateRangeResponse
+    personal: LinkedInLandingPersonalAnalyticsResponse
+    provider: str
+
+
+class LinkedInProfileMetaResponse(BaseModel):
+    """Acquisition metadata for GET /api/linkedin-social/profile."""
+
+    source: Literal["cache", "unipile"]
+    fetched_at: Optional[str] = None
+    profile_content_hash: Optional[str] = None
+
+
+class LinkedInProfileContextMetaResponse(BaseModel):
+    """Profile context build/cache metadata (Phase 2)."""
+
+    source: Literal["cache", "built"]
+    profile_context_updated_at: Optional[str] = None
+
+
+class ProfileValidationResponse(BaseModel):
+    """Phase 3 profile completeness validation result."""
+
+    is_profile_complete: bool
+    completeness_score: int
+    missing_fields: List[str] = Field(default_factory=list)
+    optional_missing_fields: List[str] = Field(default_factory=list)
+
+
+class CompletionQuestionResponse(BaseModel):
+    """Single profile completion question for the UI."""
+
+    field_key: str
+    label: str
+    input_type: Literal["text", "textarea", "tags"]
+    required: bool = True
+
+
+class ProfileCompletionResponse(BaseModel):
+    """Profile completion questions derived from validation."""
+
+    questions: List[CompletionQuestionResponse] = Field(default_factory=list)
+
+
+class AIProfileIntelligenceResponse(BaseModel):
+    """Phase 5 AI profile understanding (LLM fields only — no server meta)."""
+
+    professional_identity: str
+    primary_expertise: List[str] = Field(default_factory=list)
+    industry: str
+    experience_level: str
+    knowledge_domains: List[str] = Field(default_factory=list)
+    writing_opportunities: List[str] = Field(default_factory=list)
+    target_audience: List[str] = Field(default_factory=list)
+    communication_style: str
+    brand_positioning: str
+    summary: str
+
+
+class ProfileIntelligenceMetaResponse(BaseModel):
+    """Phase 5 intelligence acquisition metadata."""
+
+    source: Literal["cache", "generated"]
+    ai_intelligence_updated_at: Optional[str] = None
+
+
+class TopicRecommendationResponse(BaseModel):
+    """Phase 6 single personalized content recommendation."""
+
+    id: str
+    title: str
+    why_this_fits: str
+    recommended_format: Literal["LinkedIn Post", "LinkedIn Article"]
+    target_audience: List[str] = Field(default_factory=list)
+    growth_impact: Literal["High", "Medium", "Low"]
+
+
+class TopicRecommendationsMetaResponse(BaseModel):
+    """Phase 6 recommendations acquisition metadata."""
+
+    source: Literal["cache", "generated"]
+    recommendations_updated_at: Optional[str] = None
+
+
+class ProfileAnalysisErrorResponse(BaseModel):
+    """Structured failure from the LinkedIn analysis pipeline (Phases 1–6)."""
+
+    failed_phase: int = Field(..., ge=1, le=6)
+    phase_label: str
+    error_code: str
+    user_message: str
+    debug_message: Optional[str] = None
+
+
+class LinkedInProfileAcquireResponse(BaseModel):
+    """Normalized own-profile snapshot with Phase 2–6 analysis context."""
+
+    profile: Dict[str, Any] = Field(default_factory=dict)
+    meta: LinkedInProfileMetaResponse
+    profile_context: Dict[str, Any] = Field(default_factory=dict)
+    profile_context_meta: LinkedInProfileContextMetaResponse
+    profile_validation: Optional[ProfileValidationResponse] = None
+    profile_completion: Optional[ProfileCompletionResponse] = None
+    ai_profile_intelligence: Optional[AIProfileIntelligenceResponse] = None
+    ai_profile_intelligence_meta: Optional[ProfileIntelligenceMetaResponse] = None
+    recommendations: Optional[List[TopicRecommendationResponse]] = None
+    recommendations_meta: Optional[TopicRecommendationsMetaResponse] = None
+    recommendations_error: Optional[str] = None
+    last_completed_phase: Optional[int] = Field(
+        None,
+        ge=1,
+        le=6,
+        description="Highest pipeline phase that completed successfully in this request",
+    )
+    analysis_error: Optional[ProfileAnalysisErrorResponse] = None
+
+
+class LinkedInProfileCompleteRequest(BaseModel):
+    """Request body for POST /api/linkedin-social/profile/complete."""
+
+    answers: Dict[str, Any] = Field(default_factory=dict)
+
+
+class LinkedInProfileCompleteResponse(BaseModel):
+    """Response for POST /api/linkedin-social/profile/complete."""
+
+    profile_context: Dict[str, Any] = Field(default_factory=dict)
+    profile_validation: ProfileValidationResponse
+    profile_completion: ProfileCompletionResponse
+    ai_profile_intelligence: Optional[AIProfileIntelligenceResponse] = None
+    ai_profile_intelligence_meta: Optional[ProfileIntelligenceMetaResponse] = None

--- a/backend/prompts/__init__.py
+++ b/backend/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""LinkedIn Writer prompt templates."""

--- a/backend/prompts/linkedin/__init__.py
+++ b/backend/prompts/linkedin/__init__.py
@@ -1,0 +1,1 @@
+"""LinkedIn profile intelligence prompts (Phase 5)."""

--- a/backend/prompts/linkedin/profile_intelligence_prompt.py
+++ b/backend/prompts/linkedin/profile_intelligence_prompt.py
@@ -1,0 +1,58 @@
+"""
+Phase 5 — LinkedIn profile intelligence LLM prompts.
+
+Prompt engineering only. No service, repository, or business-logic imports.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+PROFILE_INTELLIGENCE_SYSTEM_PROMPT = """You are ALwrity's LinkedIn Profile Intelligence analyzer.
+
+Your task is to understand who this LinkedIn professional is based ONLY on the
+LinkedInProfileContext JSON provided in the user message.
+
+Rules:
+- Analyze ONLY the provided Profile Context JSON. Do not use outside knowledge.
+- Do not invent facts, employers, titles, skills, or credentials not supported by the data.
+- If evidence for a scalar field is missing, set that field to "Unknown".
+- List fields may be empty arrays when the profile lacks supporting data.
+- Be objective, concise, and professional. Avoid marketing hype or exaggeration.
+- writing_opportunities must be professional themes implied by the profile
+  (e.g. "Backend Best Practices") — NOT post titles, hashtags, or topic suggestions.
+- Return valid JSON only. No markdown fences, commentary, or extra keys.
+- Do NOT include a "meta" field — metadata is added server-side.
+
+Return a JSON object with exactly these keys:
+- professional_identity (string)
+- primary_expertise (array of strings)
+- industry (string)
+- experience_level (string; e.g. Junior, Mid, Senior, Executive, or Unknown)
+- knowledge_domains (array of strings)
+- writing_opportunities (array of strings)
+- target_audience (array of strings)
+- communication_style (string)
+- brand_positioning (string)
+- summary (string; concise professional summary grounded in the profile)
+"""
+
+
+def build_profile_intelligence_user_prompt(context: dict[str, Any]) -> str:
+    """
+    Build the user message for profile intelligence generation.
+
+    Args:
+        context: ``LinkedInProfileContext`` dict (sole LLM input)
+
+    Returns:
+        Compact JSON serialization of ``context``
+
+    Raises:
+        TypeError: When ``context`` is not a dict
+    """
+    if not isinstance(context, dict):
+        raise TypeError("profile context must be a dict")
+
+    return json.dumps(context, sort_keys=True, separators=(",", ":"), default=str)

--- a/backend/prompts/linkedin/topic_recommendation_prompt.py
+++ b/backend/prompts/linkedin/topic_recommendation_prompt.py
@@ -1,0 +1,59 @@
+"""
+Phase 6 — LinkedIn topic recommendation LLM prompts.
+
+Prompt engineering only. No service, repository, or business-logic imports.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+TOPIC_RECOMMENDATION_SYSTEM_PROMPT = """You are ALwrity's LinkedIn Content Advisor.
+
+Your task is to recommend exactly five personalized LinkedIn content ideas based ONLY on
+the AIProfileIntelligence JSON provided in the user message.
+
+Rules:
+- Read ONLY the provided AI Profile Intelligence JSON. Do not use outside knowledge.
+- Recommend exactly five content ideas — not post bodies, not hashtags, not drafts.
+- Each idea must be relevant to the user's expertise and professional brand.
+- Expand on writing_opportunities themes — do NOT copy them verbatim.
+- Explain why each idea fits the user in second person ("your expertise…").
+- recommended_format must be exactly "LinkedIn Post" or "LinkedIn Article".
+- target_audience must contain 1–4 professional audience labels (strings).
+- growth_impact must be exactly "High", "Medium", or "Low".
+- Avoid generic motivational quotes, viral clickbait, and irrelevant topics.
+- Return valid JSON only. No markdown fences, commentary, or extra keys.
+- Do NOT include "id" or "meta" fields — those are added server-side.
+
+Return a JSON object with exactly one key:
+- recommendations (array of exactly 5 objects)
+
+Each recommendation object must have exactly these keys:
+- title (string; concise content idea headline)
+- why_this_fits (string; 1–2 sentences explaining fit to this user)
+- recommended_format (string; "LinkedIn Post" or "LinkedIn Article")
+- target_audience (array of strings)
+- growth_impact (string; "High", "Medium", or "Low")
+"""
+
+
+def build_topic_recommendation_user_prompt(intelligence: dict[str, Any]) -> str:
+    """
+    Build the user message for topic recommendation generation.
+
+    Args:
+        intelligence: ``AIProfileIntelligence`` dict (LLM fields only; ``meta`` stripped)
+
+    Returns:
+        Compact JSON serialization of intelligence fields
+
+    Raises:
+        TypeError: When ``intelligence`` is not a dict
+    """
+    if not isinstance(intelligence, dict):
+        raise TypeError("AI profile intelligence must be a dict")
+
+    payload = {key: value for key, value in intelligence.items() if key != "meta"}
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)

--- a/backend/scripts/linkedin_fetch_profile.py
+++ b/backend/scripts/linkedin_fetch_profile.py
@@ -1,0 +1,735 @@
+"""
+LinkedIn profile acquire CLI — Phase 1 (fetch, normalize, persist, cache).
+
+Modes:
+  - Default: cache-first acquire via get_or_fetch_profile (persists to SQLite)
+  - --refresh: force Unipile fetch and DB update
+  - --dry-run: fetch + normalize only (Steps 1.1–1.2 gate; no persistence)
+  - --from-fixture: offline normalizer test from saved JSON
+  - --print-context: build Phase 2 profile context (persist when --user-id acquire)
+
+Usage:
+    python backend/scripts/linkedin_fetch_profile.py --user-id USER_ID
+    python backend/scripts/linkedin_fetch_profile.py --user-id USER_ID --refresh
+    python backend/scripts/linkedin_fetch_profile.py --user-id USER_ID --print-json
+    python backend/scripts/linkedin_fetch_profile.py --user-id USER_ID --print-context
+    python backend/scripts/linkedin_fetch_profile.py --user-id USER_ID --dry-run
+    python backend/scripts/linkedin_fetch_profile.py --from-fixture PATH --print-context
+    python backend/scripts/linkedin_fetch_profile.py --from-fixture docs/linkedin/fixtures/sample_user_profile_raw.json --print-normalized
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(backend_dir))
+
+from dotenv import load_dotenv
+
+load_dotenv(backend_dir / ".env")
+
+from loguru import logger
+
+from services.integrations.linkedin.profile_context_builder import build_profile_context
+from services.integrations.linkedin.profile_context_service import get_or_build_profile_context
+from services.integrations.linkedin.profile_context_types import (
+    ProfileContextBuildError,
+    validate_profile_context,
+)
+from services.integrations.linkedin.profile_repository import (
+    ProfileRepository,
+    compute_profile_content_hash,
+)
+from services.integrations.linkedin.profile_service import (
+    get_or_fetch_profile,
+    normalize_unipile_profile,
+    validate_normalized_profile,
+)
+from services.integrations.linkedin.types import LinkedInNotConnectedError
+from services.integrations.linkedin.unipile_client import UnipileAPIError
+from services.integrations.linkedin.unipile_provider import UnipileProvider
+from services.integrations.linkedin_oauth import LinkedInOAuthService
+
+# Official response type for GET /api/v1/users/me (Retrieve own profile).
+ACCOUNT_OWNER_PROFILE_OBJECT = "AccountOwnerProfile"
+
+# Returned by GET /api/v1/users/{identifier} with linkedin_sections (full acquire path).
+USER_PROFILE_OBJECT = "UserProfile"
+
+FIXTURE_ACCEPTED_OBJECTS: frozenset[str] = frozenset(
+    {ACCOUNT_OWNER_PROFILE_OBJECT, USER_PROFILE_OBJECT}
+)
+
+SECTION_COUNT_KEYS: tuple[str, ...] = (
+    "work_experience_total_count",
+    "education_total_count",
+    "skills_total_count",
+    "languages_total_count",
+    "certifications_total_count",
+    "volunteering_experience_total_count",
+    "projects_total_count",
+)
+
+SECTION_ARRAY_KEYS: tuple[str, ...] = (
+    "work_experience",
+    "education",
+    "skills",
+    "languages",
+    "certifications",
+    "volunteering_experience",
+    "projects",
+)
+
+
+def _section_counts_from_raw(profile: dict[str, Any]) -> dict[str, int]:
+    """Extract section counts from a raw Unipile profile payload."""
+    counts: dict[str, int] = {}
+    for key in SECTION_COUNT_KEYS:
+        value = profile.get(key)
+        if isinstance(value, int):
+            counts[key] = value
+    for array_key in SECTION_ARRAY_KEYS:
+        items = profile.get(array_key)
+        if isinstance(items, list) and array_key not in counts:
+            counts[f"{array_key}_length"] = len(items)
+    recommendations = profile.get("recommendations")
+    if isinstance(recommendations, dict):
+        for rec_key in ("given_total_count", "received_total_count"):
+            value = recommendations.get(rec_key)
+            if isinstance(value, int):
+                counts[f"recommendations_{rec_key}"] = value
+    return counts
+
+
+def _section_counts_from_normalized(profile: dict[str, Any]) -> dict[str, int]:
+    """Extract section counts from a normalized ALwrity profile."""
+    return {
+        "work_experience_total_count": profile.get("work_experience_total_count", 0),
+        "education_total_count": profile.get("education_total_count", 0),
+        "skills_total_count": profile.get("skills_total_count", 0),
+        "languages_total_count": profile.get("languages_total_count", 0),
+        "certifications_total_count": profile.get("certifications_total_count", 0),
+        "volunteering_experience_total_count": profile.get(
+            "volunteering_experience_total_count", 0
+        ),
+        "projects_total_count": profile.get("projects_total_count", 0),
+        "recommendations_given_count": profile.get("recommendations_given_count", 0),
+        "recommendations_received_count": profile.get(
+            "recommendations_received_count", 0
+        ),
+    }
+
+
+def _validate_gate(
+    profile: dict[str, Any],
+    *,
+    require_user_profile: bool = False,
+) -> list[str]:
+    """Validate Step 1.1 gate criteria for raw Unipile payloads."""
+    errors: list[str] = []
+
+    object_type = profile.get("object")
+    if require_user_profile:
+        if object_type != USER_PROFILE_OBJECT:
+            errors.append(
+                f"object must be {USER_PROFILE_OBJECT!r} on full acquire path, "
+                f"got {object_type!r}"
+            )
+    elif object_type not in FIXTURE_ACCEPTED_OBJECTS:
+        errors.append(
+            f"object must be one of {sorted(FIXTURE_ACCEPTED_OBJECTS)!r}, "
+            f"got {object_type!r}"
+        )
+
+    provider = profile.get("provider")
+    if provider is not None and provider != "LINKEDIN":
+        errors.append(f"provider must be 'LINKEDIN', got {provider!r}")
+
+    identity_fields = (
+        profile.get("first_name"),
+        profile.get("last_name"),
+        profile.get("headline"),
+        profile.get("provider_id"),
+        profile.get("public_identifier"),
+    )
+    if not any(isinstance(value, str) and value.strip() for value in identity_fields):
+        errors.append(
+            "at least one identity field required "
+            "(first_name, last_name, headline, provider_id, or public_identifier)"
+        )
+
+    if require_user_profile and object_type == USER_PROFILE_OBJECT:
+        is_self = profile.get("is_self")
+        if is_self is False:
+            logger.warning(
+                "[LinkedInProfile] is_self=False on own-profile UserProfile fetch — unexpected"
+            )
+
+    return errors
+
+
+def _print_acquire_summary(
+    normalized: dict[str, Any],
+    meta: dict[str, Any],
+    *,
+    user_id: str,
+) -> None:
+    """Print Step 1.3–1.5 acquire summary to stdout."""
+    counts = _section_counts_from_normalized(normalized)
+
+    print("\n" + "=" * 60)
+    print("LinkedIn Own Profile — Phase 1 Acquire Summary")
+    print("=" * 60)
+    print(f"user_id:                 {user_id}")
+    print(f"source:                  {meta.get('source')}")
+    print(f"fetched_at:              {meta.get('fetched_at') or '(not set)'}")
+    print(f"profile_content_hash:    {meta.get('profile_content_hash') or '(not set)'}")
+    print(f"name:                    {normalized.get('name') or '(empty)'}")
+    print(f"headline:                {normalized.get('headline') or '(empty)'}")
+    print(f"job_title:               {normalized.get('job_title') or '(empty)'}")
+    print(f"company:                 {normalized.get('company') or '(empty)'}")
+    print(f"is_self:                 {normalized.get('is_self')}")
+    print(f"followers:               {normalized.get('followers')}")
+    print(f"connections:             {normalized.get('connections')}")
+    print("\nSection counts:")
+    for key, value in sorted(counts.items()):
+        print(f"  {key}: {value}")
+    print("=" * 60 + "\n")
+
+
+def _print_dry_run_summary(profile: dict[str, Any], *, user_id: str, account_id: str) -> None:
+    """Print Step 1.1 dry-run summary to stdout."""
+    counts = _section_counts_from_raw(profile)
+    name_parts = [
+        profile.get("first_name") or "",
+        profile.get("last_name") or "",
+    ]
+    display_name = " ".join(part for part in name_parts if part).strip()
+
+    print("\n" + "=" * 60)
+    print("LinkedIn Own Profile — Phase 1 Step 1.1 Gate Summary")
+    print("=" * 60)
+    print(f"user_id:        {user_id}")
+    print(f"account_id:     {account_id}")
+    print(f"object:         {profile.get('object')}")
+    is_self = profile.get("is_self")
+    if is_self is None:
+        print("is_self:        (not returned — expected for AccountOwnerProfile)")
+    else:
+        print(f"is_self:        {is_self}")
+    print(f"provider:       {profile.get('provider')}")
+    print(f"public_id:      {profile.get('public_identifier')}")
+    print(f"name:           {display_name or '(empty)'}")
+    print(f"headline:       {profile.get('headline') or '(empty)'}")
+    print(f"follower_count: {profile.get('follower_count')}")
+    print(f"connections:    {profile.get('connections_count')}")
+    print("\nSection counts:")
+    if counts:
+        for key, value in sorted(counts.items()):
+            print(f"  {key}: {value}")
+    else:
+        print("  (no section count fields returned — check linkedin_sections param)")
+    print("=" * 60 + "\n")
+
+
+def _print_normalized_summary(normalized: dict[str, Any]) -> None:
+    """Print Step 1.2 normalization summary."""
+    print("\n" + "-" * 60)
+    print("Phase 1 Step 1.2 — Normalized Profile Summary")
+    print("-" * 60)
+    print(f"name:              {normalized.get('name') or '(empty)'}")
+    print(f"headline:          {normalized.get('headline') or '(empty)'}")
+    print(f"job_title:         {normalized.get('job_title') or '(empty)'}")
+    print(f"company:           {normalized.get('company') or '(empty)'}")
+    print(f"about length:      {len(normalized.get('about') or '')}")
+    print(f"experience count:  {len(normalized.get('experience') or [])}")
+    print(f"education count:   {len(normalized.get('education') or [])}")
+    print(f"skills count:      {len(normalized.get('skills') or [])}")
+    print(f"profile_url:       {normalized.get('profile_url') or '(empty)'}")
+    print(f"is_self:           {normalized.get('is_self')}")
+    print("-" * 60 + "\n")
+
+
+def _section_counts_from_profile_context(context: dict[str, Any]) -> dict[str, int]:
+    """Extract section counts from a Phase 2 profile context."""
+    personal = context.get("personal_information") if isinstance(context, dict) else {}
+    professional = context.get("professional_information") if isinstance(context, dict) else {}
+    linkedin = context.get("linkedin_information") if isinstance(context, dict) else {}
+    if not isinstance(personal, dict):
+        personal = {}
+    if not isinstance(professional, dict):
+        professional = {}
+    if not isinstance(linkedin, dict):
+        linkedin = {}
+
+    recommendations = professional.get("recommendations")
+    rec_given = 0
+    rec_received = 0
+    if isinstance(recommendations, dict):
+        given = recommendations.get("given")
+        received = recommendations.get("received")
+        rec_given = len(given) if isinstance(given, list) else 0
+        rec_received = len(received) if isinstance(received, list) else 0
+
+    return {
+        "experience_count": len(professional.get("experience") or []),
+        "experience_total_count": professional.get("experience_total_count", 0),
+        "education_count": len(professional.get("education") or []),
+        "education_total_count": professional.get("education_total_count", 0),
+        "skills_count": len(professional.get("skills") or []),
+        "skills_total_count": professional.get("skills_total_count", 0),
+        "languages_total_count": professional.get("languages_total_count", 0),
+        "certifications_total_count": professional.get("certifications_total_count", 0),
+        "projects_total_count": professional.get("projects_total_count", 0),
+        "volunteering_experience_total_count": professional.get(
+            "volunteering_experience_total_count", 0
+        ),
+        "recommendations_given_count": professional.get(
+            "recommendations_given_count", rec_given
+        ),
+        "recommendations_received_count": professional.get(
+            "recommendations_received_count", rec_received
+        ),
+        "followers": linkedin.get("followers", 0),
+        "connections": linkedin.get("connections", 0),
+        "about_length": len(personal.get("about") or ""),
+    }
+
+
+def _print_profile_context_summary(
+    context: dict[str, Any],
+    context_meta: dict[str, Any],
+    *,
+    user_id: str,
+) -> None:
+    """Print Phase 2 profile context summary to stdout."""
+    counts = _section_counts_from_profile_context(context)
+    personal = context.get("personal_information") or {}
+    professional = context.get("professional_information") or {}
+    context_meta_section = context.get("meta") or {}
+
+    print("\n" + "=" * 60)
+    print("LinkedIn Profile Context — Phase 2 Summary")
+    print("=" * 60)
+    print(f"user_id:                      {user_id}")
+    print(f"context_source:               {context_meta.get('source')}")
+    print(
+        "profile_context_updated_at:   "
+        f"{context_meta.get('profile_context_updated_at') or '(not persisted)'}"
+    )
+    print(
+        "built_from_profile_content_hash: "
+        f"{context_meta_section.get('built_from_profile_content_hash') or '(not set)'}"
+    )
+    print(f"name:                         {personal.get('name') or '(empty)'}")
+    print(f"headline:                     {personal.get('headline') or '(empty)'}")
+    print(f"job_title:                    {professional.get('job_title') or '(empty)'}")
+    print(f"company:                      {professional.get('company') or '(empty)'}")
+    print(f"industry:                     {professional.get('industry') or '(empty)'}")
+    print("\nSection counts:")
+    for key, value in sorted(counts.items()):
+        print(f"  {key}: {value}")
+    print("=" * 60 + "\n")
+
+
+def _resolve_profile_context(
+    normalized: dict[str, Any],
+    meta: dict[str, Any],
+    *,
+    user_id: str | None,
+    persist: bool,
+    oauth: LinkedInOAuthService | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """
+    Build or load profile context (mirrors GET /profile Phase 2 path when persisting).
+
+    Args:
+        normalized: Phase 1 normalized profile
+        meta: Phase 1 acquire meta (may include profile_content_hash)
+        user_id: ALwrity user ID when persisting to SQLite
+        persist: When True, use cache-first ``get_or_build_profile_context``
+        oauth: Optional OAuth service for repository
+
+    Returns:
+        Tuple of (profile context dict, context meta dict)
+    """
+    content_hash = meta.get("profile_content_hash") or compute_profile_content_hash(normalized)
+
+    if persist:
+        if not user_id:
+            raise ValueError("user_id is required when persisting profile context")
+        oauth_service = oauth or LinkedInOAuthService()
+        repository = ProfileRepository(oauth=oauth_service)
+        return get_or_build_profile_context(
+            user_id,
+            normalized,
+            profile_content_hash=content_hash,
+            repository=repository,
+        )
+
+    context = build_profile_context(normalized, content_hash=content_hash)
+    return context, {
+        "source": "built",
+        "profile_context_updated_at": None,
+    }
+
+
+def _emit_profile_context(
+    normalized: dict[str, Any],
+    meta: dict[str, Any],
+    *,
+    user_id: str,
+    persist: bool,
+    print_context_json: bool,
+    oauth: LinkedInOAuthService | None = None,
+) -> int:
+    """Build profile context, print summary, optionally print JSON; return exit code."""
+    logger.info(
+        "[LinkedInProfileContext] CLI build context user_id={} persist={}",
+        user_id,
+        persist,
+    )
+    try:
+        context, context_meta = _resolve_profile_context(
+            normalized,
+            meta,
+            user_id=user_id if persist else None,
+            persist=persist,
+            oauth=oauth,
+        )
+    except ProfileContextBuildError as exc:
+        logger.error("[LinkedInProfileContext] Failed to build profile context: {}", exc)
+        return 1
+    except ValueError as exc:
+        logger.error("[LinkedInProfileContext] Profile context error: {}", exc)
+        return 1
+    except Exception:
+        logger.exception("[LinkedInProfileContext] Unexpected error building profile context")
+        return 1
+
+    context_errors = validate_profile_context(context)
+    _print_profile_context_summary(context, context_meta, user_id=user_id)
+
+    if print_context_json:
+        print(json.dumps(context, indent=2, default=str))
+
+    if context_errors:
+        logger.error("[LinkedInProfileContext] Profile context validation FAILED:")
+        for error in context_errors:
+            logger.error("  - {}", error)
+        return 1
+
+    logger.info(
+        "[LinkedInProfileContext] Context complete source={} user_id={}",
+        context_meta.get("source"),
+        user_id,
+    )
+    return 0
+
+
+def _load_fixture(path: str) -> dict[str, Any]:
+    """Load raw Unipile JSON fixture from disk."""
+    fixture_path = Path(path)
+    if not fixture_path.is_file():
+        raise FileNotFoundError(f"Fixture not found: {fixture_path}")
+    with fixture_path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"Fixture must be a JSON object, got {type(data).__name__}")
+    return data
+
+
+async def _run_acquire(args: argparse.Namespace) -> int:
+    """Cache-first acquire: fetch, normalize, persist (Steps 1.3–1.5)."""
+    user_id = args.user_id.strip()
+    if not user_id:
+        logger.error("--user-id is required")
+        return 2
+
+    logger.info(
+        "[LinkedInProfile] Phase 1 acquire user_id={} refresh={}",
+        user_id,
+        args.refresh,
+    )
+
+    try:
+        normalized, meta = await get_or_fetch_profile(
+            user_id,
+            refresh=args.refresh,
+            linkedin_sections=args.linkedin_sections,
+        )
+    except LinkedInNotConnectedError as exc:
+        logger.error(f"LinkedIn not connected: {exc}")
+        return 1
+    except UnipileAPIError as exc:
+        logger.error(f"Unipile API error: {exc}")
+        return 1
+    except Exception:
+        logger.exception("[LinkedInProfile] Unexpected error during profile acquire")
+        return 1
+
+    norm_errors = validate_normalized_profile(normalized)
+    _print_acquire_summary(normalized, meta, user_id=user_id)
+
+    if args.print_json or args.print_normalized:
+        print(json.dumps(normalized, indent=2, default=str))
+
+    if norm_errors:
+        logger.error("[LinkedInProfile] Normalized profile validation FAILED:")
+        for error in norm_errors:
+            logger.error("  - {}", error)
+        return 1
+
+    if args.print_context:
+        context_code = _emit_profile_context(
+            normalized,
+            meta,
+            user_id=user_id,
+            persist=True,
+            print_context_json=True,
+        )
+        if context_code != 0:
+            return context_code
+
+    logger.info(
+        "[LinkedInProfile] Acquire complete source={} user_id={}",
+        meta.get("source"),
+        user_id,
+    )
+    return 0
+
+
+async def _run_dry_run(args: argparse.Namespace) -> int:
+    """Fetch profile, normalize, validate gates — no persistence (Steps 1.1–1.2)."""
+    if not args.user_id.strip():
+        logger.error("--user-id is required unless --from-fixture is used")
+        return 2
+
+    provider = UnipileProvider()
+    oauth = LinkedInOAuthService()
+
+    try:
+        creds = oauth.resolve_credentials(args.user_id.strip())
+    except LinkedInNotConnectedError as exc:
+        logger.error(f"LinkedIn not connected: {exc}")
+        return 1
+
+    account_id = creds.unipile_account_id
+    if not account_id:
+        logger.error(
+            "No unipile_account_id in credentials. Connect LinkedIn via Unipile first."
+        )
+        return 1
+
+    stored_account_name = creds.account_name
+
+    logger.info("[LinkedInProfile] Phase 1 Step 1.1 — dry-run fetch (two-step v1)")
+    logger.info("[LinkedInProfile] user_id={}", args.user_id)
+    logger.info("[LinkedInProfile] unipile_account_id={}", account_id)
+    logger.info(
+        "[LinkedInProfile] linkedin_sections={} (applied on /users/{{identifier}} only)",
+        args.linkedin_sections,
+    )
+
+    try:
+        profile = await provider.fetch_own_linkedin_profile(
+            args.user_id.strip(),
+            linkedin_sections=args.linkedin_sections,
+        )
+    except LinkedInNotConnectedError as exc:
+        logger.error(f"LinkedIn not connected: {exc}")
+        return 1
+    except UnipileAPIError as exc:
+        logger.error(f"Unipile API error: {exc}")
+        return 1
+    except Exception:
+        logger.exception("[LinkedInProfile] Unexpected error during profile fetch")
+        return 1
+
+    if not isinstance(profile, dict):
+        logger.error(f"Expected dict profile payload, got {type(profile).__name__}")
+        return 1
+
+    gate_errors = _validate_gate(profile, require_user_profile=True)
+    _print_dry_run_summary(profile, user_id=args.user_id.strip(), account_id=account_id)
+
+    if args.save_raw_fixture:
+        save_path = Path(args.save_raw_fixture)
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        save_path.write_text(json.dumps(profile, indent=2, default=str), encoding="utf-8")
+        logger.info("[LinkedInProfile] Raw profile saved to {}", save_path)
+
+    if args.print_raw_json:
+        print(json.dumps(profile, indent=2, default=str))
+
+    if gate_errors:
+        logger.error("[LinkedInProfile] Step 1.1 gate FAILED:")
+        for error in gate_errors:
+            logger.error("  - {}", error)
+        return 1
+
+    logger.info("[LinkedInProfile] Step 1.1 gate PASSED")
+
+    return _run_normalize_gate(
+        profile,
+        stored_account_name=stored_account_name,
+        print_normalized=args.print_normalized,
+    )
+
+
+def _run_fixture_mode(args: argparse.Namespace) -> int:
+    """Normalize from a saved raw JSON fixture (offline Step 1.2 / Phase 2 context)."""
+    try:
+        profile = _load_fixture(args.from_fixture)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        logger.error("Failed to load fixture: {}", exc)
+        return 1
+
+    logger.info("[LinkedInProfile] Loaded fixture {}", args.from_fixture)
+
+    if args.print_context:
+        logger.info("[LinkedInProfile] Phase 1 Step 1.2 — normalize (fixture context)")
+        normalized = normalize_unipile_profile(profile)
+        norm_errors = validate_normalized_profile(normalized)
+        if norm_errors:
+            logger.error("[LinkedInProfile] Normalized profile validation FAILED:")
+            for error in norm_errors:
+                logger.error("  - {}", error)
+            return 1
+        meta = {"profile_content_hash": compute_profile_content_hash(normalized)}
+        return _emit_profile_context(
+            normalized,
+            meta,
+            user_id="(fixture)",
+            persist=False,
+            print_context_json=True,
+        )
+
+    _print_dry_run_summary(profile, user_id="(fixture)", account_id="(fixture)")
+
+    if args.print_raw_json:
+        print(json.dumps(profile, indent=2, default=str))
+
+    return _run_normalize_gate(profile, print_normalized=args.print_normalized)
+
+
+def _run_normalize_gate(
+    raw_profile: dict[str, Any],
+    *,
+    stored_account_name: str | None = None,
+    print_normalized: bool,
+) -> int:
+    """Run Step 1.2 normalizer and validation gate."""
+    logger.info("[LinkedInProfile] Phase 1 Step 1.2 — normalize")
+    normalized = normalize_unipile_profile(
+        raw_profile,
+        stored_account_name=stored_account_name,
+    )
+    _print_normalized_summary(normalized)
+
+    norm_errors = validate_normalized_profile(normalized)
+    if print_normalized:
+        print(json.dumps(normalized, indent=2, default=str))
+
+    if norm_errors:
+        logger.error("[LinkedInProfile] Step 1.2 gate FAILED:")
+        for error in norm_errors:
+            logger.error("  - {}", error)
+        return 1
+
+    logger.info("[LinkedInProfile] Step 1.2 gate PASSED")
+    logger.info("[LinkedInProfile] Dry-run complete — profile not persisted")
+    return 0
+
+
+async def _run_async_entry(args: argparse.Namespace) -> int:
+    """Route to acquire, dry-run, or fixture mode."""
+    if args.from_fixture:
+        return _run_fixture_mode(args)
+    if args.dry_run:
+        return await _run_dry_run(args)
+    return await _run_acquire(args)
+
+
+def main() -> None:
+    """CLI entry point."""
+    repo_root = backend_dir.parent
+    default_fixture = (
+        repo_root / "docs" / "linkedin" / "fixtures" / "sample_user_profile_raw.json"
+    )
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fetch, normalize, persist LinkedIn profile (Phase 1) "
+            "and build profile context (Phase 2)."
+        )
+    )
+    parser.add_argument(
+        "--user-id",
+        help="ALwrity user ID (Clerk), must have unipile_account_id in linkedin_oauth_tokens",
+    )
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Force Unipile fetch and update DB (default: cache-first)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Fetch and validate gates only; do not persist (Steps 1.1–1.2)",
+    )
+    parser.add_argument(
+        "--from-fixture",
+        metavar="PATH",
+        help=f"Skip API; normalize from raw JSON fixture (default sample: {default_fixture.name})",
+    )
+    parser.add_argument(
+        "--linkedin-sections",
+        default="*",
+        help='Unipile linkedin_sections for step 2 (/users/{identifier}); default: "*"',
+    )
+    parser.add_argument(
+        "--print-json",
+        action="store_true",
+        help="Print normalized ALwrity profile JSON to stdout (acquire mode)",
+    )
+    parser.add_argument(
+        "--print-normalized",
+        action="store_true",
+        help="Print normalized ALwrity profile JSON to stdout",
+    )
+    parser.add_argument(
+        "--print-context",
+        action="store_true",
+        help="Build Phase 2 profile context and print summary + JSON to stdout",
+    )
+    parser.add_argument(
+        "--print-raw-json",
+        action="store_true",
+        help="Print raw Unipile profile JSON to stdout (dry-run / fixture only)",
+    )
+    parser.add_argument(
+        "--save-raw-fixture",
+        metavar="PATH",
+        help="Save fetched raw Unipile JSON to file for offline normalizer testing",
+    )
+    args = parser.parse_args()
+
+    if args.from_fixture is None and not args.user_id:
+        parser.error("--user-id is required unless --from-fixture is provided")
+
+    if args.print_context and args.dry_run:
+        parser.error("--print-context cannot be combined with --dry-run")
+
+    exit_code = asyncio.run(_run_async_entry(args))
+    raise SystemExit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/services/integrations/linkedin/__init__.py
+++ b/backend/services/integrations/linkedin/__init__.py
@@ -1,0 +1,6 @@
+"""
+LinkedIn Growth Engine — provider abstraction package.
+
+Import submodules directly (e.g. factory, types) to avoid circular imports
+between linkedin_oauth and provider implementations.
+"""

--- a/backend/services/integrations/linkedin/account_resolution.py
+++ b/backend/services/integrations/linkedin/account_resolution.py
@@ -1,0 +1,377 @@
+"""
+Resolve personal vs organization LinkedIn accounts from Zernio list_accounts data.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from loguru import logger
+
+from services.integrations.linkedin.types import LinkedInAccount
+from services.integrations.linkedin.zernio_client import (
+    account_id_from_item,
+    account_name_from_item,
+    account_type_from_item,
+    avatar_url_from_item,
+    list_accounts_sync,
+    _parse_account_items,
+)
+
+LOG_PREFIX = "[LinkedInAccounts]"
+
+_PERSONAL_TYPES = frozenset({"personal", "member", "individual"})
+_ORG_TYPES = frozenset({"organization", "org", "company", "page", "brand"})
+
+_HINT_ACCOUNT_ID_RE = re.compile(
+    r"accountId[=:\"'\s]+([a-f0-9]{24}|[a-zA-Z0-9][a-zA-Z0-9_-]{2,})",
+    re.IGNORECASE,
+)
+
+
+def is_personal_account_type(account_type: Optional[str]) -> bool:
+    t = (account_type or "").strip().lower()
+    if not t:
+        return False
+    return t in _PERSONAL_TYPES
+
+
+def is_org_account_type(account_type: Optional[str]) -> bool:
+    t = (account_type or "").strip().lower()
+    if not t:
+        return False
+    return t in _ORG_TYPES or t.startswith("org")
+
+
+def summarize_zernio_account_items(items: list[dict[str, Any]]) -> list[dict[str, Optional[str]]]:
+    return [
+        {
+            "id": account_id_from_item(item) or None,
+            "accountType": account_type_from_item(item),
+            "displayName": account_name_from_item(item),
+        }
+        for item in items
+    ]
+
+
+def fetch_linkedin_account_items(
+    api_key: str,
+    base_url: str,
+    profile_id: Optional[str],
+) -> tuple[list[dict[str, Any]], str]:
+    """
+    Load LinkedIn SocialAccounts from Zernio: profile-scoped first, then global if <2.
+
+    Returns (items, source) where source is ``profile`` or ``global``.
+    """
+    raw = list_accounts_sync(
+        api_key, base_url, profile_id, platform="linkedin", global_scope=False
+    )
+    items = _parse_account_items(raw)
+    source = "profile"
+    summary = summarize_zernio_account_items(items)
+    logger.warning(
+        f"{LOG_PREFIX} list_accounts scope=profile profile_id={profile_id} "
+        f"count={len(items)} items={summary}"
+    )
+
+    if len(items) < 2:
+        global_raw = list_accounts_sync(
+            api_key, base_url, None, platform="linkedin", global_scope=True
+        )
+        global_items = _parse_account_items(global_raw)
+        global_summary = summarize_zernio_account_items(global_items)
+        if len(global_items) > len(items):
+            logger.warning(
+                f"{LOG_PREFIX} list_accounts global fallback profile_count={len(items)} "
+                f"global_count={len(global_items)} items={global_summary}"
+            )
+            items = global_items
+            source = "global"
+        else:
+            logger.warning(
+                f"{LOG_PREFIX} list_accounts global unchanged profile_count={len(items)} "
+                f"global_count={len(global_items)} items={summary}"
+            )
+
+    return items, source
+
+
+def parse_zernio_error_code(message: str) -> Optional[str]:
+    lower = message.lower()
+    if "organization_not_supported" in lower:
+        return "organization_not_supported"
+    if "personal_account_not_supported" in lower:
+        return "personal_account_not_supported"
+    return None
+
+
+def parse_account_id_from_zernio_error(message: str) -> Optional[str]:
+    match = _HINT_ACCOUNT_ID_RE.search(message)
+    if match:
+        return match.group(1)
+    return None
+
+
+def partition_zernio_account_items(
+    items: list[dict[str, Any]],
+) -> tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+    """
+    Split Zernio account dicts into (personal_item, org_item).
+
+    Uses accountType when present; otherwise if exactly two accounts exist,
+    treats the non-personal one as the organization account.
+    """
+    personal_item: Optional[dict[str, Any]] = None
+    org_item: Optional[dict[str, Any]] = None
+
+    for item in items:
+        account_type = account_type_from_item(item)
+        if is_personal_account_type(account_type) and personal_item is None:
+            personal_item = item
+        elif is_org_account_type(account_type) and org_item is None:
+            org_item = item
+
+    if personal_item is None:
+        for item in items:
+            account_type = account_type_from_item(item)
+            if not is_org_account_type(account_type):
+                personal_item = item
+                break
+
+    if org_item is None:
+        for item in items:
+            if item is personal_item:
+                continue
+            account_type = account_type_from_item(item)
+            if is_org_account_type(account_type) or personal_item is not None:
+                org_item = item
+                break
+
+    if org_item is None and len(items) == 2 and personal_item is not None:
+        org_item = next((i for i in items if i is not personal_item), None)
+
+    return personal_item, org_item
+
+
+def find_personal_account(
+    accounts: list[LinkedInAccount],
+) -> Optional[LinkedInAccount]:
+    for account in accounts:
+        if is_personal_account_type(account.account_type):
+            return account
+    for account in accounts:
+        if not is_org_account_type(account.account_type):
+            return account
+    return accounts[0] if accounts else None
+
+
+def find_org_account(
+    accounts: list[LinkedInAccount],
+    *,
+    org_account_id: Optional[str] = None,
+    personal_account_id: Optional[str] = None,
+) -> Optional[LinkedInAccount]:
+    if org_account_id:
+        for account in accounts:
+            if account.account_id == org_account_id:
+                return account
+        return LinkedInAccount(
+            account_id=org_account_id,
+            account_type="organization",
+            platform="linkedin",
+        )
+
+    for account in accounts:
+        if is_org_account_type(account.account_type):
+            return account
+
+    if personal_account_id:
+        for account in accounts:
+            if account.account_id != personal_account_id:
+                return account
+
+    non_personal = [
+        a
+        for a in accounts
+        if not is_personal_account_type(a.account_type)
+        and (not personal_account_id or a.account_id != personal_account_id)
+    ]
+    if len(non_personal) == 1:
+        return non_personal[0]
+
+    return None
+
+
+@dataclass(frozen=True)
+class ResolvedAccountPair:
+    personal: LinkedInAccount
+    org: Optional[LinkedInAccount]
+    method: str
+
+    @property
+    def personal_id(self) -> str:
+        return self.personal.account_id
+
+    @property
+    def org_id(self) -> Optional[str]:
+        return self.org.account_id if self.org else None
+
+
+def _account_by_id(
+    accounts: list[LinkedInAccount], account_id: Optional[str]
+) -> Optional[LinkedInAccount]:
+    if not account_id:
+        return None
+    for account in accounts:
+        if account.account_id == account_id:
+            return account
+    return None
+
+
+def resolve_account_pair(
+    accounts: list[LinkedInAccount],
+    *,
+    stored_personal_id: Optional[str] = None,
+    stored_org_id: Optional[str] = None,
+) -> Optional[ResolvedAccountPair]:
+    """
+    Resolve personal + org Zernio SocialAccounts for analytics routing.
+    """
+    logger.info(
+        f"{LOG_PREFIX} resolve start stored_personal={stored_personal_id} "
+        f"stored_org={stored_org_id} account_count={len(accounts)}"
+    )
+
+    if not accounts:
+        logger.warning(f"{LOG_PREFIX} resolve failed reason=no_accounts")
+        return None
+
+    method = "partition"
+    personal: Optional[LinkedInAccount] = None
+    org: Optional[LinkedInAccount] = None
+
+    stored_personal = (stored_personal_id or "").strip() or None
+    stored_org = (stored_org_id or "").strip() or None
+    if stored_personal and stored_org and stored_personal == stored_org:
+        stored_org = None
+
+    if stored_personal and stored_org and stored_personal != stored_org:
+        personal = _account_by_id(accounts, stored_personal) or LinkedInAccount(
+            account_id=stored_personal,
+            account_type="personal",
+            platform="linkedin",
+        )
+        org = _account_by_id(accounts, stored_org) or LinkedInAccount(
+            account_id=stored_org,
+            account_type="organization",
+            platform="linkedin",
+        )
+        method = "stored"
+    else:
+        if stored_personal:
+            personal = _account_by_id(accounts, stored_personal) or find_personal_account(
+                accounts
+            )
+            method = "stored_personal_id"
+        else:
+            personal = find_personal_account(accounts)
+        if personal:
+            org = find_org_account(
+                accounts,
+                org_account_id=stored_org,
+                personal_account_id=personal.account_id,
+            )
+        if org is None and stored_org and personal and stored_org != personal.account_id:
+            org = LinkedInAccount(
+                account_id=stored_org,
+                account_type="organization",
+                platform="linkedin",
+            )
+            method = "stored_org_id"
+
+    if not personal or not personal.account_id:
+        logger.warning(f"{LOG_PREFIX} resolve failed reason=no_personal_account")
+        return None
+
+    if org is None:
+        logger.warning(
+            f"{LOG_PREFIX} resolve warning org_id=null personal_id={personal.account_id}"
+        )
+    else:
+        logger.warning(
+            f"{LOG_PREFIX} resolve result personal_id={personal.account_id} "
+            f"org_id={org.account_id} method={method}"
+        )
+
+    return ResolvedAccountPair(personal=personal, org=org, method=method)
+
+
+def apply_hint_swap_from_personal_error(
+    message: str,
+    accounts: list[LinkedInAccount],
+    personal_id: str,
+    org_id: Optional[str],
+) -> tuple[str, Optional[str], Optional[str]]:
+    """
+    When personal analytics fails with organization_not_supported, use Zernio hint.
+
+    Returns (new_personal_id, new_org_id, method) or unchanged ids with method=None.
+    """
+    if parse_zernio_error_code(message) != "organization_not_supported":
+        return personal_id, org_id, None
+
+    hint_id = parse_account_id_from_zernio_error(message)
+    if not hint_id:
+        return personal_id, org_id, None
+
+    new_org_id = hint_id
+    new_personal_id = personal_id
+
+    if personal_id == hint_id:
+        other = next((a for a in accounts if a.account_id != hint_id), None)
+        if other:
+            new_personal_id = other.account_id
+
+    logger.info(
+        f"{LOG_PREFIX} hint swap wrong_role=personal_as_org "
+        f"old_personal={personal_id} new_org={new_org_id} new_personal={new_personal_id}"
+    )
+    return new_personal_id, new_org_id, "hint"
+
+
+def zernio_items_to_accounts(items: list[dict[str, Any]]) -> list[LinkedInAccount]:
+    """Build LinkedInAccount list from Zernio API items using partition IDs for typing."""
+    personal_raw, org_raw = partition_zernio_account_items(items)
+    personal_id = account_id_from_item(personal_raw) if personal_raw else None
+    org_id = account_id_from_item(org_raw) if org_raw else None
+
+    accounts: list[LinkedInAccount] = []
+    for item in items:
+        aid = account_id_from_item(item)
+        if not aid:
+            continue
+        if personal_id and aid == personal_id:
+            resolved_type = "personal"
+        elif org_id and aid == org_id:
+            resolved_type = "organization"
+        else:
+            raw_type = account_type_from_item(item)
+            if is_org_account_type(raw_type):
+                resolved_type = "organization"
+            elif is_personal_account_type(raw_type):
+                resolved_type = "personal"
+            else:
+                resolved_type = raw_type
+        accounts.append(
+            LinkedInAccount(
+                account_id=aid,
+                account_type=resolved_type,
+                username=account_name_from_item(item),
+                avatar_url=avatar_url_from_item(item),
+                platform="linkedin",
+            )
+        )
+    return accounts

--- a/backend/services/integrations/linkedin/analytics_dates.py
+++ b/backend/services/integrations/linkedin/analytics_dates.py
@@ -1,0 +1,200 @@
+"""
+LinkedIn analytics date-range helpers.
+
+LinkedIn / Zernio treat the end date as exclusive. The latest two calendar days
+are typically incomplete — use DATA_LAG_DAYS when computing ranges.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+DATA_LAG_DAYS = 2
+WINDOW_DAYS = 7
+DEFAULT_PRESET_DAYS = 7
+PRESET_WINDOWS = (7, 14, 28, 90, 365)
+MAX_CUSTOM_SPAN_DAYS = 365
+
+
+class InvalidAnalyticsDateRange(ValueError):
+    """User-facing date range validation error."""
+
+
+@dataclass(frozen=True)
+class AnalyticsDateRange:
+    """Inclusive start through latest complete day, plus exclusive end for APIs."""
+
+    start: date
+    end_exclusive: date
+    label: str
+    data_lag_days: int = DATA_LAG_DAYS
+
+    @property
+    def start_iso(self) -> str:
+        return self.start.isoformat()
+
+    @property
+    def end_exclusive_iso(self) -> str:
+        return self.end_exclusive.isoformat()
+
+    @property
+    def latest_complete_day(self) -> date:
+        return self.end_exclusive - timedelta(days=1)
+
+
+def _format_label(start: date, latest_complete: date) -> str:
+    """Human-readable range, e.g. 'Jun 6 – Jun 12, 2026'."""
+    if start.year == latest_complete.year:
+        if start.month == latest_complete.month:
+            return (
+                f"{start.strftime('%b')} {start.day} – "
+                f"{latest_complete.strftime('%b')} {latest_complete.day}, "
+                f"{latest_complete.year}"
+            )
+        return (
+            f"{start.strftime('%b %d')} – {latest_complete.strftime('%b %d, %Y')}"
+        )
+    return (
+        f"{start.strftime('%b %d, %Y')} – {latest_complete.strftime('%b %d, %Y')}"
+    )
+
+
+def _latest_complete_day(today: date, *, data_lag_days: int = DATA_LAG_DAYS) -> date:
+    return today - timedelta(days=data_lag_days + 1)
+
+
+def compute_preset_range(
+    today: date,
+    window_days: int,
+    *,
+    data_lag_days: int = DATA_LAG_DAYS,
+) -> AnalyticsDateRange:
+    """
+    Rolling last N complete days relative to ``today``.
+
+    Example (today=2026-06-15, window_days=7):
+      end_exclusive=2026-06-13, start=2026-06-06, label includes Jun 6 and Jun 12.
+    """
+    if window_days not in PRESET_WINDOWS:
+        raise InvalidAnalyticsDateRange(
+            f"Invalid preset window: {window_days}. Use one of {PRESET_WINDOWS}."
+        )
+
+    end_exclusive = today - timedelta(days=data_lag_days)
+    start = end_exclusive - timedelta(days=window_days)
+    latest_complete = end_exclusive - timedelta(days=1)
+    label = _format_label(start, latest_complete)
+    return AnalyticsDateRange(
+        start=start,
+        end_exclusive=end_exclusive,
+        label=label,
+        data_lag_days=data_lag_days,
+    )
+
+
+def compute_last_7_day_range(
+    today: date,
+    *,
+    data_lag_days: int = DATA_LAG_DAYS,
+    window_days: int = WINDOW_DAYS,
+) -> AnalyticsDateRange:
+    """Rolling last 7 complete days (backward-compatible wrapper)."""
+    return compute_preset_range(
+        today,
+        window_days,
+        data_lag_days=data_lag_days,
+    )
+
+
+def compute_custom_range(
+    start_inclusive: date,
+    end_inclusive: date,
+    *,
+    today: date,
+    data_lag_days: int = DATA_LAG_DAYS,
+) -> AnalyticsDateRange:
+    """
+    Build a range from inclusive UI dates.
+
+    ``end_inclusive`` is clamped to the latest complete day. API end is exclusive.
+    """
+    latest_complete = _latest_complete_day(today, data_lag_days=data_lag_days)
+    if start_inclusive > today:
+        raise InvalidAnalyticsDateRange("Dates cannot be in the future.")
+
+    clamped_end = min(end_inclusive, latest_complete)
+    if start_inclusive > clamped_end:
+        raise InvalidAnalyticsDateRange(
+            "Start date must be on or before the end date."
+        )
+
+    span_days = (clamped_end - start_inclusive).days + 1
+    if span_days > MAX_CUSTOM_SPAN_DAYS:
+        raise InvalidAnalyticsDateRange(
+            f"Date range cannot exceed {MAX_CUSTOM_SPAN_DAYS} days."
+        )
+
+    end_exclusive = clamped_end + timedelta(days=1)
+    label = _format_label(start_inclusive, clamped_end)
+    return AnalyticsDateRange(
+        start=start_inclusive,
+        end_exclusive=end_exclusive,
+        label=label,
+        data_lag_days=data_lag_days,
+    )
+
+
+def _parse_iso_date(value: str, field_name: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise InvalidAnalyticsDateRange(
+            f"Invalid {field_name}: use YYYY-MM-DD."
+        ) from exc
+
+
+def parse_range_request(
+    *,
+    today: date,
+    preset_days: int | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    data_lag_days: int = DATA_LAG_DAYS,
+) -> AnalyticsDateRange:
+    """
+    Parse preset or custom date range request (mutually exclusive).
+
+    Defaults to 7-day preset when no custom dates are provided.
+    """
+    has_start = start_date is not None
+    has_end = end_date is not None
+
+    if has_start != has_end:
+        raise InvalidAnalyticsDateRange(
+            "Both startDate and endDate are required for a custom range."
+        )
+
+    if has_start and has_end:
+        if preset_days is not None:
+            raise InvalidAnalyticsDateRange(
+                "Cannot combine presetDays with startDate/endDate."
+            )
+        return compute_custom_range(
+            _parse_iso_date(start_date, "startDate"),
+            _parse_iso_date(end_date, "endDate"),
+            today=today,
+            data_lag_days=data_lag_days,
+        )
+
+    days = preset_days if preset_days is not None else DEFAULT_PRESET_DAYS
+    return compute_preset_range(today, days, data_lag_days=data_lag_days)
+
+
+def date_range_to_response(date_range: AnalyticsDateRange) -> dict[str, str | int]:
+    return {
+        "start": date_range.start_iso,
+        "endExclusive": date_range.end_exclusive_iso,
+        "label": date_range.label,
+        "dataLagDays": date_range.data_lag_days,
+    }

--- a/backend/services/integrations/linkedin/analytics_normalizer.py
+++ b/backend/services/integrations/linkedin/analytics_normalizer.py
@@ -1,0 +1,93 @@
+"""
+Normalize Zernio LinkedIn aggregate analytics payloads for the landing UI.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+# Request metrics (Zernio API names) — aligned with standalone CLI schemas.
+PERSONAL_DEFAULT_METRICS: tuple[str, ...] = (
+    "IMPRESSION",
+    "MEMBERS_REACHED",
+    "REACTION",
+    "COMMENT",
+    "RESHARE",
+    "POST_SAVE",
+    "POST_SEND",
+)
+
+ORG_DEFAULT_LANDING_METRICS: tuple[str, ...] = (
+    "impressions",
+    "unique_impressions",
+    "clicks",
+    "likes",
+    "comments",
+    "shares",
+    "engagement_rate",
+    "organic_followers_gained",
+)
+
+# Normalized personal keys returned to the frontend.
+PERSONAL_ANALYTICS_KEYS: tuple[str, ...] = (
+    "impressions",
+    "reach",
+    "reactions",
+    "comments",
+    "shares",
+    "saves",
+    "sends",
+    "engagementRate",
+)
+
+
+def normalize_personal_aggregate(raw: dict[str, Any]) -> dict[str, Any]:
+    """
+    Flatten Zernio personal aggregate response ``analytics`` block.
+
+    Sample source: docs/linkedin/.../outputs/linkedin_profile_analytics_total.json
+    """
+    analytics = raw.get("analytics")
+    if not isinstance(analytics, dict):
+        return {}
+
+    result: dict[str, Any] = {}
+    for key in PERSONAL_ANALYTICS_KEYS:
+        if key in analytics:
+            result[key] = analytics[key]
+
+    return result
+
+
+def normalize_org_aggregate(
+    raw: dict[str, Any],
+    *,
+    metric_keys: Optional[tuple[str, ...]] = None,
+) -> dict[str, Any]:
+    """
+    Flatten Zernio org aggregate ``metrics.{key}.total`` values.
+
+    Sample source: docs/linkedin/.../outputs/linkedin_org_analytics.json
+    """
+    metrics_block = raw.get("metrics")
+    if not isinstance(metrics_block, dict):
+        return {}
+
+    keys = metric_keys or ORG_DEFAULT_LANDING_METRICS
+    result: dict[str, Any] = {}
+    for key in keys:
+        entry = metrics_block.get(key)
+        if not isinstance(entry, dict):
+            continue
+        if "total" in entry:
+            result[key] = entry["total"]
+
+    return result
+
+
+def org_data_delay_note(raw: dict[str, Any]) -> Optional[str]:
+    """Extract Zernio data delay disclaimer when present."""
+    note = raw.get("dataDelay")
+    if isinstance(note, str) and note.strip():
+        return note.strip()
+    return None

--- a/backend/services/integrations/linkedin/content_deduplicator.py
+++ b/backend/services/integrations/linkedin/content_deduplicator.py
@@ -1,0 +1,138 @@
+"""
+LinkedIn duplicate content detection (H4).
+
+Hashes normalized post text and compares against recent ContentAsset rows
+to avoid LinkedIn 422 duplicate-content rejections.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime, timedelta
+from typing import Optional
+
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from models.content_asset_models import AssetSource, AssetType, ContentAsset
+from services.content_asset_service import ContentAssetService
+from services.integrations.linkedin.types import DuplicateCheckResult
+
+DEFAULT_LOOKBACK_DAYS = 30
+_URL_PATTERN = re.compile(r"https?://\S+", re.IGNORECASE)
+_HASHTAG_TRAIL_PATTERN = re.compile(r"(?:\s*#[\w]+\s*)+$", re.UNICODE)
+
+
+def normalize_content(text: str) -> str:
+    """Normalize post text for duplicate comparison."""
+    if not text:
+        return ""
+    normalized = text.strip().lower()
+    normalized = _URL_PATTERN.sub("", normalized)
+    normalized = _HASHTAG_TRAIL_PATTERN.sub("", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return normalized
+
+
+def content_hash(text: str) -> str:
+    """SHA-256 hash of normalized content."""
+    normalized = normalize_content(text)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+class ContentDeduplicator:
+    """Checks publish content against recent LinkedIn post hashes."""
+
+    def __init__(self, lookback_days: int = DEFAULT_LOOKBACK_DAYS):
+        self.lookback_days = lookback_days
+
+    def check_duplicate(
+        self,
+        user_id: str,
+        account_id: str,
+        content: str,
+        db: Optional[Session] = None,
+    ) -> DuplicateCheckResult:
+        candidate_hash = content_hash(content)
+
+        if db is None:
+            logger.debug(
+                "LinkedIn dedup skipped: no DB session (user=%s, account=%s)",
+                user_id,
+                account_id,
+            )
+            return DuplicateCheckResult(
+                is_duplicate=False,
+                content_hash=candidate_hash,
+            )
+
+        try:
+            service = ContentAssetService(db)
+            date_from = datetime.utcnow() - timedelta(days=self.lookback_days)
+            assets, _ = service.get_user_assets(
+                user_id=user_id,
+                asset_type=AssetType.TEXT,
+                source_module=AssetSource.LINKEDIN_WRITER,
+                date_from=date_from,
+                limit=200,
+            )
+
+            for asset in assets:
+                stored_hash = None
+                metadata = asset.asset_metadata or {}
+                if isinstance(metadata, dict):
+                    stored_hash = metadata.get("linkedin_content_hash")
+                    stored_account = metadata.get("linkedin_publish_account_id")
+                    if stored_account and stored_account != account_id:
+                        continue
+
+                if not stored_hash and asset.description:
+                    stored_hash = content_hash(asset.description)
+
+                if stored_hash and stored_hash == candidate_hash:
+                    return DuplicateCheckResult(
+                        is_duplicate=True,
+                        content_hash=candidate_hash,
+                        matched_asset_id=asset.id,
+                        reason="Content matches a recent LinkedIn post in your library.",
+                    )
+
+            return DuplicateCheckResult(
+                is_duplicate=False,
+                content_hash=candidate_hash,
+            )
+        except Exception as exc:
+            logger.warning(f"LinkedIn dedup check failed for user {user_id}: {exc}")
+            return DuplicateCheckResult(
+                is_duplicate=False,
+                content_hash=candidate_hash,
+                reason=f"dedup_check_skipped: {exc}",
+            )
+
+    def record_publish_hash(
+        self,
+        db: Session,
+        asset_id: int,
+        user_id: str,
+        account_id: str,
+        publish_hash: str,
+        post_urn: Optional[str] = None,
+    ) -> bool:
+        """Persist content hash after successful publish (future batch)."""
+        try:
+            service = ContentAssetService(db)
+            asset = service.get_asset_by_id(asset_id, user_id)
+            if not asset:
+                return False
+            metadata = dict(asset.asset_metadata or {})
+            metadata["linkedin_content_hash"] = publish_hash
+            metadata["linkedin_publish_account_id"] = account_id
+            if post_urn:
+                metadata["linkedin_post_urn"] = post_urn
+            metadata["linkedin_published_at"] = datetime.utcnow().isoformat()
+            service.update_asset(asset_id, user_id, asset_metadata=metadata)
+            return True
+        except Exception as exc:
+            logger.error(f"Failed to record LinkedIn publish hash: {exc}")
+            return False

--- a/backend/services/integrations/linkedin/exceptions.py
+++ b/backend/services/integrations/linkedin/exceptions.py
@@ -1,0 +1,49 @@
+"""LinkedIn Growth Engine integration exceptions."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from .types import LinkedInNotConnectedError
+
+
+class LinkedInDuplicateContentError(Exception):
+    """Raised when publish content matches a recent LinkedIn post."""
+
+    def __init__(
+        self,
+        message: str = "This content matches a recent LinkedIn post. Edit before publishing.",
+        *,
+        matched_asset_id: Optional[int] = None,
+        content_hash: Optional[str] = None,
+    ):
+        super().__init__(message)
+        self.matched_asset_id = matched_asset_id
+        self.content_hash = content_hash
+
+
+class LinkedInMediaValidationError(Exception):
+    """Raised when media fails LinkedIn pre-publish validation."""
+
+    def __init__(self, errors: List[str], *, file_path: Optional[str] = None):
+        self.errors = errors
+        self.file_path = file_path
+        summary = "; ".join(errors) if errors else "Media validation failed"
+        super().__init__(summary)
+
+
+class LinkedInEnvConnectError(Exception):
+    """Raised when platform env-based LinkedIn connect fails."""
+
+    def __init__(self, message: str, *, status_code: int = 400):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+__all__ = [
+    "LinkedInNotConnectedError",
+    "LinkedInDuplicateContentError",
+    "LinkedInMediaValidationError",
+    "LinkedInEnvConnectError",
+]

--- a/backend/services/integrations/linkedin/factory.py
+++ b/backend/services/integrations/linkedin/factory.py
@@ -1,0 +1,52 @@
+"""
+Factory for LinkedIn Social providers.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+from services.integrations.linkedin.native_provider import NativeLinkedInProvider
+from services.integrations.linkedin.protocol import LinkedInSocialProvider
+from services.integrations.linkedin.unipile_provider import UnipileProvider
+from services.integrations.linkedin.zernio_provider import ZernioProvider
+
+
+@lru_cache(maxsize=1)
+def _zernio_singleton() -> ZernioProvider:
+    return ZernioProvider()
+
+
+@lru_cache(maxsize=1)
+def _native_singleton() -> NativeLinkedInProvider:
+    return NativeLinkedInProvider()
+
+
+@lru_cache(maxsize=1)
+def _unipile_singleton() -> UnipileProvider:
+    return UnipileProvider()
+
+
+def get_linkedin_provider() -> LinkedInSocialProvider:
+    """
+    Return the configured LinkedIn platform provider.
+
+    Controlled by LINKEDIN_PROVIDER env var:
+    - 'zernio' (default) - Legacy Zernio provider
+    - 'unipile' - Unipile hosted auth (Phase 1 - Connection Only)
+    - 'native' - Direct LinkedIn Marketing API (not yet implemented)
+    """
+    mode = os.getenv("LINKEDIN_PROVIDER", "zernio").lower()
+    if mode == "native":
+        return _native_singleton()
+    elif mode == "unipile":
+        return _unipile_singleton()
+    return _zernio_singleton()
+
+
+def reset_linkedin_provider_cache() -> None:
+    """Clear cached provider instances (for tests)."""
+    _zernio_singleton.cache_clear()
+    _native_singleton.cache_clear()
+    _unipile_singleton.cache_clear()

--- a/backend/services/integrations/linkedin/field_coercion.py
+++ b/backend/services/integrations/linkedin/field_coercion.py
@@ -1,0 +1,55 @@
+"""
+Shared field coercion helpers for LinkedIn profile normalization and context building.
+
+Used by Phase 1 (``profile_service``) and Phase 2 (``profile_context_builder``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def clean_str(value: Any) -> str:
+    """Coerce a value to a trimmed string; None and non-strings become ``""``."""
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        return str(value).strip()
+    return value.strip()
+
+
+def coerce_bool(value: Any, *, default: bool = False) -> bool:
+    """Coerce boolean fields safely."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes"}:
+            return True
+        if lowered in {"false", "0", "no"}:
+            return False
+    return default
+
+
+def coerce_int(value: Any, *, default: int = 0) -> int:
+    """Coerce count fields to int."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return default
+
+
+def coerce_list(value: Any) -> list[Any]:
+    """Return a list or empty list when null / wrong type."""
+    if isinstance(value, list):
+        return value
+    return []

--- a/backend/services/integrations/linkedin/landing_analytics.py
+++ b/backend/services/integrations/linkedin/landing_analytics.py
@@ -1,0 +1,257 @@
+"""
+Orchestrate LinkedIn landing-page analytics (rolling 7-day BFF).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+from typing import Any, Optional
+
+from loguru import logger
+
+from services.integrations.linkedin.analytics_dates import compute_last_7_day_range
+from services.integrations.linkedin.analytics_normalizer import (
+    ORG_DEFAULT_LANDING_METRICS,
+    normalize_org_aggregate,
+    org_data_delay_note,
+)
+from services.integrations.linkedin.personal_analytics import build_personal_analytics_payload
+from services.integrations.linkedin.types import (
+    LinkedInAccount,
+    LinkedInNotConnectedError,
+    LinkedInOrganization,
+)
+from services.integrations.linkedin.account_resolution import resolve_account_pair
+from services.integrations.linkedin.zernio_client import ZernioAPIError
+from services.integrations.linkedin_oauth import LinkedInOAuthService
+
+LOG_PREFIX = "[LinkedInAnalytics]"
+
+ORG_CONNECTION_REQUIRED_MSG = (
+    "Company page analytics is not available yet. "
+    "Ensure your company page is connected in Zernio, then refresh this page."
+)
+
+
+def _friendly_org_analytics_error(exc: BaseException) -> str:
+    msg = _zernio_error_message(exc)
+    lower = msg.lower()
+    if "personal_account_not_supported" in lower or (
+        "organization accounts" in lower and "personal" in lower
+    ):
+        return ORG_CONNECTION_REQUIRED_MSG
+    return msg
+
+
+def _zernio_error_message(exc: BaseException) -> str:
+    if isinstance(exc, ZernioAPIError):
+        return str(exc)
+    return str(exc) or "LinkedIn analytics request failed"
+
+
+def _http_status_from_error(exc: BaseException) -> Optional[int]:
+    if isinstance(exc, ZernioAPIError) and exc.status_code is not None:
+        return exc.status_code
+    return None
+
+
+async def _resolve_avatar_url(
+    provider: Any,
+    user_id: str,
+    account: LinkedInAccount,
+) -> Optional[str]:
+    resolve = getattr(provider, "resolve_account_avatar_url", None)
+    if callable(resolve):
+        return await resolve(user_id, account)
+    return account.avatar_url
+
+
+async def _resolve_org_tab_avatar(
+    provider: Any,
+    user_id: str,
+    org_account: Optional[LinkedInAccount],
+    primary_managed_org: Optional[LinkedInOrganization],
+) -> tuple[Optional[str], str]:
+    """Resolve org tab image: Zernio org account first, then managed-page logo."""
+    if org_account:
+        url = await _resolve_avatar_url(provider, user_id, org_account)
+        if url:
+            return url, "account"
+    if primary_managed_org and primary_managed_org.logo_url:
+        return primary_managed_org.logo_url, "org_list"
+    return None, "none"
+
+
+async def _fetch_org_analytics(
+    provider: Any,
+    user_id: str,
+    account_id: str,
+    *,
+    start_iso: str,
+    end_exclusive_iso: str,
+) -> tuple[dict[str, Any], Optional[str]]:
+    raw = await provider.get_org_aggregate_analytics(
+        user_id,
+        account_id,
+        since=start_iso,
+        until=end_exclusive_iso,
+        metric_type="total_value",
+        metrics=list(ORG_DEFAULT_LANDING_METRICS),
+    )
+    return normalize_org_aggregate(raw), org_data_delay_note(raw)
+
+
+async def build_landing_analytics_payload(
+    user_id: str,
+    provider: Any,
+    oauth_service: LinkedInOAuthService,
+    *,
+    today: Optional[date] = None,
+) -> dict[str, Any]:
+    """
+    Build landing analytics response dict (rolling last 7 days as of ``today``).
+    """
+    logger.info(f"{LOG_PREFIX} landing request user_id={user_id}")
+
+    try:
+        oauth_service.resolve_credentials(user_id)
+    except LinkedInNotConnectedError as exc:
+        raise LinkedInNotConnectedError(str(exc)) from exc
+
+    oauth_service.try_sync_zernio_accounts(user_id)
+
+    date_range = compute_last_7_day_range(today or date.today())
+    logger.info(
+        f"{LOG_PREFIX} date range user_id={user_id} "
+        f"start={date_range.start_iso} end_exclusive={date_range.end_exclusive_iso} "
+        f"label={date_range.label!r}"
+    )
+
+    accounts = await provider.list_accounts(user_id)
+    creds = oauth_service.resolve_credentials(user_id)
+    logger.warning(
+        f"{LOG_PREFIX} creds after sync user_id={user_id} "
+        f"personal_id={creds.zernio_account_id} org_id={creds.zernio_org_account_id} "
+        f"profile_id={creds.zernio_profile_id}"
+    )
+
+    pair = resolve_account_pair(
+        accounts,
+        stored_personal_id=creds.zernio_account_id,
+        stored_org_id=creds.zernio_org_account_id,
+    )
+    if not pair or not pair.personal_id:
+        raise LinkedInNotConnectedError("No LinkedIn personal account found for user")
+
+    personal_id = pair.personal_id
+    org_analytics_account_id = pair.org_id
+    org_account = pair.org
+
+    managed_orgs: list[LinkedInOrganization] = []
+    try:
+        logger.info(
+            f"{LOG_PREFIX} fetch org metadata user_id={user_id} "
+            f"personal_id={personal_id} endpoint=linkedin-organizations"
+        )
+        managed_orgs = await provider.list_organizations(user_id, personal_id)
+    except Exception as exc:
+        logger.warning(
+            f"{LOG_PREFIX} org metadata load failed user_id={user_id}: {exc}"
+        )
+
+    primary_managed_org = managed_orgs[0] if managed_orgs else None
+    has_managed_orgs = primary_managed_org is not None
+    include_organization = org_account is not None or has_managed_orgs
+
+    org_meta_id = primary_managed_org.organization_id if primary_managed_org else None
+    org_name = primary_managed_org.name if primary_managed_org else None
+
+    logger.warning(
+        f"{LOG_PREFIX} resolved ids user_id={user_id} "
+        f"personal_id={personal_id} "
+        f"org_analytics_account_id={org_analytics_account_id} "
+        f"resolve_method={pair.method} "
+        f"org_meta_id={org_meta_id} "
+        f"has_managed_orgs={has_managed_orgs}"
+    )
+
+    personal_task = asyncio.create_task(
+        build_personal_analytics_payload(user_id, provider, oauth_service, date_range)
+    )
+
+    org_avatar_task = (
+        asyncio.create_task(
+            _resolve_org_tab_avatar(provider, user_id, org_account, primary_managed_org)
+        )
+        if include_organization
+        else None
+    )
+
+    organization_result: Optional[dict[str, Any]] = None
+    data_delay_note: Optional[str] = None
+
+    async def _run_org_fetch(target_org_id: str) -> tuple[dict[str, Any], Optional[str]]:
+        logger.info(
+            f"{LOG_PREFIX} fetch org user_id={user_id} "
+            f"account_id={target_org_id} endpoint=org-aggregate-analytics"
+        )
+        return await _fetch_org_analytics(
+            provider,
+            user_id,
+            target_org_id,
+            start_iso=date_range.start_iso,
+            end_exclusive_iso=date_range.end_exclusive_iso,
+        )
+
+    personal_payload = await personal_task
+    personal_result = personal_payload["personal"]
+    org_analytics_account_id = (
+        personal_payload.get("orgAnalyticsAccountId") or org_analytics_account_id
+    )
+
+    if include_organization:
+        organization_result = {
+            "accountId": org_analytics_account_id,
+            "orgId": org_meta_id,
+            "orgName": org_name,
+            "avatarUrl": None,
+            "analytics": {},
+            "error": None,
+        }
+        if org_analytics_account_id:
+            try:
+                org_analytics, delay_note = await _run_org_fetch(org_analytics_account_id)
+                organization_result["analytics"] = org_analytics
+                organization_result["accountId"] = org_analytics_account_id
+                if delay_note:
+                    data_delay_note = delay_note
+                logger.warning(f"{LOG_PREFIX} org analytics ok user_id={user_id}")
+            except Exception as exc:
+                organization_result["error"] = _friendly_org_analytics_error(exc)
+                status = _http_status_from_error(exc)
+                logger.warning(
+                    f"{LOG_PREFIX} org analytics failed user_id={user_id} "
+                    f"status={status}: {exc}"
+                )
+        else:
+            organization_result["error"] = ORG_CONNECTION_REQUIRED_MSG
+            logger.warning(
+                f"{LOG_PREFIX} org analytics skipped user_id={user_id} "
+                f"reason=no_org_social_account has_managed_orgs={has_managed_orgs}"
+            )
+
+    if include_organization and organization_result is not None and org_avatar_task:
+        org_avatar_url, org_avatar_source = await org_avatar_task
+        organization_result["avatarUrl"] = org_avatar_url
+        logger.info(
+            f"{LOG_PREFIX} org avatar user_id={user_id} source={org_avatar_source}"
+        )
+
+    return {
+        "dateRange": personal_payload["dateRange"],
+        "personal": personal_result,
+        "organization": organization_result,
+        "dataDelayNote": data_delay_note,
+        "provider": provider.provider_name,
+    }

--- a/backend/services/integrations/linkedin/media_validator.py
+++ b/backend/services/integrations/linkedin/media_validator.py
@@ -1,0 +1,196 @@
+"""
+LinkedIn media pre-publish validation (H5).
+
+Validates images, videos, and documents against LinkedIn/Zernio specs
+before calling the publish API.
+"""
+
+from __future__ import annotations
+
+import os
+from io import BytesIO
+from pathlib import Path
+from typing import Optional
+
+from PIL import Image
+
+from services.integrations.linkedin.types import MediaValidationResult
+
+# LinkedIn / issue #675 limits
+MAX_IMAGE_BYTES = 8 * 1024 * 1024  # 8MB
+MAX_VIDEO_BYTES = 5 * 1024 * 1024 * 1024  # 5GB
+MAX_DOCUMENT_BYTES = 100 * 1024 * 1024  # 100MB
+MAX_DOCUMENT_PAGES = 300
+
+MIN_IMAGE_WIDTH = 552
+MIN_IMAGE_HEIGHT = 276
+SUPPORTED_IMAGE_FORMATS = {"PNG", "JPEG", "JPG", "GIF", "WEBP"}
+SUPPORTED_VIDEO_EXTENSIONS = {".mp4", ".mov", ".avi"}
+SUPPORTED_DOCUMENT_EXTENSIONS = {".pdf"}
+
+SUITABLE_ASPECT_RATIOS = [
+    (0.9, 1.1),
+    (1.6, 1.8),
+    (0.7, 0.8),
+    (1.2, 1.4),
+    (1.85, 2.0),
+    (0.6, 0.72),
+    (0.65, 0.85),
+]
+
+
+def _is_aspect_ratio_suitable(width: int, height: int) -> bool:
+    if height == 0:
+        return False
+    ratio = width / height
+    return any(lo <= ratio <= hi for lo, hi in SUITABLE_ASPECT_RATIOS)
+
+
+def validate_image_bytes(image_data: bytes) -> dict[str, object]:
+    """Sync image validation (extracted from LinkedInImageGenerator thresholds)."""
+    try:
+        image = Image.open(BytesIO(image_data))
+        width, height = image.size
+        fmt = (image.format or "").upper()
+        if fmt == "JPG":
+            fmt = "JPEG"
+        return {
+            "resolution_ok": width >= MIN_IMAGE_WIDTH and height >= MIN_IMAGE_HEIGHT,
+            "aspect_ratio_suitable": _is_aspect_ratio_suitable(width, height),
+            "file_size_ok": len(image_data) <= MAX_IMAGE_BYTES,
+            "format_supported": fmt in SUPPORTED_IMAGE_FORMATS,
+            "width": width,
+            "height": height,
+            "format": fmt,
+        }
+    except Exception as exc:
+        return {
+            "resolution_ok": False,
+            "aspect_ratio_suitable": False,
+            "file_size_ok": False,
+            "format_supported": False,
+            "error": str(exc),
+        }
+
+
+def infer_media_type(file_path: str) -> str:
+    ext = Path(file_path).suffix.lower()
+    if ext in {".png", ".jpg", ".jpeg", ".gif", ".webp"}:
+        return "image"
+    if ext in SUPPORTED_VIDEO_EXTENSIONS:
+        return "video"
+    if ext in SUPPORTED_DOCUMENT_EXTENSIONS:
+        return "document"
+    return "unknown"
+
+
+class LinkedInMediaValidator:
+    """Pre-flight media validator for LinkedIn publishing."""
+
+    def validate_for_publish(
+        self, file_path: str, media_type: Optional[str] = None
+    ) -> MediaValidationResult:
+        resolved_type = media_type or infer_media_type(file_path)
+        path = Path(file_path)
+
+        if not path.exists():
+            return MediaValidationResult(valid=False, errors=[f"File not found: {file_path}"])
+
+        if resolved_type == "image":
+            return self._validate_image(path)
+        if resolved_type == "video":
+            return self._validate_video(path)
+        if resolved_type == "document":
+            return self._validate_document(path)
+
+        return MediaValidationResult(
+            valid=False,
+            errors=[f"Unsupported media type for path: {file_path}"],
+        )
+
+    def _validate_image(self, path: Path) -> MediaValidationResult:
+        errors: list[str] = []
+        warnings: list[str] = []
+
+        size = path.stat().st_size
+        if size > MAX_IMAGE_BYTES:
+            errors.append(
+                f"Image exceeds 8MB limit ({size / (1024 * 1024):.1f}MB)"
+            )
+
+        with open(path, "rb") as f:
+            data = f.read()
+
+        results = validate_image_bytes(data)
+        if results.get("error"):
+            errors.append(f"Invalid image file: {results['error']}")
+        if not results.get("format_supported"):
+            errors.append(
+                f"Unsupported image format: {results.get('format', 'unknown')}. "
+                f"Use PNG, JPEG, GIF, or WebP."
+            )
+        if not results.get("resolution_ok"):
+            errors.append(
+                f"Image resolution too small ({results.get('width')}x{results.get('height')}). "
+                f"Minimum {MIN_IMAGE_WIDTH}x{MIN_IMAGE_HEIGHT}."
+            )
+        if not results.get("aspect_ratio_suitable"):
+            warnings.append("Image aspect ratio may not be optimal for LinkedIn.")
+
+        return MediaValidationResult(
+            valid=len(errors) == 0,
+            errors=errors,
+            warnings=warnings,
+        )
+
+    def _validate_video(self, path: Path) -> MediaValidationResult:
+        errors: list[str] = []
+        ext = path.suffix.lower()
+        if ext not in SUPPORTED_VIDEO_EXTENSIONS:
+            errors.append(
+                f"Unsupported video format '{ext}'. Use MP4, MOV, or AVI."
+            )
+        size = path.stat().st_size
+        if size > MAX_VIDEO_BYTES:
+            errors.append(
+                f"Video exceeds 5GB limit ({size / (1024 ** 3):.2f}GB)"
+            )
+        return MediaValidationResult(valid=len(errors) == 0, errors=errors)
+
+    def _validate_document(self, path: Path) -> MediaValidationResult:
+        errors: list[str] = []
+        warnings: list[str] = []
+        ext = path.suffix.lower()
+        if ext not in SUPPORTED_DOCUMENT_EXTENSIONS:
+            errors.append("Documents must be PDF format.")
+        size = path.stat().st_size
+        if size > MAX_DOCUMENT_BYTES:
+            errors.append(
+                f"Document exceeds 100MB limit ({size / (1024 * 1024):.1f}MB)"
+            )
+
+        page_count = self._pdf_page_count(path)
+        if page_count is None:
+            warnings.append(
+                "Could not verify PDF page count (install pypdf for full validation)."
+            )
+        elif page_count > MAX_DOCUMENT_PAGES:
+            errors.append(
+                f"PDF has {page_count} pages; maximum is {MAX_DOCUMENT_PAGES}."
+            )
+
+        return MediaValidationResult(
+            valid=len(errors) == 0,
+            errors=errors,
+            warnings=warnings,
+        )
+
+    def _pdf_page_count(self, path: Path) -> Optional[int]:
+        try:
+            from pypdf import PdfReader  # type: ignore[import-untyped]
+
+            return len(PdfReader(str(path)).pages)
+        except ImportError:
+            return None
+        except Exception:
+            return None

--- a/backend/services/integrations/linkedin/native_provider.py
+++ b/backend/services/integrations/linkedin/native_provider.py
@@ -1,0 +1,135 @@
+"""
+Native LinkedIn Marketing API provider (stub — Phase 2+).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from services.integrations.linkedin.content_deduplicator import ContentDeduplicator
+from services.integrations.linkedin.media_validator import LinkedInMediaValidator
+from services.integrations.linkedin.publish_preflight import (
+    run_publish_preflight,
+    run_upload_preflight,
+)
+from services.integrations.linkedin.types import (
+    CommentInfo,
+    CreatePostRequest,
+    CreatePostResult,
+    LinkedInAccount,
+    LinkedInOrganization,
+    MediaUploadResult,
+    OrgMetricType,
+    ProfileAggregation,
+    ReplyResult,
+)
+
+_STUB_MSG = (
+    "Native LinkedIn Marketing API provider is not implemented yet. "
+    "Set LINKEDIN_PROVIDER=zernio to use Zernio."
+)
+
+
+class NativeLinkedInProvider:
+    """Placeholder for direct LinkedIn Marketing API integration."""
+
+    provider_name = "native"
+
+    def __init__(
+        self,
+        deduplicator: Optional[ContentDeduplicator] = None,
+        media_validator: Optional[LinkedInMediaValidator] = None,
+    ):
+        self._deduplicator = deduplicator or ContentDeduplicator()
+        self._media_validator = media_validator or LinkedInMediaValidator()
+
+    def _not_implemented(self) -> None:
+        raise NotImplementedError(_STUB_MSG)
+
+    async def list_accounts(self, user_id: str) -> list[LinkedInAccount]:
+        self._not_implemented()
+
+    async def list_organizations(
+        self, user_id: str, account_id: str
+    ) -> list[LinkedInOrganization]:
+        self._not_implemented()
+
+    async def get_profile_aggregate_analytics(
+        self,
+        user_id: str,
+        account_id: str,
+        aggregation: ProfileAggregation = "TOTAL",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        metrics: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        self._not_implemented()
+
+    async def get_org_aggregate_analytics(
+        self,
+        user_id: str,
+        account_id: str,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
+        metric_type: OrgMetricType = "total_value",
+        metrics: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        self._not_implemented()
+
+    async def get_post_analytics(
+        self,
+        user_id: str,
+        account_id: str,
+        urn: str,
+    ) -> dict[str, Any]:
+        self._not_implemented()
+
+    async def create_post(
+        self, user_id: str, request: CreatePostRequest
+    ) -> CreatePostResult:
+        await run_publish_preflight(
+            user_id,
+            request,
+            deduplicator=self._deduplicator,
+            media_validator=self._media_validator,
+        )
+        self._not_implemented()
+
+    async def upload_media(
+        self,
+        user_id: str,
+        account_id: str,
+        file_path: str,
+        media_type: str,
+    ) -> MediaUploadResult:
+        await run_upload_preflight(
+            file_path,
+            media_type,
+            media_validator=self._media_validator,
+        )
+        self._not_implemented()
+
+    async def schedule_post(
+        self, user_id: str, request: CreatePostRequest
+    ) -> CreatePostResult:
+        await run_publish_preflight(
+            user_id,
+            request,
+            deduplicator=self._deduplicator,
+            media_validator=self._media_validator,
+        )
+        self._not_implemented()
+    async def list_comments(
+        self, user_id: str, account_id: str, post_urn: str
+    ) -> list[CommentInfo]:
+        self._not_implemented()
+
+    async def reply_to_comment(
+        self,
+        user_id: str,
+        account_id: str,
+        post_urn: str,
+        comment_id: str,
+        text: str,
+    ) -> ReplyResult:
+        self._not_implemented()

--- a/backend/services/integrations/linkedin/personal_analytics.py
+++ b/backend/services/integrations/linkedin/personal_analytics.py
@@ -1,0 +1,195 @@
+"""
+Personal LinkedIn aggregate analytics BFF (date-range aware).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from loguru import logger
+
+from services.integrations.linkedin.account_resolution import (
+    apply_hint_swap_from_personal_error,
+    parse_account_id_from_zernio_error,
+    parse_zernio_error_code,
+    resolve_account_pair,
+)
+from services.integrations.linkedin.analytics_dates import (
+    AnalyticsDateRange,
+    date_range_to_response,
+)
+from services.integrations.linkedin.analytics_normalizer import (
+    PERSONAL_DEFAULT_METRICS,
+    normalize_personal_aggregate,
+)
+from services.integrations.linkedin.types import (
+    LinkedInAccount,
+    LinkedInNotConnectedError,
+)
+from services.integrations.linkedin.zernio_client import ZernioAPIError
+from services.integrations.linkedin_oauth import LinkedInOAuthService
+
+LOG_PREFIX = "[LinkedInAnalytics]"
+
+
+def _zernio_error_message(exc: BaseException) -> str:
+    if isinstance(exc, ZernioAPIError):
+        return str(exc)
+    return str(exc) or "LinkedIn analytics request failed"
+
+
+def _http_status_from_error(exc: BaseException) -> Optional[int]:
+    if isinstance(exc, ZernioAPIError) and exc.status_code is not None:
+        return exc.status_code
+    return None
+
+
+async def _resolve_avatar_url(
+    provider: Any,
+    user_id: str,
+    account: LinkedInAccount,
+) -> Optional[str]:
+    resolve = getattr(provider, "resolve_account_avatar_url", None)
+    if callable(resolve):
+        return await resolve(user_id, account)
+    return account.avatar_url
+
+
+async def fetch_personal_analytics(
+    provider: Any,
+    user_id: str,
+    account_id: str,
+    *,
+    start_iso: str,
+    end_exclusive_iso: str,
+) -> dict[str, Any]:
+    raw = await provider.get_profile_aggregate_analytics(
+        user_id,
+        account_id,
+        aggregation="TOTAL",
+        start_date=start_iso,
+        end_date=end_exclusive_iso,
+        metrics=list(PERSONAL_DEFAULT_METRICS),
+    )
+    return normalize_personal_aggregate(raw)
+
+
+async def build_personal_analytics_payload(
+    user_id: str,
+    provider: Any,
+    oauth_service: LinkedInOAuthService,
+    date_range: AnalyticsDateRange,
+) -> dict[str, Any]:
+    """Build normalized personal analytics response for a given date range."""
+    logger.warning(
+        f"{LOG_PREFIX} personal range user_id={user_id} "
+        f"start={date_range.start_iso} end_exclusive={date_range.end_exclusive_iso}"
+    )
+
+    try:
+        oauth_service.resolve_credentials(user_id)
+    except LinkedInNotConnectedError as exc:
+        raise LinkedInNotConnectedError(str(exc)) from exc
+
+    oauth_service.try_sync_zernio_accounts(user_id)
+
+    accounts = await provider.list_accounts(user_id)
+    creds = oauth_service.resolve_credentials(user_id)
+    pair = resolve_account_pair(
+        accounts,
+        stored_personal_id=creds.zernio_account_id,
+        stored_org_id=creds.zernio_org_account_id,
+    )
+    if not pair or not pair.personal_id:
+        raise LinkedInNotConnectedError("No LinkedIn personal account found for user")
+
+    personal_id = pair.personal_id
+    personal_account = pair.personal
+    org_analytics_account_id = pair.org_id
+
+    personal_result: dict[str, Any] = {
+        "accountId": personal_id,
+        "avatarUrl": None,
+        "analytics": {},
+        "error": None,
+    }
+    personal_analytics_exc: Optional[BaseException] = None
+
+    async def _run_fetch(target_personal_id: str) -> dict[str, Any]:
+        logger.info(
+            f"{LOG_PREFIX} fetch personal user_id={user_id} "
+            f"account_id={target_personal_id} endpoint=linkedin-aggregate-analytics"
+        )
+        return await fetch_personal_analytics(
+            provider,
+            user_id,
+            target_personal_id,
+            start_iso=date_range.start_iso,
+            end_exclusive_iso=date_range.end_exclusive_iso,
+        )
+
+    try:
+        personal_result["analytics"] = await _run_fetch(personal_id)
+        logger.info(f"{LOG_PREFIX} personal analytics ok user_id={user_id}")
+    except Exception as exc:
+        personal_analytics_exc = exc
+        err_msg = _zernio_error_message(exc)
+        personal_result["error"] = err_msg
+        status = _http_status_from_error(exc)
+        hint_id = parse_account_id_from_zernio_error(err_msg)
+        logger.warning(
+            f"{LOG_PREFIX} personal analytics failed user_id={user_id} "
+            f"status={status} code={parse_zernio_error_code(err_msg)} "
+            f"hint_account_id={hint_id}: {exc}"
+        )
+        new_personal_id, new_org_id, swap_method = apply_hint_swap_from_personal_error(
+            err_msg, accounts, personal_id, org_analytics_account_id
+        )
+        if swap_method and new_org_id:
+            personal_id = new_personal_id
+            org_analytics_account_id = new_org_id
+            personal_result["accountId"] = personal_id
+            personal_account = next(
+                (a for a in accounts if a.account_id == personal_id),
+                LinkedInAccount(
+                    account_id=personal_id,
+                    account_type="personal",
+                    platform="linkedin",
+                ),
+            )
+            logger.info(
+                f"{LOG_PREFIX} hint swap applied user_id={user_id} "
+                f"personal_id={personal_id} org_id={new_org_id}"
+            )
+            try:
+                personal_result["analytics"] = await _run_fetch(personal_id)
+                personal_result["error"] = None
+                personal_analytics_exc = None
+                logger.info(
+                    f"{LOG_PREFIX} personal analytics ok after hint swap user_id={user_id}"
+                )
+            except Exception as retry_exc:
+                personal_analytics_exc = retry_exc
+                personal_result["error"] = _zernio_error_message(retry_exc)
+                logger.warning(
+                    f"{LOG_PREFIX} personal analytics failed after hint swap "
+                    f"user_id={user_id}: {retry_exc}"
+                )
+
+    personal_result["avatarUrl"] = await _resolve_avatar_url(
+        provider, user_id, personal_account
+    )
+
+    if personal_analytics_exc is not None:
+        status = _http_status_from_error(personal_analytics_exc)
+        if status in (402, 412, 403):
+            raise personal_analytics_exc
+        if status == 401:
+            raise LinkedInNotConnectedError(_zernio_error_message(personal_analytics_exc))
+
+    return {
+        "dateRange": date_range_to_response(date_range),
+        "personal": personal_result,
+        "orgAnalyticsAccountId": org_analytics_account_id,
+        "provider": provider.provider_name,
+    }

--- a/backend/services/integrations/linkedin/profile_completion_questions.py
+++ b/backend/services/integrations/linkedin/profile_completion_questions.py
@@ -1,0 +1,157 @@
+"""
+Phase 4 — deterministic profile completion question generation.
+
+Maps Phase 3 ``missing_fields`` keys to static UI questions. No AI.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+from loguru import logger
+
+from services.integrations.linkedin.profile_validation_types import (
+    FIELD_PRIORITY_ORDER,
+    PROFESSIONAL_BACKGROUND_FIELD,
+)
+
+_LOG_PREFIX = "[ProfileCompletion]"
+
+CompletionInputType = Literal["text", "textarea", "tags"]
+
+MAX_COMPLETION_QUESTIONS = 5
+
+
+class CompletionQuestion(TypedDict):
+    """Single question shown in the profile completion form."""
+
+    field_key: str
+    label: str
+    input_type: CompletionInputType
+    required: bool
+
+
+class _QuestionDefinition(TypedDict):
+    label: str
+    input_type: CompletionInputType
+
+
+QUESTION_DEFINITIONS: dict[str, _QuestionDefinition] = {
+    "name": {
+        "label": "What is your full name?",
+        "input_type": "text",
+    },
+    "headline": {
+        "label": "What is your professional headline?",
+        "input_type": "text",
+    },
+    "job_title": {
+        "label": "What is your current job title?",
+        "input_type": "text",
+    },
+    "company": {
+        "label": "Which company do you currently work for?",
+        "input_type": "text",
+    },
+    "about": {
+        "label": "Tell us a little about yourself.",
+        "input_type": "textarea",
+    },
+    "industry": {
+        "label": "Which industry do you work in?",
+        "input_type": "text",
+    },
+    PROFESSIONAL_BACKGROUND_FIELD: {
+        "label": (
+            "What are your primary professional skills, or briefly describe "
+            "your experience or education?"
+        ),
+        "input_type": "textarea",
+    },
+    "skills": {
+        "label": "What are your primary professional skills?",
+        "input_type": "tags",
+    },
+    "experience": {
+        "label": "Please briefly describe your professional experience.",
+        "input_type": "textarea",
+    },
+    "education": {
+        "label": "What is your educational background?",
+        "input_type": "textarea",
+    },
+}
+
+_PRIORITY_INDEX = {key: index for index, key in enumerate(FIELD_PRIORITY_ORDER)}
+
+
+def build_completion_questions(missing_fields: list[str]) -> list[CompletionQuestion]:
+    """
+    Build ordered completion questions for Phase 3 ``missing_fields``.
+
+    Args:
+        missing_fields: Required field keys reported by the profile validator
+
+    Returns:
+        Up to ``MAX_COMPLETION_QUESTIONS`` questions in priority order
+    """
+    logger.info(
+        "{} build_completion_questions missing_fields={}",
+        _LOG_PREFIX,
+        missing_fields,
+    )
+    if not missing_fields:
+        logger.info(
+            "{} build_completion_questions complete profile — no questions",
+            _LOG_PREFIX,
+        )
+        return []
+
+    ordered_keys = _select_fields_by_priority(missing_fields)
+    capped_keys = ordered_keys[:MAX_COMPLETION_QUESTIONS]
+
+    questions: list[CompletionQuestion] = [
+        _to_completion_question(field_key) for field_key in capped_keys
+    ]
+
+    logger.info(
+        "{} build_completion_questions generated count={} field_keys={}",
+        _LOG_PREFIX,
+        len(questions),
+        [question["field_key"] for question in questions],
+    )
+    return questions
+
+
+def _select_fields_by_priority(missing_fields: list[str]) -> list[str]:
+    """Deduplicate, drop unknown keys, and sort by ``FIELD_PRIORITY_ORDER``."""
+    seen: set[str] = set()
+    known: list[str] = []
+
+    for field_key in missing_fields:
+        if field_key in seen:
+            continue
+        seen.add(field_key)
+
+        if field_key not in QUESTION_DEFINITIONS:
+            logger.warning(
+                "{} build_completion_questions unknown missing field key={} — skipping",
+                _LOG_PREFIX,
+                field_key,
+            )
+            continue
+
+        known.append(field_key)
+
+    known.sort(key=lambda key: _PRIORITY_INDEX.get(key, len(FIELD_PRIORITY_ORDER)))
+    return known
+
+
+def _to_completion_question(field_key: str) -> CompletionQuestion:
+    definition = QUESTION_DEFINITIONS[field_key]
+    return {
+        "field_key": field_key,
+        "label": definition["label"],
+        "input_type": definition["input_type"],
+        "required": True,
+    }

--- a/backend/services/integrations/linkedin/profile_completion_service.py
+++ b/backend/services/integrations/linkedin/profile_completion_service.py
@@ -1,0 +1,168 @@
+"""
+Phase 4 — profile completion orchestration.
+
+Loads validation, patches context, persists answers, and re-validates.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from loguru import logger
+
+from services.integrations.linkedin.profile_completion_questions import (
+    CompletionQuestion,
+    build_completion_questions,
+)
+from services.integrations.linkedin.profile_context_patcher import (
+    ProfileCompletionPatchError,
+    apply_completion_answers,
+)
+from services.integrations.linkedin.profile_repository import ProfileRepository
+from services.integrations.linkedin.profile_validation_service import (
+    get_or_validate_profile_context,
+)
+from services.integrations.linkedin.profile_validation_types import ProfileValidationResult
+
+_LOG_PREFIX = "[ProfileCompletion]"
+
+
+class ProfileCompletionError(Exception):
+    """Raised when profile completion cannot proceed."""
+
+
+class ProfileAlreadyCompleteError(ProfileCompletionError):
+    """Raised when submission occurs on an already-complete profile."""
+
+
+@dataclass(frozen=True)
+class ProfileCompletionResult:
+    """Outcome of a profile completion submit."""
+
+    profile_context: dict[str, Any]
+    profile_validation: ProfileValidationResult
+    questions: list[CompletionQuestion]
+
+
+def complete_profile(
+    user_id: str,
+    answers: dict[str, Any],
+    *,
+    repository: Optional[ProfileRepository] = None,
+) -> ProfileCompletionResult:
+    """
+    Apply user completion answers and re-run profile validation.
+
+    Args:
+        user_id: ALwrity user ID
+        answers: Field-keyed answers from the client
+        repository: Optional ``ProfileRepository`` (for testing)
+
+    Returns:
+        Updated context, validation, and remaining completion questions
+
+    Raises:
+        ProfileAlreadyCompleteError: When profile is already complete
+        ProfileCompletionError: When prerequisites are missing or answers invalid
+        ProfileCompletionPatchError: When patching fails
+        ValueError: When persistence or revalidation fails
+    """
+    logger.info(
+        "{} complete_profile start user_id={} answer_keys={}",
+        _LOG_PREFIX,
+        user_id,
+        sorted(answers.keys()) if isinstance(answers, dict) else None,
+    )
+
+    if not isinstance(answers, dict):
+        raise ProfileCompletionError("completion answers must be a dict")
+
+    repo = repository or ProfileRepository()
+    row = repo.get_analysis_row(user_id)
+    if not row:
+        logger.error(
+            "{} complete_profile no analysis row user_id={}",
+            _LOG_PREFIX,
+            user_id,
+        )
+        raise ProfileCompletionError(
+            f"No linkedin_analysis_context row for user_id={user_id!r}"
+        )
+
+    context = repo.get_profile_context(user_id, row=row)
+    if not context:
+        logger.error(
+            "{} complete_profile missing profile_context user_id={}",
+            _LOG_PREFIX,
+            user_id,
+        )
+        raise ProfileCompletionError("Profile context is not available")
+
+    validation, _validation_meta = get_or_validate_profile_context(
+        user_id,
+        context,
+        repository=repo,
+    )
+    if validation.get("is_profile_complete"):
+        logger.info(
+            "{} complete_profile already complete user_id={}",
+            _LOG_PREFIX,
+            user_id,
+        )
+        raise ProfileAlreadyCompleteError("Profile is already complete")
+
+    missing_fields = list(validation.get("missing_fields") or [])
+    questions_before = build_completion_questions(missing_fields)
+    logger.info(
+        "{} complete_profile missing_fields={} questions_before={}",
+        _LOG_PREFIX,
+        missing_fields,
+        len(questions_before),
+    )
+
+    accepted_answers = {
+        key: value
+        for key, value in answers.items()
+        if key in missing_fields
+    }
+    if not accepted_answers:
+        logger.error(
+            "{} complete_profile no accepted answers user_id={}",
+            _LOG_PREFIX,
+            user_id,
+        )
+        raise ProfileCompletionError("No valid answers provided for missing fields")
+
+    patched_context = apply_completion_answers(
+        context,
+        accepted_answers,
+        missing_fields,
+    )
+    repo.save_profile_context(user_id, patched_context)
+    repo.save_user_completion(user_id, accepted_answers)
+
+    updated_validation, _ = get_or_validate_profile_context(
+        user_id,
+        patched_context,
+        repository=repo,
+        force_revalidate=True,
+    )
+    remaining_questions = build_completion_questions(
+        list(updated_validation.get("missing_fields") or [])
+    )
+
+    logger.info(
+        "{} complete_profile finished user_id={} is_profile_complete={} "
+        "remaining_questions={}",
+        _LOG_PREFIX,
+        user_id,
+        updated_validation.get("is_profile_complete"),
+        len(remaining_questions),
+    )
+
+    return ProfileCompletionResult(
+        profile_context=patched_context,
+        profile_validation=updated_validation,
+        questions=remaining_questions,
+    )

--- a/backend/services/integrations/linkedin/profile_context_builder.py
+++ b/backend/services/integrations/linkedin/profile_context_builder.py
@@ -1,0 +1,391 @@
+"""
+Phase 2 — Profile Context Builder (pure transform).
+
+Maps Phase 1 flat normalized profile → grouped ``LinkedInProfileContext``.
+No DB, HTTP, or Unipile calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from services.integrations.linkedin.field_coercion import (
+    clean_str,
+    coerce_bool,
+    coerce_int,
+    coerce_list,
+)
+from services.integrations.linkedin.profile_context_types import (
+    ProfileContextBuildError,
+    default_profile_context,
+    default_primary_locale,
+    validate_profile_context,
+)
+
+_LOG_PREFIX = "[LinkedInProfileContext]"
+
+
+def build_profile_context(
+    normalized_profile: dict[str, Any],
+    *,
+    content_hash: str = "",
+) -> dict[str, Any]:
+    """
+    Map Phase 1 flat normalized profile → ``LinkedInProfileContext``.
+
+    Missing normalized fields become empty defaults; never raises on sparse input.
+    Raises ``ProfileContextBuildError`` only when ``normalized_profile`` is not a dict.
+
+    Args:
+        normalized_profile: Phase 1 normalized ALwrity profile dict
+        content_hash: Optional Phase 1 hash stored in context meta
+
+    Returns:
+        Structurally complete profile context dict
+    """
+    if not isinstance(normalized_profile, dict):
+        logger.error(
+            "{} build_profile_context invalid input type={}",
+            _LOG_PREFIX,
+            type(normalized_profile).__name__,
+        )
+        raise ProfileContextBuildError(
+            f"normalized profile must be a dict, got {type(normalized_profile).__name__}"
+        )
+
+    logger.info("{} build_profile_context start", _LOG_PREFIX)
+
+    context = default_profile_context(content_hash=content_hash)
+    context["personal_information"] = _build_personal_information(normalized_profile)
+    context["professional_information"] = _build_professional_information(normalized_profile)
+    context["linkedin_information"] = _build_linkedin_information(normalized_profile)
+
+    professional = context["professional_information"]
+    logger.info(
+        "{} build_profile_context complete name={!r} experience_count={} "
+        "education_count={} skills_count={}",
+        _LOG_PREFIX,
+        context["personal_information"].get("name"),
+        len(professional.get("experience", [])),
+        len(professional.get("education", [])),
+        len(professional.get("skills", [])),
+    )
+
+    validation_errors = validate_profile_context(context)
+    if validation_errors:
+        logger.error(
+            "{} built profile context failed validation: {}",
+            _LOG_PREFIX,
+            validation_errors,
+        )
+        raise ProfileContextBuildError(
+            "built profile context failed structural validation: "
+            + "; ".join(validation_errors)
+        )
+
+    return context
+
+
+def _build_personal_information(profile: dict[str, Any]) -> dict[str, Any]:
+    """Map normalized personal fields into ``personal_information``."""
+    logger.info("{} normalizing personal_information", _LOG_PREFIX)
+    return {
+        "first_name": clean_str(profile.get("first_name")),
+        "last_name": clean_str(profile.get("last_name")),
+        "name": clean_str(profile.get("name")),
+        "headline": clean_str(profile.get("headline")),
+        "about": clean_str(profile.get("about")),
+        "location": clean_str(profile.get("location")),
+    }
+
+
+def _build_professional_information(profile: dict[str, Any]) -> dict[str, Any]:
+    """Map normalized professional fields into ``professional_information``."""
+    logger.info("{} normalizing professional_information", _LOG_PREFIX)
+
+    skills, skills_total = _normalize_skills_section(profile)
+    experience, experience_total = _normalize_experience_section(profile)
+    education, education_total = _normalize_education_section(profile)
+    languages, languages_total = _normalize_languages_section(profile)
+    certifications, certifications_total = _normalize_object_list_section(
+        profile,
+        list_key="certifications",
+        total_key="certifications_total_count",
+    )
+    projects, projects_total = _normalize_object_list_section(
+        profile,
+        list_key="projects",
+        total_key="projects_total_count",
+    )
+    volunteering, volunteering_total = _normalize_object_list_section(
+        profile,
+        list_key="volunteering_experience",
+        total_key="volunteering_experience_total_count",
+    )
+    recommendations, given_count, received_count = _normalize_recommendations_section(
+        profile
+    )
+
+    return {
+        "job_title": clean_str(profile.get("job_title")),
+        "company": clean_str(profile.get("company")),
+        "industry": clean_str(profile.get("industry")),
+        "skills": skills,
+        "skills_total_count": skills_total,
+        "experience": experience,
+        "experience_total_count": experience_total,
+        "education": education,
+        "education_total_count": education_total,
+        "languages": languages,
+        "languages_total_count": languages_total,
+        "certifications": certifications,
+        "certifications_total_count": certifications_total,
+        "projects": projects,
+        "projects_total_count": projects_total,
+        "volunteering_experience": volunteering,
+        "volunteering_experience_total_count": volunteering_total,
+        "recommendations": recommendations,
+        "recommendations_given_count": given_count,
+        "recommendations_received_count": received_count,
+    }
+
+
+def _build_linkedin_information(profile: dict[str, Any]) -> dict[str, Any]:
+    """Map normalized LinkedIn platform fields into ``linkedin_information``."""
+    logger.info("{} normalizing linkedin_information", _LOG_PREFIX)
+    return {
+        "followers": coerce_int(profile.get("followers")),
+        "connections": coerce_int(profile.get("connections")),
+        "creator_mode": coerce_bool(profile.get("creator_mode")),
+        "is_premium": coerce_bool(profile.get("is_premium")),
+        "is_influencer": coerce_bool(profile.get("is_influencer")),
+        "is_open_profile": coerce_bool(profile.get("is_open_profile")),
+        "is_self": coerce_bool(profile.get("is_self"), default=True),
+        "profile_url": clean_str(profile.get("profile_url")),
+        "profile_picture": clean_str(profile.get("profile_picture")),
+        "background_picture": clean_str(profile.get("background_picture")),
+        "websites": _normalize_string_list(profile.get("websites")),
+        "hashtags": _normalize_string_list(profile.get("hashtags")),
+        "primary_locale": _normalize_primary_locale_section(profile.get("primary_locale")),
+        "public_identifier": clean_str(profile.get("public_identifier")),
+        "provider_id": clean_str(profile.get("provider_id")),
+        "member_urn": clean_str(profile.get("member_urn")),
+    }
+
+
+def _normalize_string_list(value: Any) -> list[str]:
+    """Coerce a list of values to trimmed non-empty strings."""
+    return [
+        cleaned
+        for item in coerce_list(value)
+        if (cleaned := clean_str(item))
+    ]
+
+
+def _normalize_primary_locale_section(value: Any) -> dict[str, str]:
+    """Normalize primary locale from Phase 1 shape."""
+    locale = default_primary_locale()
+    if not isinstance(value, dict):
+        return locale
+    locale["country"] = clean_str(value.get("country"))
+    locale["language"] = clean_str(value.get("language"))
+    return locale
+
+
+def _normalize_skills_section(profile: dict[str, Any]) -> tuple[list[dict[str, Any]], int]:
+    """Defensively normalize skills from Phase 1 normalized profile."""
+    items = coerce_list(profile.get("skills"))
+    total = coerce_int(profile.get("skills_total_count"), default=len(items))
+    skills: list[dict[str, Any]] = []
+
+    for item in items:
+        if isinstance(item, str):
+            name = clean_str(item)
+            if name:
+                skills.append({"name": name, "endorsement_count": 0})
+            continue
+        if not isinstance(item, dict):
+            continue
+        name = clean_str(item.get("name"))
+        if not name:
+            continue
+        skills.append(
+            {
+                "name": name,
+                "endorsement_count": coerce_int(item.get("endorsement_count")),
+            }
+        )
+
+    if not total and skills:
+        total = len(skills)
+    return skills, total
+
+
+def _normalize_experience_section(
+    profile: dict[str, Any],
+) -> tuple[list[dict[str, Any]], int]:
+    """Defensively normalize experience from Phase 1 normalized profile."""
+    items = coerce_list(profile.get("experience"))
+    total = coerce_int(
+        profile.get("work_experience_total_count"),
+        default=len(items),
+    )
+    experience: list[dict[str, Any]] = []
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        end_value = item.get("end")
+        role_skills = _normalize_string_list(item.get("skills"))
+        experience.append(
+            {
+                "title": clean_str(item.get("title")),
+                "company": clean_str(item.get("company")),
+                "company_id": clean_str(item.get("company_id")),
+                "company_picture_url": clean_str(item.get("company_picture_url")),
+                "start": clean_str(item.get("start")),
+                "end": None if end_value is None else clean_str(end_value),
+                "location": clean_str(item.get("location")),
+                "description": clean_str(item.get("description")),
+                "skills": role_skills,
+            }
+        )
+
+    if not total and experience:
+        total = len(experience)
+    return experience, total
+
+
+def _normalize_education_section(
+    profile: dict[str, Any],
+) -> tuple[list[dict[str, Any]], int]:
+    """Defensively normalize education from Phase 1 normalized profile."""
+    items = coerce_list(profile.get("education"))
+    total = coerce_int(profile.get("education_total_count"), default=len(items))
+    education: list[dict[str, Any]] = []
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        end_value = item.get("end")
+        start_value = item.get("start")
+        education.append(
+            {
+                "school": clean_str(item.get("school")),
+                "school_id": clean_str(item.get("school_id")),
+                "school_picture_url": clean_str(item.get("school_picture_url")),
+                "degree": clean_str(item.get("degree")),
+                "start": clean_str(start_value),
+                "end": clean_str(end_value),
+            }
+        )
+
+    if not total and education:
+        total = len(education)
+    return education, total
+
+
+def _normalize_languages_section(
+    profile: dict[str, Any],
+) -> tuple[list[dict[str, Any]], int]:
+    """Defensively normalize languages from Phase 1 normalized profile."""
+    items = coerce_list(profile.get("languages"))
+    total = coerce_int(profile.get("languages_total_count"), default=len(items))
+    languages: list[dict[str, Any]] = []
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = clean_str(item.get("name"))
+        if not name:
+            continue
+        languages.append(
+            {
+                "name": name,
+                "proficiency": clean_str(item.get("proficiency")),
+            }
+        )
+
+    if not total and languages:
+        total = len(languages)
+    return languages, total
+
+
+def _normalize_object_list_section(
+    profile: dict[str, Any],
+    *,
+    list_key: str,
+    total_key: str,
+) -> tuple[list[dict[str, Any]], int]:
+    """Defensively normalize list-of-dict sections (certifications, projects, etc.)."""
+    items = coerce_list(profile.get(list_key))
+    total = coerce_int(profile.get(total_key), default=len(items))
+    normalized: list[dict[str, Any]] = []
+    for item in items:
+        if isinstance(item, dict):
+            normalized.append(dict(item))
+    if not total and normalized:
+        total = len(normalized)
+    return normalized, total
+
+
+def _normalize_recommendation_actor(actor: Any) -> dict[str, str]:
+    """Normalize recommendation actor sub-object."""
+    if not isinstance(actor, dict):
+        return {
+            "first_name": "",
+            "last_name": "",
+            "headline": "",
+            "public_profile_url": "",
+            "profile_picture_url": "",
+        }
+    return {
+        "first_name": clean_str(actor.get("first_name")),
+        "last_name": clean_str(actor.get("last_name")),
+        "headline": clean_str(actor.get("headline")),
+        "public_profile_url": clean_str(
+            actor.get("public_profile_url") or actor.get("profile_url")
+        ),
+        "profile_picture_url": clean_str(actor.get("profile_picture_url")),
+    }
+
+
+def _normalize_recommendation_entries(items: Any) -> list[dict[str, Any]]:
+    """Normalize given/received recommendation lists."""
+    entries: list[dict[str, Any]] = []
+    for item in coerce_list(items):
+        if not isinstance(item, dict):
+            continue
+        entries.append(
+            {
+                "caption": clean_str(item.get("caption")),
+                "text": clean_str(item.get("text")),
+                "actor": _normalize_recommendation_actor(item.get("actor")),
+            }
+        )
+    return entries
+
+
+def _normalize_recommendations_section(
+    profile: dict[str, Any],
+) -> tuple[dict[str, Any], int, int]:
+    """Defensively normalize recommendations from Phase 1 normalized profile."""
+    recs = profile.get("recommendations")
+    if not isinstance(recs, dict):
+        given_count = coerce_int(profile.get("recommendations_given_count"))
+        received_count = coerce_int(profile.get("recommendations_received_count"))
+        return {"given": [], "received": []}, given_count, received_count
+
+    given = _normalize_recommendation_entries(recs.get("given"))
+    received = _normalize_recommendation_entries(recs.get("received"))
+    given_count = coerce_int(
+        profile.get("recommendations_given_count"),
+        default=coerce_int(recs.get("given_total_count"), default=len(given)),
+    )
+    received_count = coerce_int(
+        profile.get("recommendations_received_count"),
+        default=coerce_int(recs.get("received_total_count"), default=len(received)),
+    )
+    return {"given": given, "received": received}, given_count, received_count

--- a/backend/services/integrations/linkedin/profile_context_patcher.py
+++ b/backend/services/integrations/linkedin/profile_context_patcher.py
@@ -1,0 +1,320 @@
+"""
+Phase 4 — apply user completion answers to ``LinkedInProfileContext`` without overwrite.
+
+Deterministic coercion only; no validation or AI logic.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from loguru import logger
+
+from services.integrations.linkedin.field_coercion import clean_str, coerce_list
+from services.integrations.linkedin.profile_validation_types import (
+    PROFESSIONAL_BACKGROUND_FIELD,
+    is_field_empty,
+)
+
+_LOG_PREFIX = "[ProfileCompletion]"
+
+PERSONAL_SCALAR_FIELDS = frozenset({"name", "headline", "about"})
+PROFESSIONAL_SCALAR_FIELDS = frozenset({"job_title", "company", "industry"})
+
+
+class ProfileCompletionPatchError(Exception):
+    """Raised when profile context cannot be patched."""
+
+
+def apply_completion_answers(
+    context: dict[str, Any],
+    answers: dict[str, Any],
+    allowed_keys: list[str],
+) -> dict[str, Any]:
+    """
+    Patch ``LinkedInProfileContext`` with user answers for allowed missing fields.
+
+    Never overwrites non-empty LinkedIn-derived values. Ignores answer keys outside
+    ``allowed_keys``.
+
+    Args:
+        context: Current ``LinkedInProfileContext`` dict
+        answers: Field-keyed user answers (strings or string lists)
+        allowed_keys: Phase 3 ``missing_fields`` keys permitted for this submit
+
+    Returns:
+        Patched profile context dict (deep copy of input)
+
+    Raises:
+        ProfileCompletionPatchError: When ``context`` is not a dict
+    """
+    logger.info(
+        "{} apply_completion_answers allowed_keys={} answer_keys={}",
+        _LOG_PREFIX,
+        allowed_keys,
+        sorted(answers.keys()) if isinstance(answers, dict) else None,
+    )
+    if not isinstance(context, dict):
+        raise ProfileCompletionPatchError("profile context must be a dict")
+    if not isinstance(answers, dict):
+        raise ProfileCompletionPatchError("completion answers must be a dict")
+
+    allowed = set(allowed_keys)
+    patched = copy.deepcopy(context)
+    _ensure_sections(patched)
+
+    patched_fields: list[str] = []
+
+    for field_key, answer in answers.items():
+        if field_key not in allowed:
+            logger.warning(
+                "{} apply_completion_answers ignoring disallowed key={}",
+                _LOG_PREFIX,
+                field_key,
+            )
+            continue
+
+        if _apply_field_patch(patched, field_key, answer):
+            patched_fields.append(field_key)
+
+    logger.info(
+        "{} apply_completion_answers complete patched_fields={}",
+        _LOG_PREFIX,
+        patched_fields,
+    )
+    return patched
+
+
+def _ensure_sections(context: dict[str, Any]) -> None:
+    personal = context.get("personal_information")
+    if not isinstance(personal, dict):
+        context["personal_information"] = {}
+    professional = context.get("professional_information")
+    if not isinstance(professional, dict):
+        context["professional_information"] = {}
+
+
+def _apply_field_patch(
+    context: dict[str, Any],
+    field_key: str,
+    answer: Any,
+) -> bool:
+    """Apply a single field patch; return True when context was modified."""
+    if field_key == PROFESSIONAL_BACKGROUND_FIELD:
+        return _patch_professional_background(context, answer)
+
+    if field_key in PERSONAL_SCALAR_FIELDS:
+        return _patch_personal_scalar(context, field_key, answer)
+
+    if field_key in PROFESSIONAL_SCALAR_FIELDS:
+        return _patch_professional_scalar(context, field_key, answer)
+
+    if field_key == "skills":
+        return _patch_skills(context, answer)
+
+    if field_key == "experience":
+        return _patch_experience(context, answer)
+
+    if field_key == "education":
+        return _patch_education(context, answer)
+
+    logger.warning(
+        "{} apply_completion_answers unknown field key={} — skipping",
+        _LOG_PREFIX,
+        field_key,
+    )
+    return False
+
+
+def _patch_personal_scalar(
+    context: dict[str, Any],
+    field_key: str,
+    answer: Any,
+) -> bool:
+    personal = context["personal_information"]
+    current = personal.get(field_key)
+    if not is_field_empty(current):
+        logger.warning(
+            "{} apply_completion_answers skip non-empty personal field={}",
+            _LOG_PREFIX,
+            field_key,
+        )
+        return False
+
+    value = clean_str(answer)
+    if field_key == "name":
+        full_name, first_name, last_name = _split_full_name(value)
+        personal["name"] = full_name
+        if is_field_empty(personal.get("first_name")):
+            personal["first_name"] = first_name
+        if is_field_empty(personal.get("last_name")):
+            personal["last_name"] = last_name
+        return bool(full_name)
+
+    personal[field_key] = value
+    return bool(value)
+
+
+def _patch_professional_scalar(
+    context: dict[str, Any],
+    field_key: str,
+    answer: Any,
+) -> bool:
+    professional = context["professional_information"]
+    current = professional.get(field_key)
+    if not is_field_empty(current):
+        logger.warning(
+            "{} apply_completion_answers skip non-empty professional field={}",
+            _LOG_PREFIX,
+            field_key,
+        )
+        return False
+
+    value = clean_str(answer)
+    professional[field_key] = value
+    return bool(value)
+
+
+def _patch_skills(context: dict[str, Any], answer: Any) -> bool:
+    professional = context["professional_information"]
+    current_skills = professional.get("skills")
+    if not is_field_empty(current_skills):
+        logger.warning(
+            "{} apply_completion_answers skip non-empty skills",
+            _LOG_PREFIX,
+        )
+        return False
+
+    skills = _coerce_skills_answer(answer)
+    if not skills:
+        return False
+
+    professional["skills"] = skills
+    professional["skills_total_count"] = len(skills)
+    return True
+
+
+def _patch_experience(context: dict[str, Any], answer: Any) -> bool:
+    professional = context["professional_information"]
+    experience = professional.get("experience")
+    if not isinstance(experience, list):
+        experience = []
+        professional["experience"] = experience
+
+    if not is_field_empty(experience):
+        logger.warning(
+            "{} apply_completion_answers skip non-empty experience",
+            _LOG_PREFIX,
+        )
+        return False
+
+    description = clean_str(answer)
+    if not description:
+        return False
+
+    experience.append(_empty_experience_entry(description))
+    professional["experience_total_count"] = len(experience)
+    return True
+
+
+def _patch_education(context: dict[str, Any], answer: Any) -> bool:
+    professional = context["professional_information"]
+    education = professional.get("education")
+    if not isinstance(education, list):
+        education = []
+        professional["education"] = education
+
+    if not is_field_empty(education):
+        logger.warning(
+            "{} apply_completion_answers skip non-empty education",
+            _LOG_PREFIX,
+        )
+        return False
+
+    school = clean_str(answer)
+    if not school:
+        return False
+
+    education.append(_empty_education_entry(school))
+    professional["education_total_count"] = len(education)
+    return True
+
+
+def _patch_professional_background(context: dict[str, Any], answer: Any) -> bool:
+    text = clean_str(answer)
+    if not text:
+        return False
+
+    if _looks_like_comma_separated_skills(text):
+        return _patch_skills(context, _split_skill_tokens(text))
+
+    return _patch_experience(context, text)
+
+
+def _split_full_name(full_name: str) -> tuple[str, str, str]:
+    """Return (full_name, first_name, last_name) from user input."""
+    cleaned = clean_str(full_name)
+    if not cleaned:
+        return "", "", ""
+
+    parts = cleaned.split(None, 1)
+    if len(parts) == 1:
+        return cleaned, parts[0], ""
+    return cleaned, parts[0], parts[1]
+
+
+def _looks_like_comma_separated_skills(text: str) -> bool:
+    """True when free text appears to be a comma-separated skill list."""
+    parts = [clean_str(part) for part in text.split(",") if clean_str(part)]
+    return len(parts) >= 2
+
+
+def _split_skill_tokens(text: str) -> list[str]:
+    return [clean_str(part) for part in text.split(",") if clean_str(part)]
+
+
+def _coerce_skills_answer(answer: Any) -> list[dict[str, Any]]:
+    """Convert user skills answer into ``ProfileSkillContext`` dicts."""
+    raw_items: list[Any]
+    if isinstance(answer, str):
+        raw_items = _split_skill_tokens(answer) if "," in answer else [clean_str(answer)]
+    elif isinstance(answer, list):
+        raw_items = coerce_list(answer)
+    else:
+        return []
+
+    skills: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in raw_items:
+        name = clean_str(item)
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        skills.append({"name": name, "endorsement_count": 0})
+    return skills
+
+
+def _empty_experience_entry(description: str) -> dict[str, Any]:
+    return {
+        "title": "",
+        "company": "",
+        "company_id": "",
+        "company_picture_url": "",
+        "start": "",
+        "end": None,
+        "location": "",
+        "description": clean_str(description),
+        "skills": [],
+    }
+
+
+def _empty_education_entry(school: str) -> dict[str, Any]:
+    return {
+        "school": clean_str(school),
+        "school_id": "",
+        "school_picture_url": "",
+        "degree": "",
+        "start": "",
+        "end": "",
+    }

--- a/backend/services/integrations/linkedin/profile_context_service.py
+++ b/backend/services/integrations/linkedin/profile_context_service.py
@@ -1,0 +1,149 @@
+"""
+Phase 2 — Profile context orchestration (cache-first build).
+
+Invoked after Phase 1 acquire; never calls Unipile.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from loguru import logger
+
+from services.integrations.linkedin.profile_context_builder import build_profile_context
+from services.integrations.linkedin.profile_context_types import (
+    ProfileContextAcquireMeta,
+    ProfileContextBuildError,
+)
+from services.integrations.linkedin.profile_repository import ProfileRepository
+
+_LOG_PREFIX = "[LinkedInProfileContext]"
+
+
+def _context_hash_matches(
+    cached_context: dict[str, Any],
+    profile_content_hash: Optional[str],
+) -> bool:
+    """Return True when cached context meta matches the current profile hash."""
+    if not profile_content_hash:
+        return False
+    meta = cached_context.get("meta")
+    if not isinstance(meta, dict):
+        return False
+    stored_hash = meta.get("built_from_profile_content_hash")
+    return isinstance(stored_hash, str) and stored_hash == profile_content_hash
+
+
+def get_or_build_profile_context(
+    user_id: str,
+    normalized_profile: dict[str, Any],
+    *,
+    profile_content_hash: Optional[str] = None,
+    repository: Optional[ProfileRepository] = None,
+    force_rebuild: bool = False,
+) -> tuple[dict[str, Any], ProfileContextAcquireMeta]:
+    """
+    Cache-first orchestrator: return profile context and acquisition metadata.
+
+    Serves from ``profile_context_json`` when present and ``profile_content_hash``
+    matches the stored snapshot. Otherwise builds from ``normalized_profile``,
+    persists, and returns ``meta.source = "built"``.
+
+    Args:
+        user_id: ALwrity user ID (Clerk)
+        normalized_profile: Phase 1 normalized profile dict
+        profile_content_hash: Current normalized profile hash from Phase 1 meta
+        repository: Optional ``ProfileRepository`` (for testing)
+        force_rebuild: Skip cache and rebuild context
+
+    Returns:
+        Tuple of (profile context dict, acquire meta with source cache|built)
+
+    Raises:
+        ProfileContextBuildError: When context cannot be built
+        ValueError: When persistence fails (e.g. missing analysis row)
+    """
+    logger.info(
+        "{} get_or_build_profile_context user_id={} force_rebuild={} hash={}",
+        _LOG_PREFIX,
+        user_id,
+        force_rebuild,
+        profile_content_hash[:12] if profile_content_hash else None,
+    )
+    repo = repository or ProfileRepository()
+
+    if not force_rebuild:
+        row = repo.get_analysis_row(user_id)
+        cached = repo.get_profile_context(user_id, row=row) if row else None
+        row_hash = row.get("profile_content_hash") if row else None
+        if (
+            cached
+            and profile_content_hash
+            and row_hash == profile_content_hash
+            and _context_hash_matches(cached, profile_content_hash)
+        ):
+            meta: ProfileContextAcquireMeta = {
+                "source": "cache",
+                "profile_context_updated_at": (
+                    row.get("profile_context_updated_at") if row else None
+                ),
+            }
+            logger.info(
+                "{} get_or_build_profile_context source=cache user_id={}",
+                _LOG_PREFIX,
+                user_id,
+            )
+            return cached, meta
+
+        if cached and profile_content_hash and row_hash != profile_content_hash:
+            logger.info(
+                "{} profile_content_hash mismatch — rebuilding context user_id={}",
+                _LOG_PREFIX,
+                user_id,
+            )
+        elif row and not cached:
+            logger.info(
+                "{} profile_context_json empty — building context user_id={}",
+                _LOG_PREFIX,
+                user_id,
+            )
+
+    try:
+        context = build_profile_context(
+            normalized_profile,
+            content_hash=profile_content_hash or "",
+        )
+        updated_at = repo.save_profile_context(
+            user_id,
+            context,
+            content_hash=profile_content_hash,
+        )
+    except ProfileContextBuildError:
+        logger.exception(
+            "{} get_or_build_profile_context build failed user_id={}",
+            _LOG_PREFIX,
+            user_id,
+        )
+        raise
+    except Exception as exc:
+        logger.exception(
+            "{} get_or_build_profile_context unexpected error user_id={}: {}",
+            _LOG_PREFIX,
+            user_id,
+            exc,
+        )
+        raise ProfileContextBuildError(
+            "Unable to build LinkedIn profile context"
+        ) from exc
+
+    built_meta: ProfileContextAcquireMeta = {
+        "source": "built",
+        "profile_context_updated_at": updated_at,
+    }
+    logger.info(
+        "{} get_or_build_profile_context source=built user_id={} updated_at={}",
+        _LOG_PREFIX,
+        user_id,
+        updated_at,
+    )
+    return context, built_meta

--- a/backend/services/integrations/linkedin/profile_context_types.py
+++ b/backend/services/integrations/linkedin/profile_context_types.py
@@ -1,0 +1,552 @@
+"""
+Phase 2 — LinkedIn Profile Context types, field contract, and validation.
+
+Defines ``LinkedInProfileContext`` shape, normalization→context field mapping,
+default factory, and gate validation (Step 2.1).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Optional, TypedDict
+
+# Bump when ``LinkedInProfileContext`` top-level or nested keys change.
+PROFILE_CONTEXT_SCHEMA_VERSION = 1
+
+ProfileContextSource = Literal["cache", "built"]
+
+
+class ProfileContextBuildError(Exception):
+    """Raised when profile context cannot be built from normalized input."""
+
+
+class PrimaryLocaleContext(TypedDict):
+    country: str
+    language: str
+
+
+class ProfileSkillContext(TypedDict):
+    name: str
+    endorsement_count: int
+
+
+class ProfileExperienceContext(TypedDict):
+    title: str
+    company: str
+    company_id: str
+    company_picture_url: str
+    start: str
+    end: Optional[str]
+    location: str
+    description: str
+    skills: list[str]
+
+
+class ProfileEducationContext(TypedDict):
+    school: str
+    school_id: str
+    school_picture_url: str
+    degree: str
+    start: str
+    end: str
+
+
+class ProfileLanguageContext(TypedDict):
+    name: str
+    proficiency: str
+
+
+class RecommendationActorContext(TypedDict):
+    first_name: str
+    last_name: str
+    headline: str
+    public_profile_url: str
+    profile_picture_url: str
+
+
+class RecommendationEntryContext(TypedDict):
+    caption: str
+    text: str
+    actor: RecommendationActorContext
+
+
+class ProfileRecommendationsContext(TypedDict):
+    given: list[RecommendationEntryContext]
+    received: list[RecommendationEntryContext]
+
+
+class PersonalInformationContext(TypedDict):
+    first_name: str
+    last_name: str
+    name: str
+    headline: str
+    about: str
+    location: str
+
+
+class ProfessionalInformationContext(TypedDict):
+    job_title: str
+    company: str
+    industry: str
+    skills: list[ProfileSkillContext]
+    skills_total_count: int
+    experience: list[ProfileExperienceContext]
+    experience_total_count: int
+    education: list[ProfileEducationContext]
+    education_total_count: int
+    languages: list[ProfileLanguageContext]
+    languages_total_count: int
+    certifications: list[dict[str, Any]]
+    certifications_total_count: int
+    projects: list[dict[str, Any]]
+    projects_total_count: int
+    volunteering_experience: list[dict[str, Any]]
+    volunteering_experience_total_count: int
+    recommendations: ProfileRecommendationsContext
+    recommendations_given_count: int
+    recommendations_received_count: int
+
+
+class LinkedInInformationContext(TypedDict):
+    followers: int
+    connections: int
+    creator_mode: bool
+    is_premium: bool
+    is_influencer: bool
+    is_open_profile: bool
+    is_self: bool
+    profile_url: str
+    profile_picture: str
+    background_picture: str
+    websites: list[str]
+    hashtags: list[str]
+    primary_locale: PrimaryLocaleContext
+    public_identifier: str
+    provider_id: str
+    member_urn: str
+
+
+class ProfileContextMeta(TypedDict):
+    built_from_profile_content_hash: str
+    schema_version: int
+
+
+class LinkedInProfileContext(TypedDict):
+    personal_information: PersonalInformationContext
+    professional_information: ProfessionalInformationContext
+    linkedin_information: LinkedInInformationContext
+    meta: ProfileContextMeta
+
+
+class ProfileContextMetaResponse(TypedDict, total=False):
+    """Orchestration metadata returned alongside profile context."""
+
+    source: ProfileContextSource
+    profile_context_updated_at: Optional[str]
+
+
+class ProfileContextAcquireMeta(TypedDict):
+    """Metadata returned by ``get_or_build_profile_context`` (Step 2.4)."""
+
+    source: ProfileContextSource
+    profile_context_updated_at: Optional[str]
+
+
+# Top-level keys on LinkedInProfileContext (Step 2.1 gate).
+PROFILE_CONTEXT_KEYS: frozenset[str] = frozenset(
+    {
+        "personal_information",
+        "professional_information",
+        "linkedin_information",
+        "meta",
+    }
+)
+
+PERSONAL_INFORMATION_KEYS: frozenset[str] = frozenset(
+    {
+        "first_name",
+        "last_name",
+        "name",
+        "headline",
+        "about",
+        "location",
+    }
+)
+
+PROFESSIONAL_INFORMATION_KEYS: frozenset[str] = frozenset(
+    {
+        "job_title",
+        "company",
+        "industry",
+        "skills",
+        "skills_total_count",
+        "experience",
+        "experience_total_count",
+        "education",
+        "education_total_count",
+        "languages",
+        "languages_total_count",
+        "certifications",
+        "certifications_total_count",
+        "projects",
+        "projects_total_count",
+        "volunteering_experience",
+        "volunteering_experience_total_count",
+        "recommendations",
+        "recommendations_given_count",
+        "recommendations_received_count",
+    }
+)
+
+LINKEDIN_INFORMATION_KEYS: frozenset[str] = frozenset(
+    {
+        "followers",
+        "connections",
+        "creator_mode",
+        "is_premium",
+        "is_influencer",
+        "is_open_profile",
+        "is_self",
+        "profile_url",
+        "profile_picture",
+        "background_picture",
+        "websites",
+        "hashtags",
+        "primary_locale",
+        "public_identifier",
+        "provider_id",
+        "member_urn",
+    }
+)
+
+PROFILE_CONTEXT_META_KEYS: frozenset[str] = frozenset(
+    {
+        "built_from_profile_content_hash",
+        "schema_version",
+    }
+)
+
+PRIMARY_LOCALE_KEYS: frozenset[str] = frozenset({"country", "language"})
+
+RECOMMENDATIONS_KEYS: frozenset[str] = frozenset({"given", "received"})
+
+# Phase 1 normalized key → (section, field) on LinkedInProfileContext.
+# ``industry`` and ``meta.*`` are not sourced from normalized profile keys.
+NORMALIZED_TO_PROFILE_CONTEXT_MAP: dict[str, tuple[str, str]] = {
+    "first_name": ("personal_information", "first_name"),
+    "last_name": ("personal_information", "last_name"),
+    "name": ("personal_information", "name"),
+    "headline": ("personal_information", "headline"),
+    "about": ("personal_information", "about"),
+    "location": ("personal_information", "location"),
+    "job_title": ("professional_information", "job_title"),
+    "company": ("professional_information", "company"),
+    "skills": ("professional_information", "skills"),
+    "skills_total_count": ("professional_information", "skills_total_count"),
+    "experience": ("professional_information", "experience"),
+    "work_experience_total_count": (
+        "professional_information",
+        "experience_total_count",
+    ),
+    "education": ("professional_information", "education"),
+    "education_total_count": ("professional_information", "education_total_count"),
+    "languages": ("professional_information", "languages"),
+    "languages_total_count": ("professional_information", "languages_total_count"),
+    "certifications": ("professional_information", "certifications"),
+    "certifications_total_count": (
+        "professional_information",
+        "certifications_total_count",
+    ),
+    "projects": ("professional_information", "projects"),
+    "projects_total_count": ("professional_information", "projects_total_count"),
+    "volunteering_experience": (
+        "professional_information",
+        "volunteering_experience",
+    ),
+    "volunteering_experience_total_count": (
+        "professional_information",
+        "volunteering_experience_total_count",
+    ),
+    "recommendations": ("professional_information", "recommendations"),
+    "recommendations_given_count": (
+        "professional_information",
+        "recommendations_given_count",
+    ),
+    "recommendations_received_count": (
+        "professional_information",
+        "recommendations_received_count",
+    ),
+    "followers": ("linkedin_information", "followers"),
+    "connections": ("linkedin_information", "connections"),
+    "creator_mode": ("linkedin_information", "creator_mode"),
+    "is_premium": ("linkedin_information", "is_premium"),
+    "is_influencer": ("linkedin_information", "is_influencer"),
+    "is_open_profile": ("linkedin_information", "is_open_profile"),
+    "is_self": ("linkedin_information", "is_self"),
+    "profile_url": ("linkedin_information", "profile_url"),
+    "profile_picture": ("linkedin_information", "profile_picture"),
+    "background_picture": ("linkedin_information", "background_picture"),
+    "websites": ("linkedin_information", "websites"),
+    "hashtags": ("linkedin_information", "hashtags"),
+    "primary_locale": ("linkedin_information", "primary_locale"),
+    "public_identifier": ("linkedin_information", "public_identifier"),
+    "provider_id": ("linkedin_information", "provider_id"),
+    "member_urn": ("linkedin_information", "member_urn"),
+}
+
+
+def default_primary_locale() -> PrimaryLocaleContext:
+    """Return empty primary locale."""
+    return {"country": "", "language": ""}
+
+
+def default_recommendations() -> ProfileRecommendationsContext:
+    """Return empty recommendations container."""
+    return {"given": [], "received": []}
+
+
+def default_personal_information() -> PersonalInformationContext:
+    """Return empty personal information section."""
+    return {
+        "first_name": "",
+        "last_name": "",
+        "name": "",
+        "headline": "",
+        "about": "",
+        "location": "",
+    }
+
+
+def default_professional_information() -> ProfessionalInformationContext:
+    """Return empty professional information section."""
+    return {
+        "job_title": "",
+        "company": "",
+        "industry": "",
+        "skills": [],
+        "skills_total_count": 0,
+        "experience": [],
+        "experience_total_count": 0,
+        "education": [],
+        "education_total_count": 0,
+        "languages": [],
+        "languages_total_count": 0,
+        "certifications": [],
+        "certifications_total_count": 0,
+        "projects": [],
+        "projects_total_count": 0,
+        "volunteering_experience": [],
+        "volunteering_experience_total_count": 0,
+        "recommendations": default_recommendations(),
+        "recommendations_given_count": 0,
+        "recommendations_received_count": 0,
+    }
+
+
+def default_linkedin_information() -> LinkedInInformationContext:
+    """Return empty LinkedIn platform metadata section."""
+    return {
+        "followers": 0,
+        "connections": 0,
+        "creator_mode": False,
+        "is_premium": False,
+        "is_influencer": False,
+        "is_open_profile": False,
+        "is_self": True,
+        "profile_url": "",
+        "profile_picture": "",
+        "background_picture": "",
+        "websites": [],
+        "hashtags": [],
+        "primary_locale": default_primary_locale(),
+        "public_identifier": "",
+        "provider_id": "",
+        "member_urn": "",
+    }
+
+
+def default_profile_context_meta(
+    *,
+    content_hash: str = "",
+) -> ProfileContextMeta:
+    """Return profile context meta with schema version."""
+    return {
+        "built_from_profile_content_hash": content_hash,
+        "schema_version": PROFILE_CONTEXT_SCHEMA_VERSION,
+    }
+
+
+def default_profile_context(
+    *,
+    content_hash: str = "",
+) -> dict[str, Any]:
+    """
+    Return a structurally complete ``LinkedInProfileContext`` with empty defaults.
+
+    Args:
+        content_hash: Optional Phase 1 ``profile_content_hash`` for meta linkage
+
+    Returns:
+        Dict matching ``PROFILE_CONTEXT_KEYS`` and nested key contracts
+    """
+    return {
+        "personal_information": default_personal_information(),
+        "professional_information": default_professional_information(),
+        "linkedin_information": default_linkedin_information(),
+        "meta": default_profile_context_meta(content_hash=content_hash),
+    }
+
+
+def validate_profile_context(context: dict[str, Any]) -> list[str]:
+    """
+    Validate Step 2.1 gate: profile context shape matches ``PROFILE_CONTEXT_KEYS``.
+
+    Args:
+        context: Candidate ``LinkedInProfileContext`` dict
+
+    Returns:
+        List of error messages (empty when valid)
+    """
+    errors: list[str] = []
+
+    if not isinstance(context, dict):
+        return ["profile context must be a dict"]
+
+    keys = set(context.keys())
+    missing = PROFILE_CONTEXT_KEYS - keys
+    extra = keys - PROFILE_CONTEXT_KEYS
+    if missing:
+        errors.append(f"missing profile context keys: {sorted(missing)}")
+    if extra:
+        errors.append(f"unexpected extra keys: {sorted(extra)}")
+
+    personal = context.get("personal_information")
+    if not isinstance(personal, dict):
+        errors.append("personal_information must be a dict")
+    else:
+        personal_keys = set(personal.keys())
+        personal_missing = PERSONAL_INFORMATION_KEYS - personal_keys
+        personal_extra = personal_keys - PERSONAL_INFORMATION_KEYS
+        if personal_missing:
+            errors.append(
+                f"missing personal_information keys: {sorted(personal_missing)}"
+            )
+        if personal_extra:
+            errors.append(
+                f"unexpected personal_information keys: {sorted(personal_extra)}"
+            )
+
+    professional = context.get("professional_information")
+    if not isinstance(professional, dict):
+        errors.append("professional_information must be a dict")
+    else:
+        prof_keys = set(professional.keys())
+        prof_missing = PROFESSIONAL_INFORMATION_KEYS - prof_keys
+        prof_extra = prof_keys - PROFESSIONAL_INFORMATION_KEYS
+        if prof_missing:
+            errors.append(
+                f"missing professional_information keys: {sorted(prof_missing)}"
+            )
+        if prof_extra:
+            errors.append(
+                f"unexpected professional_information keys: {sorted(prof_extra)}"
+            )
+
+        for list_key in (
+            "skills",
+            "experience",
+            "education",
+            "languages",
+            "certifications",
+            "projects",
+            "volunteering_experience",
+        ):
+            if not isinstance(professional.get(list_key), list):
+                errors.append(f"professional_information.{list_key} must be a list")
+
+        recs = professional.get("recommendations")
+        if not isinstance(recs, dict):
+            errors.append("professional_information.recommendations must be a dict")
+        else:
+            rec_keys = set(recs.keys())
+            if rec_keys != RECOMMENDATIONS_KEYS:
+                errors.append(
+                    "professional_information.recommendations must contain "
+                    "given and received only"
+                )
+            elif not isinstance(recs.get("given"), list) or not isinstance(
+                recs.get("received"), list
+            ):
+                errors.append(
+                    "professional_information.recommendations.given/received "
+                    "must be lists"
+                )
+
+        for int_key in (
+            "skills_total_count",
+            "experience_total_count",
+            "education_total_count",
+            "languages_total_count",
+            "certifications_total_count",
+            "projects_total_count",
+            "volunteering_experience_total_count",
+            "recommendations_given_count",
+            "recommendations_received_count",
+        ):
+            if not isinstance(professional.get(int_key), int):
+                errors.append(f"professional_information.{int_key} must be an int")
+
+    linkedin = context.get("linkedin_information")
+    if not isinstance(linkedin, dict):
+        errors.append("linkedin_information must be a dict")
+    else:
+        li_keys = set(linkedin.keys())
+        li_missing = LINKEDIN_INFORMATION_KEYS - li_keys
+        li_extra = li_keys - LINKEDIN_INFORMATION_KEYS
+        if li_missing:
+            errors.append(f"missing linkedin_information keys: {sorted(li_missing)}")
+        if li_extra:
+            errors.append(f"unexpected linkedin_information keys: {sorted(li_extra)}")
+
+        for list_key in ("websites", "hashtags"):
+            if not isinstance(linkedin.get(list_key), list):
+                errors.append(f"linkedin_information.{list_key} must be a list")
+
+        locale = linkedin.get("primary_locale")
+        if not isinstance(locale, dict):
+            errors.append("linkedin_information.primary_locale must be a dict")
+        elif set(locale.keys()) != PRIMARY_LOCALE_KEYS:
+            errors.append(
+                "linkedin_information.primary_locale must contain country and language only"
+            )
+
+        for int_key in ("followers", "connections"):
+            if not isinstance(linkedin.get(int_key), int):
+                errors.append(f"linkedin_information.{int_key} must be an int")
+
+        for bool_key in (
+            "creator_mode",
+            "is_premium",
+            "is_influencer",
+            "is_open_profile",
+            "is_self",
+        ):
+            if not isinstance(linkedin.get(bool_key), bool):
+                errors.append(f"linkedin_information.{bool_key} must be a bool")
+
+    meta = context.get("meta")
+    if not isinstance(meta, dict):
+        errors.append("meta must be a dict")
+    else:
+        meta_keys = set(meta.keys())
+        meta_missing = PROFILE_CONTEXT_META_KEYS - meta_keys
+        meta_extra = meta_keys - PROFILE_CONTEXT_META_KEYS
+        if meta_missing:
+            errors.append(f"missing meta keys: {sorted(meta_missing)}")
+        if meta_extra:
+            errors.append(f"unexpected meta keys: {sorted(meta_extra)}")
+        if not isinstance(meta.get("schema_version"), int):
+            errors.append("meta.schema_version must be an int")
+        if not isinstance(meta.get("built_from_profile_content_hash"), str):
+            errors.append("meta.built_from_profile_content_hash must be a str")
+
+    return errors

--- a/backend/services/integrations/linkedin/profile_intelligence_llm.py
+++ b/backend/services/integrations/linkedin/profile_intelligence_llm.py
@@ -1,0 +1,168 @@
+"""
+Phase 5 — LLM adapter for AI profile intelligence (Gemini structured JSON).
+
+Thin wrapper over injectable ``generate_fn``; no validation or persistence.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Optional
+
+from loguru import logger
+
+from services.integrations.linkedin.profile_intelligence_types import (
+    DEFAULT_PROFILE_INTELLIGENCE_MODEL,
+    ai_profile_intelligence_json_schema,
+)
+from services.llm_providers.gemini_provider import gemini_structured_json_response
+
+_LOG_PREFIX = "[ProfileIntelligence]"
+
+PROFILE_INTELLIGENCE_LLM_TEMPERATURE = 0.2
+PROFILE_INTELLIGENCE_LLM_MAX_TOKENS = 4096
+
+ProfileIntelligenceGenerateFn = Callable[..., Any]
+
+
+class ProfileIntelligenceLLMError(Exception):
+    """Raised when the LLM provider fails for profile intelligence generation."""
+
+    def __init__(self, message: str, *, error_kind: str = "unknown") -> None:
+        super().__init__(message)
+        self.error_kind = error_kind
+
+
+def _classify_gemini_error(exc: Exception) -> str:
+    """Return a safe error category for Gemini/provider failures (for logging)."""
+    msg = str(exc).lower()
+    if "resource_exhausted" in msg or "quota" in msg or "rate limit" in msg:
+        return "quota_or_rate_limit"
+    if "401" in msg or "403" in msg or "api key" in msg or "authentication" in msg:
+        return "auth"
+    if "timeout" in msg or "timed out" in msg or "deadline" in msg:
+        return "timeout"
+    if "invalid json" in msg or "json" in msg:
+        return "invalid_json"
+    return "provider_error"
+
+
+def _log_gemini_provider_error(exc: Exception, *, user_id: Optional[str]) -> None:
+    """Log Gemini/provider failures with safe metadata for production debugging."""
+    error_kind = _classify_gemini_error(exc)
+    logger.error(
+        "{} Gemini/provider failure kind={} type={} user_id={} message={}",
+        _LOG_PREFIX,
+        error_kind,
+        type(exc).__name__,
+        user_id,
+        str(exc)[:500],
+    )
+    logger.exception(
+        "{} Gemini/provider traceback user_id={} kind={}",
+        _LOG_PREFIX,
+        user_id,
+        error_kind,
+    )
+
+
+def call_profile_intelligence_llm(
+    *,
+    system_prompt: str,
+    user_prompt: str,
+    user_id: Optional[str] = None,
+    generate_fn: ProfileIntelligenceGenerateFn = gemini_structured_json_response,
+) -> dict[str, Any]:
+    """
+    Call the LLM to generate structured profile intelligence JSON.
+
+    Args:
+        system_prompt: System instruction for the model
+        user_prompt: User message (serialized ``LinkedInProfileContext`` JSON)
+        user_id: Optional ALwrity user ID for provider usage tracking
+        generate_fn: Injectable structured JSON generator (default: Gemini)
+
+    Returns:
+        Parsed dict from the LLM (not yet validated by Pydantic)
+
+    Raises:
+        ProfileIntelligenceLLMError: When the provider fails or returns unusable output
+    """
+    schema = ai_profile_intelligence_json_schema()
+    logger.info(
+        "{} call_profile_intelligence_llm start model={} user_prompt_len={} user_id={}",
+        _LOG_PREFIX,
+        DEFAULT_PROFILE_INTELLIGENCE_MODEL,
+        len(user_prompt) if isinstance(user_prompt, str) else None,
+        user_id,
+    )
+
+    try:
+        response = generate_fn(
+            prompt=user_prompt,
+            schema=schema,
+            temperature=PROFILE_INTELLIGENCE_LLM_TEMPERATURE,
+            max_tokens=PROFILE_INTELLIGENCE_LLM_MAX_TOKENS,
+            system_prompt=system_prompt,
+            user_id=user_id,
+        )
+    except ProfileIntelligenceLLMError:
+        raise
+    except Exception as exc:
+        _log_gemini_provider_error(exc, user_id=user_id)
+        error_kind = _classify_gemini_error(exc)
+        raise ProfileIntelligenceLLMError(
+            "Unable to generate AI profile intelligence from LLM",
+            error_kind=error_kind,
+        ) from exc
+
+    try:
+        result = _coerce_llm_dict(response)
+    except ProfileIntelligenceLLMError as exc:
+        logger.error(
+            "{} call_profile_intelligence_llm invalid response user_id={} kind={} "
+            "type={} message={}",
+            _LOG_PREFIX,
+            user_id,
+            exc.error_kind,
+            type(response).__name__,
+            str(exc),
+        )
+        raise
+
+    logger.info(
+        "{} call_profile_intelligence_llm complete user_id={} response_keys={}",
+        _LOG_PREFIX,
+        user_id,
+        sorted(result.keys()),
+    )
+    return result
+
+
+def _coerce_llm_dict(response: Any) -> dict[str, Any]:
+    """Normalize provider output to a dict."""
+    if isinstance(response, dict):
+        return response
+    if isinstance(response, str):
+        try:
+            parsed = json.loads(response)
+        except json.JSONDecodeError as exc:
+            logger.error(
+                "{} LLM returned invalid JSON string error={}",
+                _LOG_PREFIX,
+                exc,
+            )
+            raise ProfileIntelligenceLLMError(
+                "LLM returned invalid JSON string",
+                error_kind="invalid_json",
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise ProfileIntelligenceLLMError(
+                "LLM JSON response must be an object",
+                error_kind="invalid_json",
+            )
+        return parsed
+    raise ProfileIntelligenceLLMError(
+        f"Unexpected LLM response type: {type(response).__name__}",
+        error_kind="invalid_response",
+    )

--- a/backend/services/integrations/linkedin/profile_intelligence_service.py
+++ b/backend/services/integrations/linkedin/profile_intelligence_service.py
@@ -1,0 +1,370 @@
+"""
+Phase 5 — AI profile intelligence orchestration (cache-first generate).
+
+Gates on profile completeness, coordinates LLM + validation + persistence.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Optional, TypedDict
+
+from loguru import logger
+
+from prompts.linkedin.profile_intelligence_prompt import (
+    PROFILE_INTELLIGENCE_SYSTEM_PROMPT,
+    build_profile_intelligence_user_prompt,
+)
+from services.integrations.linkedin.profile_intelligence_llm import (
+    ProfileIntelligenceGenerateFn,
+    ProfileIntelligenceLLMError,
+    call_profile_intelligence_llm,
+)
+from services.integrations.linkedin.profile_intelligence_validator import (
+    ProfileIntelligenceValidationError,
+    build_stored_ai_profile_intelligence,
+    normalize_ai_profile_intelligence_raw,
+    validate_ai_profile_intelligence_payload,
+)
+from services.integrations.linkedin.profile_repository import (
+    ProfileRepository,
+    compute_profile_context_hash,
+)
+from services.integrations.linkedin.profile_validation_types import ProfileValidationResult
+from services.llm_providers.gemini_provider import gemini_structured_json_response
+
+_LOG_PREFIX = "[ProfileIntelligence]"
+
+VALIDATION_RETRY_USER_SUFFIX = (
+    "\n\nPrevious response failed schema validation. "
+    "Return valid JSON only matching the required schema exactly."
+)
+
+
+class ProfileIntelligenceError(Exception):
+    """Base error for profile intelligence orchestration."""
+
+
+class ProfileIntelligenceAcquireMeta(TypedDict, total=False):
+    """Metadata for intelligence acquisition."""
+
+    source: Literal["cache", "generated"]
+    ai_intelligence_updated_at: Optional[str]
+
+
+def get_or_generate_profile_intelligence(
+    user_id: str,
+    profile_context: dict[str, Any],
+    *,
+    profile_validation: ProfileValidationResult,
+    repository: Optional[ProfileRepository] = None,
+    force_regenerate: bool = False,
+    generate_fn: ProfileIntelligenceGenerateFn = gemini_structured_json_response,
+) -> tuple[Optional[dict[str, Any]], ProfileIntelligenceAcquireMeta]:
+    """
+    Return cached or newly generated AI profile intelligence.
+
+    Skips LLM when ``profile_validation.is_profile_complete`` is False.
+
+    Args:
+        user_id: ALwrity user ID
+        profile_context: Current ``LinkedInProfileContext`` dict
+        profile_validation: Phase 3 validation result (completeness gate)
+        repository: Optional ``ProfileRepository`` (for testing)
+        force_regenerate: Bypass cache and regenerate via LLM
+        generate_fn: Injectable LLM adapter (for testing)
+
+    Returns:
+        Tuple of (intelligence dict or ``None`` when incomplete, acquire meta)
+
+    Raises:
+        ProfileIntelligenceLLMError: When LLM fails after validation retry
+        ProfileIntelligenceValidationError: When validation fails after retry
+        ValueError: When analysis row is missing during generation
+    """
+    logger.info(
+        "{} ============================================================",
+        _LOG_PREFIX,
+    )
+    logger.info("{} Starting AI profile understanding user_id={}", _LOG_PREFIX, user_id)
+    logger.info(
+        "{} Gate check is_profile_complete={} force_regenerate={}",
+        _LOG_PREFIX,
+        profile_validation.get("is_profile_complete"),
+        force_regenerate,
+    )
+
+    if not profile_validation.get("is_profile_complete"):
+        logger.info(
+            "{} Skipping intelligence — profile incomplete user_id={} missing_fields={}",
+            _LOG_PREFIX,
+            user_id,
+            profile_validation.get("missing_fields"),
+        )
+        return None, {"ai_intelligence_updated_at": None}
+
+    if not isinstance(profile_context, dict):
+        logger.error(
+            "{} Invalid profile_context type={} user_id={}",
+            _LOG_PREFIX,
+            type(profile_context).__name__,
+            user_id,
+        )
+        raise ProfileIntelligenceError("profile context must be a dict")
+
+    repo = repository or ProfileRepository()
+    row = repo.get_analysis_row(user_id)
+    if not row:
+        logger.error(
+            "{} No analysis row for intelligence user_id={}",
+            _LOG_PREFIX,
+            user_id,
+        )
+        raise ValueError(
+            f"No linkedin_analysis_context row for user_id={user_id!r}; "
+            "acquire normalized profile first"
+        )
+
+    context_hash = compute_profile_context_hash(profile_context)
+    logger.info(
+        "{} Context hash computed user_id={} hash={}",
+        _LOG_PREFIX,
+        user_id,
+        context_hash[:12],
+    )
+
+    if not force_regenerate:
+        cached = repo.get_ai_profile_intelligence(user_id, row=row)
+        if cached and _is_intelligence_cache_valid(
+            cached,
+            context_hash=context_hash,
+            row=row,
+            user_id=user_id,
+        ):
+            meta: ProfileIntelligenceAcquireMeta = {
+                "source": "cache",
+                "ai_intelligence_updated_at": row.get("ai_intelligence_updated_at"),
+            }
+            logger.info(
+                "{} Cache hit user_id={} ai_intelligence_updated_at={}",
+                _LOG_PREFIX,
+                user_id,
+                meta.get("ai_intelligence_updated_at"),
+            )
+            logger.info("{} AI profile understanding finished source=cache", _LOG_PREFIX)
+            return cached, meta
+
+        logger.info(
+            "{} Cache miss user_id={} cached_present={}",
+            _LOG_PREFIX,
+            user_id,
+            cached is not None,
+        )
+    else:
+        logger.info(
+            "{} force_regenerate=True — bypassing cache user_id={}",
+            _LOG_PREFIX,
+            user_id,
+        )
+
+    stored = _generate_and_persist_intelligence(
+        user_id,
+        profile_context,
+        context_hash=context_hash,
+        repository=repo,
+        generate_fn=generate_fn,
+    )
+    updated_at = repo.get_analysis_row(user_id)
+    ai_updated = updated_at.get("ai_intelligence_updated_at") if updated_at else None
+
+    generated_meta: ProfileIntelligenceAcquireMeta = {
+        "source": "generated",
+        "ai_intelligence_updated_at": ai_updated,
+    }
+    logger.info(
+        "{} AI profile understanding finished source=generated user_id={}",
+        _LOG_PREFIX,
+        user_id,
+    )
+    return stored, generated_meta
+
+
+def _is_intelligence_cache_valid(
+    cached: dict[str, Any],
+    *,
+    context_hash: str,
+    row: dict[str, Any],
+    user_id: str,
+) -> bool:
+    """Return True when cached intelligence matches the current profile context."""
+    meta = cached.get("meta")
+    if not isinstance(meta, dict):
+        logger.warning(
+            "{} Cache invalid — missing meta user_id={}",
+            _LOG_PREFIX,
+            user_id,
+        )
+        return False
+
+    stored_hash = meta.get("built_from_profile_context_hash")
+    if not isinstance(stored_hash, str) or stored_hash != context_hash:
+        logger.info(
+            "{} Cache invalid — context hash mismatch user_id={} stored={} current={}",
+            _LOG_PREFIX,
+            user_id,
+            stored_hash[:12] if isinstance(stored_hash, str) and stored_hash else None,
+            context_hash[:12],
+        )
+        return False
+
+    context_updated_at = row.get("profile_context_updated_at")
+    ai_updated_at = row.get("ai_intelligence_updated_at")
+    if (
+        isinstance(context_updated_at, str)
+        and isinstance(ai_updated_at, str)
+        and context_updated_at > ai_updated_at
+    ):
+        logger.info(
+            "{} Cache invalid — profile_context_updated_at newer user_id={} "
+            "context_updated_at={} ai_updated_at={}",
+            _LOG_PREFIX,
+            user_id,
+            context_updated_at,
+            ai_updated_at,
+        )
+        return False
+
+    logger.debug(
+        "{} Cache valid user_id={} hash={}",
+        _LOG_PREFIX,
+        user_id,
+        context_hash[:12],
+    )
+    return True
+
+
+def _generate_and_persist_intelligence(
+    user_id: str,
+    profile_context: dict[str, Any],
+    *,
+    context_hash: str,
+    repository: ProfileRepository,
+    generate_fn: ProfileIntelligenceGenerateFn,
+) -> dict[str, Any]:
+    """Run LLM (with one validation retry), validate, and persist intelligence."""
+    logger.info("{} Preparing LLM prompt user_id={}", _LOG_PREFIX, user_id)
+    user_prompt = build_profile_intelligence_user_prompt(profile_context)
+    logger.info(
+        "{} User prompt ready user_id={} prompt_len={}",
+        _LOG_PREFIX,
+        user_id,
+        len(user_prompt),
+    )
+
+    raw = _call_llm_with_validation_retry(
+        user_id=user_id,
+        user_prompt=user_prompt,
+        generate_fn=generate_fn,
+    )
+
+    payload = validate_ai_profile_intelligence_payload(raw)
+    stored = build_stored_ai_profile_intelligence(payload, context_hash=context_hash)
+    logger.info(
+        "{} Persisting ai_profile_intelligence_json user_id={} hash={}",
+        _LOG_PREFIX,
+        user_id,
+        context_hash[:12],
+    )
+    try:
+        repository.save_ai_profile_intelligence(
+            user_id,
+            stored,
+            context_hash=context_hash,
+        )
+    except ValueError as exc:
+        logger.exception(
+            "{} Failed to persist intelligence user_id={}: {}",
+            _LOG_PREFIX,
+            user_id,
+            exc,
+        )
+        raise ProfileIntelligenceError(
+            "Unable to persist AI profile intelligence"
+        ) from exc
+
+    logger.info("{} Persisted ai_profile_intelligence_json user_id={}", _LOG_PREFIX, user_id)
+    return stored
+
+
+def _call_llm_with_validation_retry(
+    *,
+    user_id: str,
+    user_prompt: str,
+    generate_fn: ProfileIntelligenceGenerateFn,
+) -> dict[str, Any]:
+    """Call LLM once; retry once when validation fails on the parsed response."""
+    logger.info("{} Sending request to LLM user_id={}", _LOG_PREFIX, user_id)
+    raw = call_profile_intelligence_llm(
+        system_prompt=PROFILE_INTELLIGENCE_SYSTEM_PROMPT,
+        user_prompt=user_prompt,
+        user_id=user_id,
+        generate_fn=generate_fn,
+    )
+    logger.info(
+        "{} AI response received user_id={} keys={}",
+        _LOG_PREFIX,
+        user_id,
+        sorted(raw.keys()) if isinstance(raw, dict) else None,
+    )
+
+    normalized = normalize_ai_profile_intelligence_raw(raw) if isinstance(raw, dict) else raw
+
+    try:
+        validate_ai_profile_intelligence_payload(normalized)
+        logger.info("{} Validation passed on first attempt user_id={}", _LOG_PREFIX, user_id)
+        return normalized
+    except ProfileIntelligenceValidationError as first_error:
+        logger.warning(
+            "{} Validation failed — retrying LLM once user_id={} code={}: {}",
+            _LOG_PREFIX,
+            user_id,
+            first_error.validation_code,
+            first_error,
+        )
+
+    retry_prompt = f"{user_prompt}{VALIDATION_RETRY_USER_SUFFIX}"
+    logger.info("{} Sending validation retry to LLM user_id={}", _LOG_PREFIX, user_id)
+    retry_raw = call_profile_intelligence_llm(
+        system_prompt=PROFILE_INTELLIGENCE_SYSTEM_PROMPT,
+        user_prompt=retry_prompt,
+        user_id=user_id,
+        generate_fn=generate_fn,
+    )
+    logger.info(
+        "{} Retry AI response received user_id={} keys={}",
+        _LOG_PREFIX,
+        user_id,
+        sorted(retry_raw.keys()) if isinstance(retry_raw, dict) else None,
+    )
+
+    retry_normalized = (
+        normalize_ai_profile_intelligence_raw(retry_raw)
+        if isinstance(retry_raw, dict)
+        else retry_raw
+    )
+
+    try:
+        validate_ai_profile_intelligence_payload(retry_normalized)
+        logger.info("{} Validation passed on retry user_id={}", _LOG_PREFIX, user_id)
+        return retry_normalized
+    except ProfileIntelligenceValidationError as retry_error:
+        logger.exception(
+            "{} Validation failed after retry user_id={} code={}: {}",
+            _LOG_PREFIX,
+            user_id,
+            retry_error.validation_code,
+            retry_error,
+        )
+        raise ProfileIntelligenceValidationError(
+            f"AI profile intelligence failed validation after retry ({retry_error})",
+            validation_code=retry_error.validation_code,
+        ) from retry_error

--- a/backend/services/integrations/linkedin/profile_intelligence_types.py
+++ b/backend/services/integrations/linkedin/profile_intelligence_types.py
@@ -1,0 +1,74 @@
+"""
+Phase 5 — AI profile intelligence Pydantic types and JSON schema export.
+
+Defines LLM output shape (without ``meta``) and stored payload with server-side meta.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+PROFILE_INTELLIGENCE_SCHEMA_VERSION = 1
+DEFAULT_PROFILE_INTELLIGENCE_MODEL = "gemini-2.5-flash"
+UNKNOWN_SENTINEL = "Unknown"
+
+
+class AIProfileIntelligencePayload(BaseModel):
+    """
+    Structured LLM output for profile understanding.
+
+    Does not include ``meta`` — attached server-side after validation.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    professional_identity: str
+    primary_expertise: list[str]
+    industry: str
+    experience_level: str
+    knowledge_domains: list[str]
+    writing_opportunities: list[str]
+    target_audience: list[str]
+    communication_style: str
+    brand_positioning: str
+    summary: str
+
+
+class AIProfileIntelligenceMeta(BaseModel):
+    """Server-owned metadata for cached AI profile intelligence."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    built_from_profile_context_hash: str = ""
+    schema_version: int = Field(default=PROFILE_INTELLIGENCE_SCHEMA_VERSION)
+    model: str = Field(default=DEFAULT_PROFILE_INTELLIGENCE_MODEL)
+
+
+class StoredAIProfileIntelligence(BaseModel):
+    """Full persisted intelligence object including server ``meta``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    meta: AIProfileIntelligenceMeta
+    professional_identity: str
+    primary_expertise: list[str]
+    industry: str
+    experience_level: str
+    knowledge_domains: list[str]
+    writing_opportunities: list[str]
+    target_audience: list[str]
+    communication_style: str
+    brand_positioning: str
+    summary: str
+
+
+def ai_profile_intelligence_json_schema() -> dict[str, Any]:
+    """
+    Return JSON schema for Gemini structured output (LLM fields only).
+
+    Returns:
+        JSON schema dict suitable for ``gemini_structured_json_response``
+    """
+    return AIProfileIntelligencePayload.model_json_schema()

--- a/backend/services/integrations/linkedin/profile_intelligence_validator.py
+++ b/backend/services/integrations/linkedin/profile_intelligence_validator.py
@@ -1,0 +1,254 @@
+"""
+Phase 5 — pure AI profile intelligence validation (no LLM, no persistence).
+
+Parses LLM output with Pydantic and applies post-checks before meta attachment.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+from pydantic import ValidationError
+
+from services.integrations.linkedin.field_coercion import clean_str
+from services.integrations.linkedin.profile_intelligence_types import (
+    AIProfileIntelligenceMeta,
+    AIProfileIntelligencePayload,
+    DEFAULT_PROFILE_INTELLIGENCE_MODEL,
+    PROFILE_INTELLIGENCE_SCHEMA_VERSION,
+    UNKNOWN_SENTINEL,
+    StoredAIProfileIntelligence,
+)
+
+_LOG_PREFIX = "[ProfileIntelligence]"
+
+_SCALAR_FIELDS: tuple[str, ...] = (
+    "professional_identity",
+    "industry",
+    "experience_level",
+    "communication_style",
+    "brand_positioning",
+    "summary",
+)
+
+_LIST_FIELDS: tuple[str, ...] = (
+    "primary_expertise",
+    "knowledge_domains",
+    "writing_opportunities",
+    "target_audience",
+)
+
+
+class ProfileIntelligenceValidationError(Exception):
+    """Raised when AI profile intelligence output fails validation."""
+
+    def __init__(self, message: str, *, validation_code: str = "validation_failed") -> None:
+        super().__init__(message)
+        self.validation_code = validation_code
+
+
+def normalize_ai_profile_intelligence_raw(raw: dict[str, Any]) -> dict[str, Any]:
+    """
+    Best-effort normalize LLM JSON before strict Pydantic validation.
+
+    Strips strings, replaces empty scalars with ``Unknown``, drops empty list
+    items, and ignores unexpected keys from the model.
+    """
+    normalized: dict[str, Any] = {}
+
+    for field_name in _SCALAR_FIELDS:
+        cleaned = clean_str(raw.get(field_name))
+        normalized[field_name] = cleaned if cleaned else UNKNOWN_SENTINEL
+
+    for field_name in _LIST_FIELDS:
+        items = raw.get(field_name)
+        if not isinstance(items, list):
+            normalized[field_name] = []
+            continue
+        normalized[field_name] = [
+            cleaned
+            for item in items
+            if isinstance(item, str) and (cleaned := clean_str(item))
+        ]
+
+    logger.debug(
+        "{} normalize_ai_profile_intelligence_raw scalar_unknowns={} list_counts={}",
+        _LOG_PREFIX,
+        sum(1 for key in _SCALAR_FIELDS if normalized[key] == UNKNOWN_SENTINEL),
+        {key: len(normalized[key]) for key in _LIST_FIELDS},
+    )
+    return normalized
+
+
+def _first_pydantic_field_hint(exc: ValidationError) -> str:
+    """Extract a concise field hint from a Pydantic validation error."""
+    for error in exc.errors():
+        loc = error.get("loc") or ()
+        field = ".".join(str(part) for part in loc if part != "__root__")
+        msg = error.get("msg", "invalid value")
+        if field:
+            return f"{field}: {msg}"
+        return str(msg)
+    return "schema validation failed"
+
+
+def validate_ai_profile_intelligence_payload(
+    raw: Any,
+) -> AIProfileIntelligencePayload:
+    """
+    Validate raw LLM output into ``AIProfileIntelligencePayload``.
+
+    Applies Pydantic parsing (``extra='forbid'``) and deterministic post-checks.
+
+    Args:
+        raw: Parsed JSON object from the LLM
+
+    Returns:
+        Validated payload model
+
+    Raises:
+        ProfileIntelligenceValidationError: When parsing or post-checks fail
+    """
+    logger.info("{} validate_ai_profile_intelligence_payload start", _LOG_PREFIX)
+
+    if not isinstance(raw, dict):
+        logger.error(
+            "{} validate_ai_profile_intelligence_payload not a dict type={}",
+            _LOG_PREFIX,
+            type(raw).__name__,
+        )
+        raise ProfileIntelligenceValidationError(
+            "AI profile intelligence must be a JSON object"
+        )
+
+    try:
+        payload = AIProfileIntelligencePayload.model_validate(raw)
+    except ValidationError as exc:
+        field_hint = _first_pydantic_field_hint(exc)
+        logger.exception(
+            "{} validate_ai_profile_intelligence_payload pydantic error hint={}: {}",
+            _LOG_PREFIX,
+            field_hint,
+            exc,
+        )
+        raise ProfileIntelligenceValidationError(
+            f"AI profile intelligence failed schema validation ({field_hint})",
+            validation_code="schema_validation",
+        ) from exc
+
+    _run_post_checks(payload)
+    logger.info(
+        "{} validate_ai_profile_intelligence_payload ok fields={}",
+        _LOG_PREFIX,
+        len(_SCALAR_FIELDS) + len(_LIST_FIELDS),
+    )
+    return payload
+
+
+def build_stored_ai_profile_intelligence(
+    payload: AIProfileIntelligencePayload,
+    *,
+    context_hash: str = "",
+    model: str = DEFAULT_PROFILE_INTELLIGENCE_MODEL,
+) -> dict[str, Any]:
+    """
+    Attach server-side ``meta`` and return a persistence-ready dict.
+
+    Args:
+        payload: Validated LLM output
+        context_hash: Canonical hash of source ``LinkedInProfileContext``
+        model: LLM model identifier used for generation
+
+    Returns:
+        Dict matching ``StoredAIProfileIntelligence`` shape
+    """
+    logger.info(
+        "{} build_stored_ai_profile_intelligence context_hash={} model={}",
+        _LOG_PREFIX,
+        context_hash[:12] if context_hash else None,
+        model,
+    )
+    stored = StoredAIProfileIntelligence(
+        meta=AIProfileIntelligenceMeta(
+            built_from_profile_context_hash=context_hash,
+            schema_version=PROFILE_INTELLIGENCE_SCHEMA_VERSION,
+            model=model,
+        ),
+        **payload.model_dump(),
+    )
+    return stored.model_dump()
+
+
+def _run_post_checks(payload: AIProfileIntelligencePayload) -> None:
+    """Apply scalar and list item rules beyond Pydantic type checks."""
+    data = payload.model_dump()
+
+    for field_name in _SCALAR_FIELDS:
+        value = data[field_name]
+        cleaned = clean_str(value)
+        if isinstance(value, str) and value != "" and cleaned == "":
+            logger.error(
+                "{} post-check whitespace-only scalar field={}",
+                _LOG_PREFIX,
+                field_name,
+            )
+            raise ProfileIntelligenceValidationError(
+                f"AI profile intelligence field {field_name!r} must not be whitespace-only",
+                validation_code="empty_scalar",
+            )
+        if cleaned == "":
+            logger.error(
+                "{} post-check empty scalar field={}",
+                _LOG_PREFIX,
+                field_name,
+            )
+            raise ProfileIntelligenceValidationError(
+                f"AI profile intelligence field {field_name!r} must not be empty",
+                validation_code="empty_scalar",
+            )
+        if cleaned != value:
+            logger.error(
+                "{} post-check untrimmed scalar field={}",
+                _LOG_PREFIX,
+                field_name,
+            )
+            raise ProfileIntelligenceValidationError(
+                f"AI profile intelligence field {field_name!r} must not contain "
+                "leading or trailing whitespace",
+                validation_code="untrimmed_scalar",
+            )
+
+    for field_name in _LIST_FIELDS:
+        items = data[field_name]
+        if not isinstance(items, list):
+            continue
+        for index, item in enumerate(items):
+            if not isinstance(item, str):
+                logger.error(
+                    "{} post-check list item not string field={} index={}",
+                    _LOG_PREFIX,
+                    field_name,
+                    index,
+                )
+                raise ProfileIntelligenceValidationError(
+                    f"AI profile intelligence field {field_name!r} items must be strings",
+                    validation_code="invalid_list_item",
+                )
+            if clean_str(item) == "":
+                logger.error(
+                    "{} post-check empty list item field={} index={}",
+                    _LOG_PREFIX,
+                    field_name,
+                    index,
+                )
+                raise ProfileIntelligenceValidationError(
+                    f"AI profile intelligence field {field_name!r} "
+                    f"contains an empty list item",
+                    validation_code="empty_list_item",
+                )
+
+
+def is_unknown_scalar(value: str) -> bool:
+    """Return True when a scalar uses the sparse-profile sentinel."""
+    return clean_str(value) == UNKNOWN_SENTINEL

--- a/backend/services/integrations/linkedin/profile_repository.py
+++ b/backend/services/integrations/linkedin/profile_repository.py
@@ -1,0 +1,1143 @@
+"""
+LinkedIn analysis context repository — Phase 1 persistence (SQLite).
+
+Stores normalized profile snapshots in ``linkedin_analysis_context`` per user,
+co-located with ``linkedin_oauth_tokens`` in the per-user SQLite database.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from datetime import datetime, timedelta
+from typing import Any, Optional
+
+from loguru import logger
+
+from services.integrations.linkedin_oauth import LinkedInOAuthService
+
+
+def compute_profile_content_hash(profile: dict[str, Any]) -> str:
+    """Return SHA-256 hex digest of canonical normalized profile JSON."""
+    canonical = json.dumps(profile, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+_INTELLIGENCE_HASH_FIELDS: tuple[str, ...] = (
+    "professional_identity",
+    "primary_expertise",
+    "industry",
+    "experience_level",
+    "knowledge_domains",
+    "writing_opportunities",
+    "target_audience",
+    "communication_style",
+    "brand_positioning",
+    "summary",
+)
+
+
+def compute_ai_intelligence_hash(intelligence: dict[str, Any]) -> str:
+    """
+    Return SHA-256 hex digest of canonical ``AIProfileIntelligence`` JSON.
+
+    Strips server ``meta`` and hashes only LLM intelligence fields (Phase 6 cache key).
+    """
+    if not isinstance(intelligence, dict):
+        logger.error(
+            "[TopicRecommendation] compute_ai_intelligence_hash invalid type={}",
+            type(intelligence).__name__,
+        )
+        raise TypeError("AI profile intelligence must be a dict")
+
+    payload = {
+        key: intelligence[key]
+        for key in _INTELLIGENCE_HASH_FIELDS
+        if key in intelligence
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    logger.debug(
+        "[TopicRecommendation] compute_ai_intelligence_hash hash={} bytes={} fields={}",
+        digest[:12],
+        len(canonical),
+        len(payload),
+    )
+    return digest
+
+
+def compute_profile_context_hash(context: dict[str, Any]) -> str:
+    """
+    Return SHA-256 hex digest of canonical ``LinkedInProfileContext`` JSON.
+
+    Used by Phase 5 to detect when AI profile intelligence must be regenerated
+    (e.g. after Phase 4 patches context without changing Phase 1 hash).
+    """
+    if not isinstance(context, dict):
+        logger.error(
+            "[ProfileIntelligence] compute_profile_context_hash invalid type={}",
+            type(context).__name__,
+        )
+        raise TypeError("profile context must be a dict")
+    canonical = json.dumps(context, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    logger.debug(
+        "[ProfileIntelligence] compute_profile_context_hash hash={} bytes={}",
+        digest[:12],
+        len(canonical),
+    )
+    return digest
+
+
+class ProfileRepository:
+    """Read/write ``linkedin_analysis_context`` rows for a single user."""
+
+    _ROW_COLUMNS: tuple[str, ...] = (
+        "id",
+        "user_id",
+        "unipile_account_id",
+        "normalized_profile_json",
+        "raw_userprofile_json",
+        "profile_content_hash",
+        "fetched_at",
+        "profile_context_json",
+        "profile_validation_json",
+        "user_completion_json",
+        "ai_profile_intelligence_json",
+        "topic_recommendations_json",
+        "profile_context_updated_at",
+        "ai_intelligence_updated_at",
+        "recommendations_updated_at",
+        "created_at",
+        "updated_at",
+    )
+
+    def __init__(
+        self,
+        db_path: Optional[str] = None,
+        oauth: Optional[LinkedInOAuthService] = None,
+    ) -> None:
+        self._oauth = oauth or LinkedInOAuthService(db_path=db_path)
+
+    def _ensure_db(self, user_id: str) -> str:
+        """Ensure OAuth + analysis tables exist; return SQLite path."""
+        self._oauth._init_db(user_id)
+        return self._oauth._get_db_path(user_id)
+
+    def _row_to_dict(self, row: tuple[Any, ...]) -> dict[str, Any]:
+        return dict(zip(self._ROW_COLUMNS, row))
+
+    def get_analysis_row(self, user_id: str) -> Optional[dict[str, Any]]:
+        """
+        Load the full analysis row for ``user_id``, or ``None`` when absent.
+
+        Args:
+            user_id: ALwrity user ID (Clerk)
+
+        Returns:
+            Row dict with all ``linkedin_analysis_context`` columns, or ``None``
+        """
+        logger.info("[LinkedInProfile] ProfileRepository.get_analysis_row user_id={}", user_id)
+        db_path = self._ensure_db(user_id)
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT
+                    id, user_id, unipile_account_id,
+                    normalized_profile_json, raw_userprofile_json,
+                    profile_content_hash, fetched_at,
+                    profile_context_json, profile_validation_json,
+                    user_completion_json, ai_profile_intelligence_json,
+                    topic_recommendations_json,
+                    profile_context_updated_at, ai_intelligence_updated_at,
+                    recommendations_updated_at,
+                    created_at, updated_at
+                FROM linkedin_analysis_context
+                WHERE user_id = ?
+                """,
+                (user_id,),
+            )
+            row = cursor.fetchone()
+        if not row:
+            logger.info(
+                "[LinkedInProfile] ProfileRepository.get_analysis_row no row user_id={}",
+                user_id,
+            )
+            return None
+        return self._row_to_dict(row)
+
+    def get_normalized_profile(
+        self,
+        user_id: str,
+        *,
+        row: Optional[dict[str, Any]] = None,
+    ) -> Optional[dict[str, Any]]:
+        """
+        Read cached normalized profile JSON for ``user_id``.
+
+        Args:
+            user_id: ALwrity user ID
+            row: Optional pre-loaded analysis row to avoid a second DB read
+
+        Returns:
+            Parsed normalized profile dict, or ``None`` when not stored
+        """
+        if row is None:
+            row = self.get_analysis_row(user_id)
+        if not row:
+            return None
+        raw_json = row.get("normalized_profile_json")
+        if not raw_json:
+            return None
+        try:
+            parsed = json.loads(raw_json)
+        except json.JSONDecodeError:
+            logger.error(
+                "[LinkedInProfile] Invalid normalized_profile_json for user_id={}",
+                user_id,
+            )
+            return None
+        if not isinstance(parsed, dict):
+            logger.error(
+                "[LinkedInProfile] normalized_profile_json is not an object user_id={}",
+                user_id,
+            )
+            return None
+        return parsed
+
+    def get_profile_context(
+        self,
+        user_id: str,
+        *,
+        row: Optional[dict[str, Any]] = None,
+    ) -> Optional[dict[str, Any]]:
+        """
+        Read cached profile context JSON for ``user_id``.
+
+        Args:
+            user_id: ALwrity user ID
+            row: Optional pre-loaded analysis row to avoid a second DB read
+
+        Returns:
+            Parsed ``LinkedInProfileContext`` dict, or ``None`` when not stored/invalid
+        """
+        logger.info(
+            "[LinkedInProfileContext] ProfileRepository.get_profile_context user_id={}",
+            user_id,
+        )
+        if row is None:
+            row = self.get_analysis_row(user_id)
+        if not row:
+            logger.info(
+                "[LinkedInProfileContext] ProfileRepository.get_profile_context "
+                "no row user_id={}",
+                user_id,
+            )
+            return None
+        raw_json = row.get("profile_context_json")
+        if not raw_json:
+            logger.info(
+                "[LinkedInProfileContext] ProfileRepository.get_profile_context "
+                "empty profile_context_json user_id={}",
+                user_id,
+            )
+            return None
+        try:
+            parsed = json.loads(raw_json)
+        except json.JSONDecodeError:
+            logger.error(
+                "[LinkedInProfileContext] Invalid profile_context_json user_id={}",
+                user_id,
+            )
+            return None
+        if not isinstance(parsed, dict):
+            logger.error(
+                "[LinkedInProfileContext] profile_context_json is not an object "
+                "user_id={}",
+                user_id,
+            )
+            return None
+        logger.info(
+            "[LinkedInProfileContext] ProfileRepository.get_profile_context hit "
+            "user_id={}",
+            user_id,
+        )
+        return parsed
+
+    def save_profile_context(
+        self,
+        user_id: str,
+        context: dict[str, Any],
+        *,
+        content_hash: Optional[str] = None,
+    ) -> str:
+        """
+        Persist Phase 2 profile context JSON and ``profile_context_updated_at``.
+
+        Does not modify ``normalized_profile_json`` or other Phase 1 columns.
+        Requires an existing ``linkedin_analysis_context`` row (from Phase 1 acquire).
+
+        Args:
+            user_id: ALwrity user ID
+            context: Built ``LinkedInProfileContext`` dict
+            content_hash: Optional Phase 1 hash to stamp in ``meta`` before save
+
+        Returns:
+            ISO timestamp written to ``profile_context_updated_at``
+
+        Raises:
+            ValueError: When no analysis row exists for ``user_id``
+        """
+        logger.info(
+            "[LinkedInProfileContext] ProfileRepository.save_profile_context user_id={}",
+            user_id,
+        )
+        if not isinstance(context, dict):
+            raise ValueError("profile context must be a dict")
+
+        context_to_save = context
+        if content_hash is not None:
+            context_to_save = json.loads(
+                json.dumps(context, separators=(",", ":"), default=str)
+            )
+            meta = context_to_save.get("meta")
+            if not isinstance(meta, dict):
+                meta = {}
+                context_to_save["meta"] = meta
+            meta["built_from_profile_content_hash"] = content_hash
+
+        context_json = json.dumps(context_to_save, separators=(",", ":"), default=str)
+        now = datetime.utcnow().isoformat()
+        db_path = self._ensure_db(user_id)
+
+        existing = self.get_analysis_row(user_id)
+        if not existing:
+            logger.error(
+                "[LinkedInProfileContext] save_profile_context no analysis row "
+                "user_id={}",
+                user_id,
+            )
+            raise ValueError(
+                f"No linkedin_analysis_context row for user_id={user_id!r}; "
+                "acquire normalized profile first"
+            )
+
+        normalized_before = existing.get("normalized_profile_json")
+
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                UPDATE linkedin_analysis_context
+                SET profile_context_json = ?,
+                    profile_context_updated_at = ?,
+                    updated_at = ?
+                WHERE user_id = ?
+                """,
+                (context_json, now, now, user_id),
+            )
+            conn.commit()
+
+        row_after = self.get_analysis_row(user_id)
+        if row_after and row_after.get("normalized_profile_json") != normalized_before:
+            logger.warning(
+                "[LinkedInProfileContext] normalized_profile_json changed unexpectedly "
+                "during save_profile_context user_id={}",
+                user_id,
+            )
+
+        logger.info(
+            "[LinkedInProfileContext] ProfileRepository.save_profile_context complete "
+            "user_id={} profile_context_updated_at={}",
+            user_id,
+            now,
+        )
+        return now
+
+    def get_profile_validation(
+        self,
+        user_id: str,
+        *,
+        row: Optional[dict[str, Any]] = None,
+    ) -> Optional[dict[str, Any]]:
+        """
+        Read cached profile validation JSON for ``user_id``.
+
+        Args:
+            user_id: ALwrity user ID
+            row: Optional pre-loaded analysis row to avoid a second DB read
+
+        Returns:
+            Parsed Phase 3 validation result dict, or ``None`` when not stored/invalid
+        """
+        logger.info(
+            "[ProfileValidation] ProfileRepository.get_profile_validation user_id={}",
+            user_id,
+        )
+        if row is None:
+            row = self.get_analysis_row(user_id)
+        if not row:
+            logger.info(
+                "[ProfileValidation] ProfileRepository.get_profile_validation "
+                "no row user_id={}",
+                user_id,
+            )
+            return None
+        raw_json = row.get("profile_validation_json")
+        if not raw_json:
+            logger.info(
+                "[ProfileValidation] ProfileRepository.get_profile_validation "
+                "empty profile_validation_json user_id={}",
+                user_id,
+            )
+            return None
+        try:
+            parsed = json.loads(raw_json)
+        except json.JSONDecodeError:
+            logger.error(
+                "[ProfileValidation] Invalid profile_validation_json user_id={}",
+                user_id,
+            )
+            return None
+        if not isinstance(parsed, dict):
+            logger.error(
+                "[ProfileValidation] profile_validation_json is not an object "
+                "user_id={}",
+                user_id,
+            )
+            return None
+        logger.info(
+            "[ProfileValidation] ProfileRepository.get_profile_validation hit "
+            "user_id={}",
+            user_id,
+        )
+        return parsed
+
+    def save_profile_validation(
+        self,
+        user_id: str,
+        validation: dict[str, Any],
+    ) -> str:
+        """
+        Persist Phase 3 profile validation JSON.
+
+        Does not modify ``profile_context_json`` or Phase 1 columns.
+        Requires an existing ``linkedin_analysis_context`` row.
+
+        Args:
+            user_id: ALwrity user ID
+            validation: Phase 3 validation result dict
+
+        Returns:
+            ISO timestamp written to ``updated_at``
+
+        Raises:
+            ValueError: When no analysis row exists or validation is not a dict
+        """
+        logger.info(
+            "[ProfileValidation] ProfileRepository.save_profile_validation user_id={}",
+            user_id,
+        )
+        if not isinstance(validation, dict):
+            raise ValueError("profile validation must be a dict")
+
+        validation_json = json.dumps(validation, separators=(",", ":"), default=str)
+        now = datetime.utcnow().isoformat()
+        db_path = self._ensure_db(user_id)
+
+        existing = self.get_analysis_row(user_id)
+        if not existing:
+            logger.error(
+                "[ProfileValidation] save_profile_validation no analysis row "
+                "user_id={}",
+                user_id,
+            )
+            raise ValueError(
+                f"No linkedin_analysis_context row for user_id={user_id!r}; "
+                "acquire normalized profile first"
+            )
+
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                UPDATE linkedin_analysis_context
+                SET profile_validation_json = ?,
+                    updated_at = ?
+                WHERE user_id = ?
+                """,
+                (validation_json, now, user_id),
+            )
+            conn.commit()
+
+        logger.info(
+            "[ProfileValidation] ProfileRepository.save_profile_validation complete "
+            "user_id={} updated_at={}",
+            user_id,
+            now,
+        )
+        return now
+
+    def get_user_completion(
+        self,
+        user_id: str,
+        *,
+        row: Optional[dict[str, Any]] = None,
+    ) -> Optional[dict[str, Any]]:
+        """
+        Read cached user completion answers for ``user_id``.
+
+        Args:
+            user_id: ALwrity user ID
+            row: Optional pre-loaded analysis row to avoid a second DB read
+
+        Returns:
+            Parsed user completion dict keyed by field, or ``None`` when absent/invalid
+        """
+        logger.info(
+            "[ProfileCompletion] ProfileRepository.get_user_completion user_id={}",
+            user_id,
+        )
+        if row is None:
+            row = self.get_analysis_row(user_id)
+        if not row:
+            logger.info(
+                "[ProfileCompletion] ProfileRepository.get_user_completion "
+                "no row user_id={}",
+                user_id,
+            )
+            return None
+        raw_json = row.get("user_completion_json")
+        if not raw_json:
+            logger.info(
+                "[ProfileCompletion] ProfileRepository.get_user_completion "
+                "empty user_completion_json user_id={}",
+                user_id,
+            )
+            return None
+        try:
+            parsed = json.loads(raw_json)
+        except json.JSONDecodeError:
+            logger.error(
+                "[ProfileCompletion] Invalid user_completion_json user_id={}",
+                user_id,
+            )
+            return None
+        if not isinstance(parsed, dict):
+            logger.error(
+                "[ProfileCompletion] user_completion_json is not an object "
+                "user_id={}",
+                user_id,
+            )
+            return None
+        logger.info(
+            "[ProfileCompletion] ProfileRepository.get_user_completion hit "
+            "user_id={} field_count={}",
+            user_id,
+            len(parsed),
+        )
+        return parsed
+
+    def save_user_completion(
+        self,
+        user_id: str,
+        answers: dict[str, Any],
+    ) -> dict[str, Any]:
+        """
+        Merge user completion answers into ``user_completion_json``.
+
+        New keys are added; existing keys are overwritten by the latest submit.
+
+        Args:
+            user_id: ALwrity user ID
+            answers: Field-keyed answers from a completion submit
+
+        Returns:
+            Merged completion dict after persist
+
+        Raises:
+            ValueError: When no analysis row exists or answers is not a dict
+        """
+        logger.info(
+            "[ProfileCompletion] ProfileRepository.save_user_completion user_id={} "
+            "answer_keys={}",
+            user_id,
+            sorted(answers.keys()) if isinstance(answers, dict) else None,
+        )
+        if not isinstance(answers, dict):
+            raise ValueError("user completion answers must be a dict")
+
+        existing = self.get_analysis_row(user_id)
+        if not existing:
+            logger.error(
+                "[ProfileCompletion] save_user_completion no analysis row "
+                "user_id={}",
+                user_id,
+            )
+            raise ValueError(
+                f"No linkedin_analysis_context row for user_id={user_id!r}; "
+                "acquire normalized profile first"
+            )
+
+        merged: dict[str, Any] = {}
+        current = self.get_user_completion(user_id, row=existing)
+        if current:
+            merged.update(current)
+        merged.update(answers)
+
+        completion_json = json.dumps(merged, separators=(",", ":"), default=str)
+        now = datetime.utcnow().isoformat()
+        db_path = self._ensure_db(user_id)
+
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                UPDATE linkedin_analysis_context
+                SET user_completion_json = ?,
+                    updated_at = ?
+                WHERE user_id = ?
+                """,
+                (completion_json, now, user_id),
+            )
+            conn.commit()
+
+        logger.info(
+            "[ProfileCompletion] ProfileRepository.save_user_completion complete "
+            "user_id={} field_count={}",
+            user_id,
+            len(merged),
+        )
+        return merged
+
+    def get_ai_profile_intelligence(
+        self,
+        user_id: str,
+        *,
+        row: Optional[dict[str, Any]] = None,
+    ) -> Optional[dict[str, Any]]:
+        """
+        Read cached AI profile intelligence JSON for ``user_id``.
+
+        Args:
+            user_id: ALwrity user ID
+            row: Optional pre-loaded analysis row to avoid a second DB read
+
+        Returns:
+            Parsed Phase 5 intelligence dict, or ``None`` when not stored/invalid
+        """
+        logger.info(
+            "[ProfileIntelligence] ProfileRepository.get_ai_profile_intelligence "
+            "user_id={}",
+            user_id,
+        )
+        if row is None:
+            row = self.get_analysis_row(user_id)
+        if not row:
+            logger.info(
+                "[ProfileIntelligence] ProfileRepository.get_ai_profile_intelligence "
+                "no row user_id={}",
+                user_id,
+            )
+            return None
+        raw_json = row.get("ai_profile_intelligence_json")
+        if not raw_json:
+            logger.info(
+                "[ProfileIntelligence] ProfileRepository.get_ai_profile_intelligence "
+                "empty ai_profile_intelligence_json user_id={}",
+                user_id,
+            )
+            return None
+        try:
+            parsed = json.loads(raw_json)
+        except json.JSONDecodeError as exc:
+            logger.exception(
+                "[ProfileIntelligence] Invalid ai_profile_intelligence_json "
+                "user_id={}: {}",
+                user_id,
+                exc,
+            )
+            return None
+        if not isinstance(parsed, dict):
+            logger.error(
+                "[ProfileIntelligence] ai_profile_intelligence_json is not an object "
+                "user_id={}",
+                user_id,
+            )
+            return None
+        logger.info(
+            "[ProfileIntelligence] ProfileRepository.get_ai_profile_intelligence hit "
+            "user_id={}",
+            user_id,
+        )
+        return parsed
+
+    def save_ai_profile_intelligence(
+        self,
+        user_id: str,
+        intelligence: dict[str, Any],
+        *,
+        context_hash: Optional[str] = None,
+    ) -> str:
+        """
+        Persist Phase 5 AI profile intelligence JSON and ``ai_intelligence_updated_at``.
+
+        Does not modify ``profile_context_json`` or upstream columns.
+        Requires an existing ``linkedin_analysis_context`` row.
+
+        Args:
+            user_id: ALwrity user ID
+            intelligence: Validated AI profile intelligence dict
+            context_hash: Optional profile context hash to stamp in ``meta``
+
+        Returns:
+            ISO timestamp written to ``ai_intelligence_updated_at``
+
+        Raises:
+            ValueError: When no analysis row exists or intelligence is not a dict
+        """
+        logger.info(
+            "[ProfileIntelligence] ProfileRepository.save_ai_profile_intelligence "
+            "user_id={}",
+            user_id,
+        )
+        if not isinstance(intelligence, dict):
+            raise ValueError("AI profile intelligence must be a dict")
+
+        intelligence_to_save = intelligence
+        if context_hash is not None:
+            intelligence_to_save = json.loads(
+                json.dumps(intelligence, separators=(",", ":"), default=str)
+            )
+            meta = intelligence_to_save.get("meta")
+            if not isinstance(meta, dict):
+                meta = {}
+                intelligence_to_save["meta"] = meta
+            meta["built_from_profile_context_hash"] = context_hash
+
+        intelligence_json = json.dumps(
+            intelligence_to_save,
+            separators=(",", ":"),
+            default=str,
+        )
+        now = datetime.utcnow().isoformat()
+        db_path = self._ensure_db(user_id)
+
+        existing = self.get_analysis_row(user_id)
+        if not existing:
+            logger.error(
+                "[ProfileIntelligence] save_ai_profile_intelligence no analysis row "
+                "user_id={}",
+                user_id,
+            )
+            raise ValueError(
+                f"No linkedin_analysis_context row for user_id={user_id!r}; "
+                "acquire normalized profile first"
+            )
+
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(
+                    """
+                    UPDATE linkedin_analysis_context
+                    SET ai_profile_intelligence_json = ?,
+                        ai_intelligence_updated_at = ?,
+                        updated_at = ?
+                    WHERE user_id = ?
+                    """,
+                    (intelligence_json, now, now, user_id),
+                )
+                conn.commit()
+            except sqlite3.Error as exc:
+                logger.exception(
+                    "[ProfileIntelligence] save_ai_profile_intelligence db error "
+                    "user_id={}: {}",
+                    user_id,
+                    exc,
+                )
+                raise ValueError(
+                    "Failed to persist AI profile intelligence"
+                ) from exc
+
+        logger.info(
+            "[ProfileIntelligence] ProfileRepository.save_ai_profile_intelligence "
+            "complete user_id={} ai_intelligence_updated_at={} context_hash={}",
+            user_id,
+            now,
+            context_hash[:12] if context_hash else None,
+        )
+        self._clear_topic_recommendations(user_id, db_path=db_path, updated_at=now)
+        return now
+
+    def get_topic_recommendations(
+        self,
+        user_id: str,
+        *,
+        row: Optional[dict[str, Any]] = None,
+    ) -> Optional[dict[str, Any]]:
+        """
+        Read cached topic recommendations JSON for ``user_id``.
+
+        Args:
+            user_id: ALwrity user ID
+            row: Optional pre-loaded analysis row to avoid a second DB read
+
+        Returns:
+            Parsed Phase 6 recommendations dict, or ``None`` when not stored/invalid
+        """
+        logger.info(
+            "[TopicRecommendation] ProfileRepository.get_topic_recommendations user_id={}",
+            user_id,
+        )
+        if row is None:
+            row = self.get_analysis_row(user_id)
+        if not row:
+            logger.info(
+                "[TopicRecommendation] ProfileRepository.get_topic_recommendations "
+                "no row user_id={}",
+                user_id,
+            )
+            return None
+        raw_json = row.get("topic_recommendations_json")
+        if not raw_json:
+            logger.info(
+                "[TopicRecommendation] ProfileRepository.get_topic_recommendations "
+                "empty topic_recommendations_json user_id={}",
+                user_id,
+            )
+            return None
+        try:
+            parsed = json.loads(raw_json)
+        except json.JSONDecodeError as exc:
+            logger.exception(
+                "[TopicRecommendation] Invalid topic_recommendations_json user_id={}: {}",
+                user_id,
+                exc,
+            )
+            return None
+        if not isinstance(parsed, dict):
+            logger.error(
+                "[TopicRecommendation] topic_recommendations_json is not an object user_id={}",
+                user_id,
+            )
+            return None
+        logger.info(
+            "[TopicRecommendation] ProfileRepository.get_topic_recommendations hit user_id={}",
+            user_id,
+        )
+        return parsed
+
+    def save_topic_recommendations(
+        self,
+        user_id: str,
+        recommendations: dict[str, Any],
+        *,
+        intelligence_hash: Optional[str] = None,
+    ) -> str:
+        """
+        Persist Phase 6 topic recommendations JSON and ``recommendations_updated_at``.
+
+        Requires an existing ``linkedin_analysis_context`` row.
+
+        Args:
+            user_id: ALwrity user ID
+            recommendations: Validated stored recommendations dict
+            intelligence_hash: Optional intelligence hash to stamp in ``meta``
+
+        Returns:
+            ISO timestamp written to ``recommendations_updated_at``
+
+        Raises:
+            ValueError: When no analysis row exists or recommendations is not a dict
+        """
+        logger.info(
+            "[TopicRecommendation] ProfileRepository.save_topic_recommendations user_id={}",
+            user_id,
+        )
+        if not isinstance(recommendations, dict):
+            raise ValueError("Topic recommendations must be a dict")
+
+        recommendations_to_save = recommendations
+        if intelligence_hash is not None:
+            recommendations_to_save = json.loads(
+                json.dumps(recommendations, separators=(",", ":"), default=str)
+            )
+            meta = recommendations_to_save.get("meta")
+            if not isinstance(meta, dict):
+                meta = {}
+                recommendations_to_save["meta"] = meta
+            meta["built_from_intelligence_hash"] = intelligence_hash
+
+        recommendations_json = json.dumps(
+            recommendations_to_save,
+            separators=(",", ":"),
+            default=str,
+        )
+        now = datetime.utcnow().isoformat()
+        db_path = self._ensure_db(user_id)
+
+        existing = self.get_analysis_row(user_id)
+        if not existing:
+            logger.error(
+                "[TopicRecommendation] save_topic_recommendations no analysis row user_id={}",
+                user_id,
+            )
+            raise ValueError(
+                f"No linkedin_analysis_context row for user_id={user_id!r}; "
+                "acquire normalized profile first"
+            )
+
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(
+                    """
+                    UPDATE linkedin_analysis_context
+                    SET topic_recommendations_json = ?,
+                        recommendations_updated_at = ?,
+                        updated_at = ?
+                    WHERE user_id = ?
+                    """,
+                    (recommendations_json, now, now, user_id),
+                )
+                conn.commit()
+            except sqlite3.Error as exc:
+                logger.exception(
+                    "[TopicRecommendation] save_topic_recommendations db error user_id={}: {}",
+                    user_id,
+                    exc,
+                )
+                raise ValueError("Failed to persist topic recommendations") from exc
+
+        logger.info(
+            "[TopicRecommendation] ProfileRepository.save_topic_recommendations "
+            "complete user_id={} recommendations_updated_at={} intelligence_hash={}",
+            user_id,
+            now,
+            intelligence_hash[:12] if intelligence_hash else None,
+        )
+        return now
+
+    def _clear_topic_recommendations(
+        self,
+        user_id: str,
+        *,
+        db_path: str,
+        updated_at: str,
+    ) -> None:
+        """Clear Phase 6 recommendations when upstream intelligence changes."""
+        logger.info(
+            "[TopicRecommendation] ProfileRepository._clear_topic_recommendations user_id={}",
+            user_id,
+        )
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                UPDATE linkedin_analysis_context
+                SET topic_recommendations_json = NULL,
+                    recommendations_updated_at = NULL,
+                    updated_at = ?
+                WHERE user_id = ?
+                """,
+                (updated_at, user_id),
+            )
+            conn.commit()
+        logger.info(
+            "[TopicRecommendation] ProfileRepository._clear_topic_recommendations complete "
+            "user_id={}",
+            user_id,
+        )
+
+    def has_fresh_profile(
+        self,
+        user_id: str,
+        *,
+        max_age_hours: int = 168,
+    ) -> bool:
+        """
+        Return True when a cached profile exists and ``fetched_at`` is within TTL.
+
+        Args:
+            user_id: ALwrity user ID
+            max_age_hours: Maximum cache age in hours (default 7 days)
+
+        Returns:
+            True when cached profile is present and not expired
+        """
+        row = self.get_analysis_row(user_id)
+        if not row or not row.get("normalized_profile_json") or not row.get("fetched_at"):
+            return False
+        fetched_at = row["fetched_at"]
+        try:
+            if isinstance(fetched_at, str):
+                fetched_dt = datetime.fromisoformat(fetched_at.replace("Z", "+00:00"))
+            else:
+                fetched_dt = fetched_at
+            if fetched_dt.tzinfo is not None:
+                fetched_dt = fetched_dt.replace(tzinfo=None)
+            age = datetime.utcnow() - fetched_dt
+            fresh = age <= timedelta(hours=max_age_hours)
+            logger.info(
+                "[LinkedInProfile] has_fresh_profile user_id={} fresh={} age_hours={:.1f}",
+                user_id,
+                fresh,
+                age.total_seconds() / 3600,
+            )
+            return fresh
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "[LinkedInProfile] has_fresh_profile parse error user_id={}: {}",
+                user_id,
+                exc,
+            )
+            return False
+
+    def invalidate_downstream(self, user_id: str) -> None:
+        """
+        Clear Phase 2/3/4/5 derived columns when normalized profile hash changes.
+
+        Args:
+            user_id: ALwrity user ID
+        """
+        logger.info(
+            "[LinkedInProfile] ProfileRepository.invalidate_downstream user_id={}",
+            user_id,
+        )
+        db_path = self._ensure_db(user_id)
+        now = datetime.utcnow().isoformat()
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                UPDATE linkedin_analysis_context
+                SET profile_context_json = NULL,
+                    profile_validation_json = NULL,
+                    user_completion_json = NULL,
+                    ai_profile_intelligence_json = NULL,
+                    topic_recommendations_json = NULL,
+                    profile_context_updated_at = NULL,
+                    ai_intelligence_updated_at = NULL,
+                    recommendations_updated_at = NULL,
+                    updated_at = ?
+                WHERE user_id = ?
+                """,
+                (now, user_id),
+            )
+            conn.commit()
+        logger.info(
+            "[LinkedInProfile] ProfileRepository.invalidate_downstream complete user_id={}",
+            user_id,
+        )
+
+    def save_normalized_profile(
+        self,
+        user_id: str,
+        unipile_account_id: str,
+        profile: dict[str, Any],
+        *,
+        raw: Optional[dict[str, Any]] = None,
+    ) -> str:
+        """
+        Upsert Phase 1 normalized profile snapshot with hash and ``fetched_at``.
+
+        When ``profile_content_hash`` changes, derived downstream columns are cleared.
+
+        Args:
+            user_id: ALwrity user ID
+            unipile_account_id: Connected Unipile account ID
+            profile: Normalized ALwrity profile dict
+            raw: Optional raw Unipile UserProfile (stored internally only)
+
+        Returns:
+            New ``profile_content_hash`` value
+        """
+        logger.info(
+            "[LinkedInProfile] ProfileRepository.save_normalized_profile user_id={} "
+            "unipile_account_id={}",
+            user_id,
+            unipile_account_id,
+        )
+        db_path = self._ensure_db(user_id)
+        profile_json = json.dumps(profile, separators=(",", ":"), default=str)
+        raw_json = json.dumps(raw, separators=(",", ":"), default=str) if raw else None
+        content_hash = compute_profile_content_hash(profile)
+        now = datetime.utcnow().isoformat()
+
+        existing = self.get_analysis_row(user_id)
+        hash_changed = bool(
+            existing
+            and existing.get("profile_content_hash")
+            and existing["profile_content_hash"] != content_hash
+        )
+
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            if existing:
+                cursor.execute(
+                    """
+                    UPDATE linkedin_analysis_context
+                    SET unipile_account_id = ?,
+                        normalized_profile_json = ?,
+                        raw_userprofile_json = ?,
+                        profile_content_hash = ?,
+                        fetched_at = ?,
+                        updated_at = ?
+                    WHERE user_id = ?
+                    """,
+                    (
+                        unipile_account_id,
+                        profile_json,
+                        raw_json,
+                        content_hash,
+                        now,
+                        now,
+                        user_id,
+                    ),
+                )
+            else:
+                cursor.execute(
+                    """
+                    INSERT INTO linkedin_analysis_context (
+                        user_id,
+                        unipile_account_id,
+                        normalized_profile_json,
+                        raw_userprofile_json,
+                        profile_content_hash,
+                        fetched_at,
+                        created_at,
+                        updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        user_id,
+                        unipile_account_id,
+                        profile_json,
+                        raw_json,
+                        content_hash,
+                        now,
+                        now,
+                        now,
+                    ),
+                )
+            conn.commit()
+
+        if hash_changed:
+            logger.info(
+                "[LinkedInProfile] profile_content_hash changed — invalidating downstream "
+                "user_id={}",
+                user_id,
+            )
+            self.invalidate_downstream(user_id)
+
+        logger.info(
+            "[LinkedInProfile] ProfileRepository.save_normalized_profile complete "
+            "user_id={} hash={} hash_changed={}",
+            user_id,
+            content_hash[:12],
+            hash_changed,
+        )
+        return content_hash

--- a/backend/services/integrations/linkedin/profile_service.py
+++ b/backend/services/integrations/linkedin/profile_service.py
@@ -1,0 +1,674 @@
+"""
+LinkedIn profile acquisition service — Phase 1 (fetch + normalize + cache).
+
+Maps Unipile AccountOwnerProfile / UserProfile payloads to ALwrity's normalized
+profile shape for Phases 2–6. Orchestrates cache-first acquire via ProfileRepository.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, TypedDict
+
+from loguru import logger
+
+from services.integrations.linkedin.field_coercion import (
+    clean_str as _clean_str,
+    coerce_bool as _coerce_bool,
+    coerce_int as _coerce_int,
+    coerce_list as _coerce_list,
+)
+# Backward compatibility: ``_clean_str`` / ``_coerce_*`` were historically defined in
+# this module. They remain importable here; new code should use ``field_coercion`` directly.
+from services.integrations.linkedin.profile_repository import ProfileRepository
+from services.integrations.linkedin.types import LinkedInNotConnectedError
+from services.integrations.linkedin.unipile_client import avatar_url_from_user_profile
+from services.integrations.linkedin.unipile_provider import (
+    UnipileProvider,
+    unipile_display_name_from_item,
+)
+from services.integrations.linkedin_oauth import LinkedInOAuthService
+
+
+class ProfileMeta(TypedDict):
+    """Metadata returned alongside a normalized profile."""
+
+    source: str
+    fetched_at: Optional[str]
+    profile_content_hash: Optional[str]
+
+
+async def fetch_linkedin_profile(
+    user_id: str,
+    *,
+    provider: Optional[UnipileProvider] = None,
+    linkedin_sections: str = "*",
+) -> dict[str, Any]:
+    """
+    Fetch raw Unipile UserProfile for the connected user (no cache, no normalize).
+
+    Args:
+        user_id: ALwrity user ID (Clerk)
+        provider: Optional UnipileProvider instance (for testing)
+        linkedin_sections: Unipile sections query for step 2
+
+    Returns:
+        Raw Unipile UserProfile dictionary
+    """
+    logger.info("[LinkedInProfile] fetch_linkedin_profile user_id={}", user_id)
+    unipile = provider or UnipileProvider()
+    raw = await unipile.fetch_own_linkedin_profile(
+        user_id,
+        linkedin_sections=linkedin_sections,
+    )
+    if not isinstance(raw, dict):
+        raise TypeError(f"Expected dict UserProfile, got {type(raw).__name__}")
+    logger.info(
+        "[LinkedInProfile] UserProfile fetched is_self={} "
+        "work_experience_total_count={} skills_total_count={}",
+        raw.get("is_self"),
+        raw.get("work_experience_total_count"),
+        raw.get("skills_total_count"),
+    )
+    return raw
+
+
+async def get_or_fetch_profile(
+    user_id: str,
+    *,
+    refresh: bool = False,
+    provider: Optional[UnipileProvider] = None,
+    repository: Optional[ProfileRepository] = None,
+    oauth: Optional[LinkedInOAuthService] = None,
+    linkedin_sections: str = "*",
+) -> tuple[dict[str, Any], ProfileMeta]:
+    """
+    Cache-first orchestrator: return normalized profile and acquisition metadata.
+
+    Cache hit (no Unipile HTTP) when a row exists, ``unipile_account_id`` matches,
+    and ``refresh`` is False. Otherwise fetches from Unipile, normalizes, and persists.
+
+    Args:
+        user_id: ALwrity user ID (Clerk)
+        refresh: Force Unipile fetch and DB update
+        provider: Optional UnipileProvider (for testing)
+        repository: Optional ProfileRepository (for testing)
+        oauth: Optional LinkedInOAuthService (for testing)
+        linkedin_sections: Unipile sections query for step 2
+
+    Returns:
+        Tuple of (normalized profile dict, meta dict with source/cache fields)
+
+    Raises:
+        LinkedInNotConnectedError: When user has no connected Unipile account
+    """
+    logger.info(
+        "[LinkedInProfile] get_or_fetch_profile user_id={} refresh={}",
+        user_id,
+        refresh,
+    )
+    oauth_service = oauth or LinkedInOAuthService()
+    repo = repository or ProfileRepository(oauth=oauth_service)
+    unipile = provider or UnipileProvider(oauth_service=oauth_service)
+
+    creds = oauth_service.resolve_credentials(user_id)
+    account_id = creds.unipile_account_id
+    if not account_id:
+        raise LinkedInNotConnectedError(
+            "No Unipile LinkedIn account connected. "
+            "Connect via hosted OAuth before fetching profile."
+        )
+
+    if not refresh:
+        row = repo.get_analysis_row(user_id)
+        cached = repo.get_normalized_profile(user_id, row=row) if row else None
+        if (
+            row
+            and cached
+            and row.get("unipile_account_id") == account_id
+            and row.get("normalized_profile_json")
+        ):
+            meta: ProfileMeta = {
+                "source": "cache",
+                "fetched_at": row.get("fetched_at"),
+                "profile_content_hash": row.get("profile_content_hash"),
+            }
+            logger.info(
+                "[LinkedInProfile] get_or_fetch_profile source=cache user_id={} "
+                "fetched_at={}",
+                user_id,
+                meta["fetched_at"],
+            )
+            return cached, meta
+
+        if row and row.get("unipile_account_id") != account_id:
+            logger.info(
+                "[LinkedInProfile] unipile_account_id changed — cache stale user_id={}",
+                user_id,
+            )
+
+    logger.info(
+        "[LinkedInProfile] Calling Unipile GET /users/me linkedin_sections={} "
+        "(step 2 only)",
+        linkedin_sections,
+    )
+    raw = await fetch_linkedin_profile(
+        user_id,
+        provider=unipile,
+        linkedin_sections=linkedin_sections,
+    )
+    normalized = normalize_unipile_profile(
+        raw,
+        stored_account_name=creds.account_name,
+    )
+    content_hash = repo.save_normalized_profile(
+        user_id,
+        account_id,
+        normalized,
+        raw=raw,
+    )
+    row = repo.get_analysis_row(user_id)
+    meta = {
+        "source": "unipile",
+        "fetched_at": row.get("fetched_at") if row else None,
+        "profile_content_hash": content_hash,
+    }
+    logger.info(
+        "[LinkedInProfile] get_or_fetch_profile source=unipile user_id={} "
+        "fetched_at={}",
+        user_id,
+        meta["fetched_at"],
+    )
+    return normalized, meta
+
+
+# Top-level keys on the Phase 1 normalized profile (API-safe output).
+NORMALIZED_PROFILE_KEYS: frozenset[str] = frozenset(
+    {
+        "first_name",
+        "last_name",
+        "name",
+        "headline",
+        "about",
+        "job_title",
+        "company",
+        "location",
+        "provider_id",
+        "public_identifier",
+        "member_urn",
+        "primary_locale",
+        "is_open_profile",
+        "is_premium",
+        "is_influencer",
+        "creator_mode",
+        "is_self",
+        "websites",
+        "hashtags",
+        "followers",
+        "connections",
+        "profile_url",
+        "profile_picture",
+        "background_picture",
+        "skills_total_count",
+        "skills",
+        "work_experience_total_count",
+        "experience",
+        "education_total_count",
+        "education",
+        "languages_total_count",
+        "languages",
+        "certifications_total_count",
+        "certifications",
+        "volunteering_experience_total_count",
+        "volunteering_experience",
+        "projects_total_count",
+        "projects",
+        "recommendations_given_count",
+        "recommendations_received_count",
+        "recommendations",
+    }
+)
+
+# Raw Unipile keys that must not appear on normalized output.
+FORBIDDEN_RAW_KEYS: frozenset[str] = frozenset(
+    {
+        "object",
+        "provider",
+        "summary",
+        "work_experience",
+        "follower_count",
+        "connections_count",
+        "profile_picture_url",
+        "profile_picture_url_large",
+        "background_picture_url",
+        "is_creator",
+        "entity_urn",
+        "object_urn",
+        "premium",
+        "open_profile",
+    }
+)
+
+
+def _normalize_primary_locale(raw: dict[str, Any]) -> dict[str, str]:
+    """Map Unipile primary_locale to ALwrity shape."""
+    locale = raw.get("primary_locale")
+    if not isinstance(locale, dict):
+        return {"country": "", "language": ""}
+    return {
+        "country": _clean_str(locale.get("country")),
+        "language": _clean_str(locale.get("language")),
+    }
+
+
+def _normalize_experience(raw: dict[str, Any]) -> tuple[list[dict[str, Any]], int]:
+    """Map work_experience[] to experience[] plus total count."""
+    items = _coerce_list(raw.get("work_experience"))
+    total = _coerce_int(raw.get("work_experience_total_count"), default=len(items))
+    experience: list[dict[str, Any]] = []
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        role_skills = _coerce_list(item.get("skills"))
+        normalized_skills = [
+            _clean_str(skill) if isinstance(skill, str) else _clean_str(skill.get("name"))
+            for skill in role_skills
+            if (isinstance(skill, str) and skill.strip())
+            or (isinstance(skill, dict) and _clean_str(skill.get("name")))
+        ]
+        end_value = item.get("end")
+        experience.append(
+            {
+                "title": _clean_str(item.get("position")),
+                "company": _clean_str(item.get("company")),
+                "company_id": _clean_str(item.get("company_id")),
+                "company_picture_url": _clean_str(item.get("company_picture_url")),
+                "start": _clean_str(item.get("start")),
+                "end": end_value if end_value is None else _clean_str(end_value),
+                "location": _clean_str(item.get("location")),
+                "description": _clean_str(item.get("description")),
+                "skills": normalized_skills,
+            }
+        )
+
+    if not total and experience:
+        total = len(experience)
+    return experience, total
+
+
+def _derive_current_role(
+    experience: list[dict[str, Any]],
+) -> tuple[str, str]:
+    """Return job_title and company from the first current role (end is null)."""
+    for role in experience:
+        if role.get("end") is None:
+            return _clean_str(role.get("title")), _clean_str(role.get("company"))
+    if experience:
+        first = experience[0]
+        return _clean_str(first.get("title")), _clean_str(first.get("company"))
+    return "", ""
+
+
+def _normalize_education(raw: dict[str, Any]) -> tuple[list[dict[str, Any]], int]:
+    """Map education[] plus total count."""
+    items = _coerce_list(raw.get("education"))
+    total = _coerce_int(raw.get("education_total_count"), default=len(items))
+    education: list[dict[str, Any]] = []
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        end_value = item.get("end")
+        start_value = item.get("start")
+        education.append(
+            {
+                "school": _clean_str(item.get("school")),
+                "school_id": _clean_str(item.get("school_id")),
+                "school_picture_url": _clean_str(item.get("school_picture_url")),
+                "degree": _clean_str(item.get("degree")),
+                "start": "" if start_value is None else _clean_str(start_value),
+                "end": "" if end_value is None else _clean_str(end_value),
+            }
+        )
+
+    if not total and education:
+        total = len(education)
+    return education, total
+
+
+def _normalize_skills(raw: dict[str, Any]) -> tuple[list[dict[str, Any]], int]:
+    """Map skills[] to {name, endorsement_count} entries."""
+    items = _coerce_list(raw.get("skills"))
+    total = _coerce_int(raw.get("skills_total_count"), default=len(items))
+    skills: list[dict[str, Any]] = []
+
+    for item in items:
+        if isinstance(item, str):
+            name = _clean_str(item)
+            if name:
+                skills.append({"name": name, "endorsement_count": 0})
+            continue
+        if not isinstance(item, dict):
+            continue
+        name = _clean_str(item.get("name"))
+        if not name:
+            continue
+        skills.append(
+            {
+                "name": name,
+                "endorsement_count": _coerce_int(item.get("endorsement_count")),
+            }
+        )
+
+    if not total and skills:
+        total = len(skills)
+    return skills, total
+
+
+def _normalize_languages(raw: dict[str, Any]) -> tuple[list[dict[str, Any]], int]:
+    """Map languages[] to {name, proficiency}."""
+    items = _coerce_list(raw.get("languages"))
+    total = _coerce_int(raw.get("languages_total_count"), default=len(items))
+    languages: list[dict[str, Any]] = []
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = _clean_str(item.get("name"))
+        if not name:
+            continue
+        languages.append(
+            {
+                "name": name,
+                "proficiency": _clean_str(item.get("proficiency")),
+            }
+        )
+
+    if not total and languages:
+        total = len(languages)
+    return languages, total
+
+
+def _normalize_object_list(raw: dict[str, Any], key: str, total_key: str) -> tuple[list[dict[str, Any]], int]:
+    """Pass through list-of-dict sections (certifications, projects, volunteering)."""
+    items = _coerce_list(raw.get(key))
+    total = _coerce_int(raw.get(total_key), default=len(items))
+    normalized: list[dict[str, Any]] = []
+    for item in items:
+        if isinstance(item, dict):
+            normalized.append({k: v for k, v in item.items()})
+    if not total and normalized:
+        total = len(normalized)
+    return normalized, total
+
+
+def _normalize_recommendation_actor(actor: Any) -> dict[str, str]:
+    """Normalize recommendation actor sub-object."""
+    if not isinstance(actor, dict):
+        return {
+            "first_name": "",
+            "last_name": "",
+            "headline": "",
+            "public_profile_url": "",
+            "profile_picture_url": "",
+        }
+    return {
+        "first_name": _clean_str(actor.get("first_name")),
+        "last_name": _clean_str(actor.get("last_name")),
+        "headline": _clean_str(actor.get("headline")),
+        "public_profile_url": _clean_str(
+            actor.get("public_profile_url") or actor.get("profile_url")
+        ),
+        "profile_picture_url": _clean_str(actor.get("profile_picture_url")),
+    }
+
+
+def _normalize_recommendation_entries(items: Any) -> list[dict[str, Any]]:
+    """Normalize given/received recommendation lists."""
+    entries: list[dict[str, Any]] = []
+    for item in _coerce_list(items):
+        if not isinstance(item, dict):
+            continue
+        entries.append(
+            {
+                "caption": _clean_str(item.get("caption")),
+                "text": _clean_str(item.get("text")),
+                "actor": _normalize_recommendation_actor(item.get("actor")),
+            }
+        )
+    return entries
+
+
+def _normalize_recommendations(raw: dict[str, Any]) -> tuple[dict[str, Any], int, int]:
+    """Map recommendations object and counts."""
+    recs = raw.get("recommendations")
+    if not isinstance(recs, dict):
+        return {"given": [], "received": []}, 0, 0
+
+    given = _normalize_recommendation_entries(recs.get("given"))
+    received = _normalize_recommendation_entries(recs.get("received"))
+    given_count = _coerce_int(recs.get("given_total_count"), default=len(given))
+    received_count = _coerce_int(recs.get("received_total_count"), default=len(received))
+    return {"given": given, "received": received}, given_count, received_count
+
+
+def _resolve_profile_url(raw: dict[str, Any]) -> str:
+    """Build LinkedIn profile URL from public_profile_url or public_identifier."""
+    direct = _clean_str(raw.get("public_profile_url"))
+    if direct.startswith("http"):
+        return direct
+    public_id = _clean_str(raw.get("public_identifier"))
+    if public_id:
+        return f"https://www.linkedin.com/in/{public_id}"
+    return ""
+
+
+def _resolve_is_self(raw: dict[str, Any]) -> bool:
+    """
+    Resolve is_self for normalized own-profile output.
+
+    AccountOwnerProfile (/users/me) does not include is_self; treat as True.
+    """
+    if raw.get("is_self") is True:
+        return True
+    if raw.get("is_self") is False:
+        return False
+    if raw.get("object") == "AccountOwnerProfile":
+        return True
+    return True
+
+
+def normalize_unipile_profile(
+    raw: dict[str, Any],
+    *,
+    stored_account_name: Optional[str] = None,
+) -> dict[str, Any]:
+    """
+    Convert a Unipile own-profile payload to ALwrity's normalized profile shape.
+
+    Accepts ``AccountOwnerProfile`` (GET /users/me) and enriched ``UserProfile``
+    payloads. Never includes raw Unipile-only keys in the result.
+
+    Args:
+        raw: Raw dict from fetch_own_linkedin_profile (UserProfile) or fixture
+        stored_account_name: Optional fallback display name from linkedin_oauth_tokens
+
+    Returns:
+        Normalized profile dict matching Phase 1 response model
+    """
+    if not isinstance(raw, dict):
+        logger.warning("[LinkedInProfile] normalize_unipile_profile received non-dict input")
+        raw = {}
+
+    logger.info("[LinkedInProfile] Normalizing Unipile profile object={!r}", raw.get("object"))
+
+    experience, work_total = _normalize_experience(raw)
+    job_title, company = _derive_current_role(experience)
+    education, education_total = _normalize_education(raw)
+    skills, skills_total = _normalize_skills(raw)
+    languages, languages_total = _normalize_languages(raw)
+    certifications, certifications_total = _normalize_object_list(
+        raw, "certifications", "certifications_total_count"
+    )
+    volunteering, volunteering_total = _normalize_object_list(
+        raw, "volunteering_experience", "volunteering_experience_total_count"
+    )
+    projects, projects_total = _normalize_object_list(raw, "projects", "projects_total_count")
+    recommendations, rec_given, rec_received = _normalize_recommendations(raw)
+
+    first_name = _clean_str(raw.get("first_name"))
+    last_name = _clean_str(raw.get("last_name"))
+    name = unipile_display_name_from_item(
+        raw,
+        user_id="",
+        stored_account_name=stored_account_name,
+    )
+    if not name:
+        name = f"{first_name} {last_name}".strip()
+
+    profile_picture = avatar_url_from_user_profile(raw) or ""
+
+    normalized: dict[str, Any] = {
+        "first_name": first_name,
+        "last_name": last_name,
+        "name": name,
+        "headline": _clean_str(raw.get("headline")),
+        "about": _clean_str(raw.get("summary")),
+        "job_title": job_title,
+        "company": company,
+        "location": _clean_str(raw.get("location")),
+        "provider_id": _clean_str(raw.get("provider_id")),
+        "public_identifier": _clean_str(raw.get("public_identifier")),
+        "member_urn": _clean_str(
+            raw.get("member_urn") or raw.get("object_urn") or raw.get("entity_urn")
+        ),
+        "primary_locale": _normalize_primary_locale(raw),
+        "is_open_profile": _coerce_bool(raw.get("is_open_profile", raw.get("open_profile"))),
+        "is_premium": _coerce_bool(raw.get("is_premium", raw.get("premium"))),
+        "is_influencer": _coerce_bool(raw.get("is_influencer")),
+        "creator_mode": _coerce_bool(raw.get("is_creator")),
+        "is_self": _resolve_is_self(raw),
+        "websites": [
+            _clean_str(url)
+            for url in _coerce_list(raw.get("websites"))
+            if _clean_str(url)
+        ],
+        "hashtags": [
+            _clean_str(tag)
+            for tag in _coerce_list(raw.get("hashtags"))
+            if _clean_str(tag)
+        ],
+        "followers": _coerce_int(raw.get("follower_count")),
+        "connections": _coerce_int(raw.get("connections_count")),
+        "profile_url": _resolve_profile_url(raw),
+        "profile_picture": profile_picture,
+        "background_picture": _clean_str(
+            raw.get("background_picture_url") or raw.get("background_picture")
+        ),
+        "skills_total_count": skills_total,
+        "skills": skills,
+        "work_experience_total_count": work_total,
+        "experience": experience,
+        "education_total_count": education_total,
+        "education": education,
+        "languages_total_count": languages_total,
+        "languages": languages,
+        "certifications_total_count": certifications_total,
+        "certifications": certifications,
+        "volunteering_experience_total_count": volunteering_total,
+        "volunteering_experience": volunteering,
+        "projects_total_count": projects_total,
+        "projects": projects,
+        "recommendations_given_count": rec_given,
+        "recommendations_received_count": rec_received,
+        "recommendations": recommendations,
+    }
+
+    logger.info(
+        "[LinkedInProfile] Normalized profile name={!r} experience_count={} "
+        "education_count={} skills_count={}",
+        normalized.get("name"),
+        len(normalized.get("experience", [])),
+        len(normalized.get("education", [])),
+        len(normalized.get("skills", [])),
+    )
+    return normalized
+
+
+def validate_normalized_profile(profile: dict[str, Any]) -> list[str]:
+    """
+    Validate Step 1.2 gate: normalized output shape and no raw Unipile leakage.
+
+    Returns:
+        List of error messages (empty when valid).
+    """
+    errors: list[str] = []
+
+    if not isinstance(profile, dict):
+        return ["normalized profile must be a dict"]
+
+    keys = set(profile.keys())
+    missing = NORMALIZED_PROFILE_KEYS - keys
+    extra = keys - NORMALIZED_PROFILE_KEYS
+    if missing:
+        errors.append(f"missing normalized keys: {sorted(missing)}")
+    if extra:
+        errors.append(f"unexpected extra keys: {sorted(extra)}")
+
+    leaked = keys & FORBIDDEN_RAW_KEYS
+    if leaked:
+        errors.append(f"raw Unipile keys leaked into output: {sorted(leaked)}")
+
+    for list_key in (
+        "skills",
+        "experience",
+        "education",
+        "languages",
+        "websites",
+        "hashtags",
+        "certifications",
+        "volunteering_experience",
+        "projects",
+    ):
+        if not isinstance(profile.get(list_key), list):
+            errors.append(f"{list_key} must be a list")
+
+    recs = profile.get("recommendations")
+    if not isinstance(recs, dict):
+        errors.append("recommendations must be a dict")
+    elif not isinstance(recs.get("given"), list) or not isinstance(recs.get("received"), list):
+        errors.append("recommendations.given and recommendations.received must be lists")
+
+    locale = profile.get("primary_locale")
+    if not isinstance(locale, dict):
+        errors.append("primary_locale must be a dict")
+    elif set(locale.keys()) != {"country", "language"}:
+        errors.append("primary_locale must contain country and language only")
+
+    for int_key in (
+        "followers",
+        "connections",
+        "skills_total_count",
+        "work_experience_total_count",
+        "education_total_count",
+        "languages_total_count",
+        "certifications_total_count",
+        "volunteering_experience_total_count",
+        "projects_total_count",
+        "recommendations_given_count",
+        "recommendations_received_count",
+    ):
+        if not isinstance(profile.get(int_key), int):
+            errors.append(f"{int_key} must be an int")
+
+    for bool_key in (
+        "is_open_profile",
+        "is_premium",
+        "is_influencer",
+        "creator_mode",
+        "is_self",
+    ):
+        if not isinstance(profile.get(bool_key), bool):
+            errors.append(f"{bool_key} must be a bool")
+
+    return errors

--- a/backend/services/integrations/linkedin/profile_validation_service.py
+++ b/backend/services/integrations/linkedin/profile_validation_service.py
@@ -1,0 +1,91 @@
+"""
+Phase 3 — profile validation orchestration (validate + cache).
+
+Never calls Unipile or generates questions.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Optional, TypedDict
+
+from loguru import logger
+
+from services.integrations.linkedin.profile_repository import ProfileRepository
+from services.integrations.linkedin.profile_validation_types import ProfileValidationResult
+from services.integrations.linkedin.profile_validator import validate_profile_completeness
+
+_LOG_PREFIX = "[ProfileValidation]"
+
+
+class ProfileValidationAcquireMeta(TypedDict):
+    """Metadata for validation acquisition."""
+
+    source: Literal["cache", "validated"]
+
+
+def get_or_validate_profile_context(
+    user_id: str,
+    profile_context: dict[str, Any],
+    *,
+    repository: Optional[ProfileRepository] = None,
+    force_revalidate: bool = False,
+) -> tuple[ProfileValidationResult, ProfileValidationAcquireMeta]:
+    """
+    Validate profile context and persist ``profile_validation_json``.
+
+    Serves cached validation when present unless ``force_revalidate`` is True.
+
+    Args:
+        user_id: ALwrity user ID
+        profile_context: Current ``LinkedInProfileContext`` dict
+        repository: Optional ``ProfileRepository`` (for testing)
+        force_revalidate: Skip cache and always run validator
+
+    Returns:
+        Tuple of (validation result, acquire meta)
+
+    Raises:
+        ValueError: When no analysis row exists for ``user_id``
+    """
+    logger.info(
+        "{} get_or_validate_profile_context user_id={} force_revalidate={}",
+        _LOG_PREFIX,
+        user_id,
+        force_revalidate,
+    )
+    repo = repository or ProfileRepository()
+    row = repo.get_analysis_row(user_id)
+    if not row:
+        logger.error(
+            "{} get_or_validate_profile_context no analysis row user_id={}",
+            _LOG_PREFIX,
+            user_id,
+        )
+        raise ValueError(
+            f"No linkedin_analysis_context row for user_id={user_id!r}; "
+            "acquire normalized profile first"
+        )
+
+    if not force_revalidate:
+        cached = repo.get_profile_validation(user_id, row=row)
+        if cached:
+            meta: ProfileValidationAcquireMeta = {"source": "cache"}
+            logger.info(
+                "{} get_or_validate_profile_context source=cache user_id={}",
+                _LOG_PREFIX,
+                user_id,
+            )
+            return cached, meta
+
+    validation = validate_profile_completeness(profile_context)
+    repo.save_profile_validation(user_id, validation)
+
+    validated_meta: ProfileValidationAcquireMeta = {"source": "validated"}
+    logger.info(
+        "{} get_or_validate_profile_context source=validated user_id={} "
+        "is_profile_complete={}",
+        _LOG_PREFIX,
+        user_id,
+        validation.get("is_profile_complete"),
+    )
+    return validation, validated_meta

--- a/backend/services/integrations/linkedin/profile_validation_types.py
+++ b/backend/services/integrations/linkedin/profile_validation_types.py
@@ -1,0 +1,65 @@
+"""
+Phase 3/4 — shared profile validation field keys and ordering.
+
+Phase 3 emits ``missing_fields`` using these keys; Phase 4 question generation
+consumes the same vocabulary without re-deriving completeness rules.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict
+
+from services.integrations.linkedin.field_coercion import clean_str
+
+# Sentinel when skills, experience, and education are all empty (OR-group).
+PROFESSIONAL_BACKGROUND_FIELD: Literal["professional_background"] = "professional_background"
+
+# Canonical keys Phase 3 may place in ``missing_fields``.
+MISSING_FIELD_KEYS: tuple[str, ...] = (
+    "name",
+    "headline",
+    "job_title",
+    "company",
+    "about",
+    PROFESSIONAL_BACKGROUND_FIELD,
+    "skills",
+    "experience",
+    "education",
+    "industry",
+)
+
+# Priority when capping completion questions (highest first).
+FIELD_PRIORITY_ORDER: tuple[str, ...] = MISSING_FIELD_KEYS
+
+
+class ProfileValidationResult(TypedDict, total=False):
+    """Standardized Phase 3 validation payload."""
+
+    is_profile_complete: bool
+    completeness_score: int
+    missing_fields: list[str]
+    optional_missing_fields: list[str]
+
+
+def is_field_empty(value: Any) -> bool:
+    """
+    Return True when a profile field is considered missing/empty.
+
+    Matches Phase 3 completeness rules: ``None``, blank strings, and empty lists
+    are empty. Used by Phase 3 validator and Phase 4 patcher no-overwrite checks.
+
+    Args:
+        value: Scalar, list, or other profile field value
+
+    Returns:
+        True when the value should be treated as missing
+    """
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return clean_str(value) == ""
+    if isinstance(value, list):
+        return len(value) == 0
+    if isinstance(value, dict):
+        return len(value) == 0
+    return False

--- a/backend/services/integrations/linkedin/profile_validator.py
+++ b/backend/services/integrations/linkedin/profile_validator.py
@@ -1,0 +1,115 @@
+"""
+Phase 3 — pure profile completeness validation (no AI, no persistence).
+
+Evaluates ``LinkedInProfileContext`` and returns standardized missing-field keys.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from services.integrations.linkedin.profile_validation_types import (
+    PROFESSIONAL_BACKGROUND_FIELD,
+    ProfileValidationResult,
+    is_field_empty,
+)
+
+_LOG_PREFIX = "[ProfileValidator]"
+
+_REQUIRED_SCALAR_FIELDS: tuple[tuple[str, str, str], ...] = (
+    ("name", "personal_information", "name"),
+    ("headline", "personal_information", "headline"),
+    ("job_title", "professional_information", "job_title"),
+    ("company", "professional_information", "company"),
+    ("about", "personal_information", "about"),
+)
+
+_OPTIONAL_FIELDS: tuple[tuple[str, str, str], ...] = (
+    ("location", "personal_information", "location"),
+    ("profile_url", "linkedin_information", "profile_url"),
+    ("profile_picture", "linkedin_information", "profile_picture"),
+    ("followers", "linkedin_information", "followers"),
+    ("connections", "linkedin_information", "connections"),
+)
+
+_REQUIRED_FIELD_COUNT = len(_REQUIRED_SCALAR_FIELDS) + 1  # OR-group counts as one
+
+
+def validate_profile_completeness(context: dict[str, Any]) -> ProfileValidationResult:
+    """
+    Validate whether ``LinkedInProfileContext`` has enough data for Phase 5.
+
+    Args:
+        context: Built profile context dict
+
+    Returns:
+        Validation result with completeness score and missing field keys
+    """
+    logger.info("{} validate_profile_completeness start", _LOG_PREFIX)
+
+    missing_fields: list[str] = []
+    optional_missing_fields: list[str] = []
+    completed_count = 0
+
+    for field_key, section, path in _REQUIRED_SCALAR_FIELDS:
+        value = _read_context_field(context, section, path)
+        if is_field_empty(value):
+            missing_fields.append(field_key)
+        else:
+            completed_count += 1
+
+    if _professional_background_missing(context):
+        missing_fields.append(PROFESSIONAL_BACKGROUND_FIELD)
+    else:
+        completed_count += 1
+
+    for field_key, section, path in _OPTIONAL_FIELDS:
+        value = _read_context_field(context, section, path)
+        if is_field_empty(value):
+            optional_missing_fields.append(field_key)
+
+    completeness_score = round(completed_count / _REQUIRED_FIELD_COUNT * 100)
+    is_profile_complete = len(missing_fields) == 0
+
+    result: ProfileValidationResult = {
+        "is_profile_complete": is_profile_complete,
+        "completeness_score": completeness_score,
+        "missing_fields": missing_fields,
+        "optional_missing_fields": optional_missing_fields,
+    }
+
+    logger.info(
+        "{} validate_profile_completeness complete is_profile_complete={} "
+        "score={} missing_count={}",
+        _LOG_PREFIX,
+        is_profile_complete,
+        completeness_score,
+        len(missing_fields),
+    )
+    return result
+
+
+def _read_context_field(context: dict[str, Any], section: str, path: str) -> Any:
+    section_data = context.get(section)
+    if not isinstance(section_data, dict):
+        return None
+    return section_data.get(path)
+
+
+def _professional_background_missing(context: dict[str, Any]) -> bool:
+    """True when skills, experience, and education are all empty."""
+    professional = context.get("professional_information")
+    if not isinstance(professional, dict):
+        return True
+
+    skills = professional.get("skills")
+    experience = professional.get("experience")
+    education = professional.get("education")
+
+    return (
+        is_field_empty(skills)
+        and is_field_empty(experience)
+        and is_field_empty(education)
+    )

--- a/backend/services/integrations/linkedin/protocol.py
+++ b/backend/services/integrations/linkedin/protocol.py
@@ -1,0 +1,100 @@
+"""
+LinkedIn Social Provider Protocol — vendor-neutral contract for Growth Engine.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Protocol, runtime_checkable
+
+from .types import (
+    CommentInfo,
+    CreatePostRequest,
+    CreatePostResult,
+    LinkedInAccount,
+    LinkedInOrganization,
+    MediaUploadResult,
+    OrgMetricType,
+    ProfileAggregation,
+    ReplyResult,
+)
+
+
+@runtime_checkable
+class LinkedInSocialProvider(Protocol):
+    """Abstract contract for LinkedIn platform operations (Zernio or native API)."""
+
+    @property
+    def provider_name(self) -> str:
+        ...
+
+    async def list_accounts(self, user_id: str) -> list[LinkedInAccount]:
+        ...
+
+    async def list_organizations(
+        self, user_id: str, account_id: str
+    ) -> list[LinkedInOrganization]:
+        ...
+
+    async def get_profile_aggregate_analytics(
+        self,
+        user_id: str,
+        account_id: str,
+        aggregation: ProfileAggregation = "TOTAL",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        metrics: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        ...
+
+    async def get_org_aggregate_analytics(
+        self,
+        user_id: str,
+        account_id: str,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
+        metric_type: OrgMetricType = "total_value",
+        metrics: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        ...
+
+    async def get_post_analytics(
+        self,
+        user_id: str,
+        account_id: str,
+        urn: str,
+    ) -> dict[str, Any]:
+        ...
+
+    async def create_post(
+        self, user_id: str, request: CreatePostRequest
+    ) -> CreatePostResult:
+        ...
+
+    async def upload_media(
+        self,
+        user_id: str,
+        account_id: str,
+        file_path: str,
+        media_type: str,
+    ) -> MediaUploadResult:
+        ...
+
+    async def schedule_post(
+        self, user_id: str, request: CreatePostRequest
+    ) -> CreatePostResult:
+        ...
+
+    async def list_comments(
+        self, user_id: str, account_id: str, post_urn: str
+    ) -> list[CommentInfo]:
+        ...
+
+    async def reply_to_comment(
+        self,
+        user_id: str,
+        account_id: str,
+        post_urn: str,
+        comment_id: str,
+        text: str,
+    ) -> ReplyResult:
+        ...

--- a/backend/services/integrations/linkedin/publish_preflight.py
+++ b/backend/services/integrations/linkedin/publish_preflight.py
@@ -1,0 +1,73 @@
+"""
+Pre-publish validation orchestrator (H4 + H5).
+
+Runs duplicate detection and media validation before Zernio/native publish.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from services.integrations.linkedin.content_deduplicator import ContentDeduplicator
+from services.integrations.linkedin.exceptions import (
+    LinkedInDuplicateContentError,
+    LinkedInMediaValidationError,
+)
+from services.integrations.linkedin.media_validator import (
+    LinkedInMediaValidator,
+    infer_media_type,
+)
+from services.integrations.linkedin.types import CreatePostRequest
+
+
+async def run_publish_preflight(
+    user_id: str,
+    request: CreatePostRequest,
+    *,
+    db: Optional[Session] = None,
+    deduplicator: Optional[ContentDeduplicator] = None,
+    media_validator: Optional[LinkedInMediaValidator] = None,
+) -> str:
+    """
+    Run H4/H5 guards before publish.
+
+    Returns content_hash for caller to persist after successful publish.
+    Raises LinkedInDuplicateContentError or LinkedInMediaValidationError on failure.
+    """
+    dedup = deduplicator or ContentDeduplicator()
+    validator = media_validator or LinkedInMediaValidator()
+
+    dup_result = dedup.check_duplicate(
+        user_id=user_id,
+        account_id=request.account_id,
+        content=request.content,
+        db=db,
+    )
+    if dup_result.is_duplicate:
+        raise LinkedInDuplicateContentError(
+            matched_asset_id=dup_result.matched_asset_id,
+            content_hash=dup_result.content_hash,
+        )
+
+    for media_path in request.media_urls or []:
+        media_type = infer_media_type(media_path)
+        result = validator.validate_for_publish(media_path, media_type)
+        if not result.valid:
+            raise LinkedInMediaValidationError(result.errors, file_path=media_path)
+
+    return dup_result.content_hash
+
+
+async def run_upload_preflight(
+    file_path: str,
+    media_type: str,
+    *,
+    media_validator: Optional[LinkedInMediaValidator] = None,
+) -> None:
+    """Run H5 media validation before upload_media."""
+    validator = media_validator or LinkedInMediaValidator()
+    result = validator.validate_for_publish(file_path, media_type)
+    if not result.valid:
+        raise LinkedInMediaValidationError(result.errors, file_path=file_path)

--- a/backend/services/integrations/linkedin/topic_recommendation_llm.py
+++ b/backend/services/integrations/linkedin/topic_recommendation_llm.py
@@ -1,0 +1,174 @@
+"""
+Phase 6 — LLM adapter for topic recommendations (Gemini structured JSON).
+
+Thin wrapper over injectable ``generate_fn``; no validation or persistence.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Optional
+
+from loguru import logger
+
+from services.integrations.linkedin.topic_recommendation_types import (
+    DEFAULT_TOPIC_RECOMMENDATION_MODEL,
+    topic_recommendation_json_schema,
+)
+from services.llm_providers.gemini_provider import gemini_structured_json_response
+
+_LOG_PREFIX = "[TopicRecommendation]"
+
+TOPIC_RECOMMENDATION_LLM_TEMPERATURE = 0.3
+TOPIC_RECOMMENDATION_LLM_MAX_TOKENS = 4096
+
+TopicRecommendationGenerateFn = Callable[..., Any]
+
+
+class TopicRecommendationLLMError(Exception):
+    """Raised when the LLM provider fails for topic recommendation generation."""
+
+    def __init__(self, message: str, *, error_kind: str = "unknown") -> None:
+        super().__init__(message)
+        self.error_kind = error_kind
+
+
+def _classify_gemini_error(exc: Exception) -> str:
+    """Return a safe error category for Gemini/provider failures (for logging)."""
+    msg = str(exc).lower()
+    if "resource_exhausted" in msg or "quota" in msg or "rate limit" in msg:
+        return "quota_or_rate_limit"
+    if "401" in msg or "403" in msg or "api key" in msg or "authentication" in msg:
+        return "auth"
+    if "timeout" in msg or "timed out" in msg or "deadline" in msg:
+        return "timeout"
+    if "invalid json" in msg or "json" in msg:
+        return "invalid_json"
+    return "provider_error"
+
+
+def _log_gemini_provider_error(exc: Exception, *, user_id: Optional[str]) -> None:
+    """Log Gemini/provider failures with safe metadata for production debugging."""
+    error_kind = _classify_gemini_error(exc)
+    logger.error(
+        "{} Gemini/provider failure kind={} type={} user_id={} message={}",
+        _LOG_PREFIX,
+        error_kind,
+        type(exc).__name__,
+        user_id,
+        str(exc)[:500],
+    )
+    logger.exception(
+        "{} Gemini/provider traceback user_id={} kind={}",
+        _LOG_PREFIX,
+        user_id,
+        error_kind,
+    )
+
+
+def call_topic_recommendation_llm(
+    *,
+    system_prompt: str,
+    user_prompt: str,
+    user_id: Optional[str] = None,
+    generate_fn: TopicRecommendationGenerateFn = gemini_structured_json_response,
+) -> dict[str, Any]:
+    """
+    Call the LLM to generate structured topic recommendation JSON.
+
+    Args:
+        system_prompt: System instruction for the model
+        user_prompt: User message (serialized ``AIProfileIntelligence`` JSON)
+        user_id: Optional ALwrity user ID for provider usage tracking
+        generate_fn: Injectable structured JSON generator (default: Gemini)
+
+    Returns:
+        Parsed dict from the LLM (not yet validated by Pydantic)
+
+    Raises:
+        TopicRecommendationLLMError: When the provider fails or returns unusable output
+    """
+    schema = topic_recommendation_json_schema()
+    logger.info(
+        "{} call_topic_recommendation_llm start model={} user_prompt_len={} user_id={}",
+        _LOG_PREFIX,
+        DEFAULT_TOPIC_RECOMMENDATION_MODEL,
+        len(user_prompt) if isinstance(user_prompt, str) else None,
+        user_id,
+    )
+
+    try:
+        response = generate_fn(
+            prompt=user_prompt,
+            schema=schema,
+            temperature=TOPIC_RECOMMENDATION_LLM_TEMPERATURE,
+            max_tokens=TOPIC_RECOMMENDATION_LLM_MAX_TOKENS,
+            system_prompt=system_prompt,
+            user_id=user_id,
+        )
+    except TopicRecommendationLLMError:
+        raise
+    except Exception as exc:
+        _log_gemini_provider_error(exc, user_id=user_id)
+        error_kind = _classify_gemini_error(exc)
+        raise TopicRecommendationLLMError(
+            "Unable to generate topic recommendations from LLM",
+            error_kind=error_kind,
+        ) from exc
+
+    try:
+        result = _coerce_llm_dict(response)
+    except TopicRecommendationLLMError as exc:
+        logger.error(
+            "{} call_topic_recommendation_llm invalid response user_id={} kind={} "
+            "type={} message={}",
+            _LOG_PREFIX,
+            user_id,
+            exc.error_kind,
+            type(response).__name__,
+            str(exc),
+        )
+        raise
+
+    recommendation_count = None
+    if isinstance(result.get("recommendations"), list):
+        recommendation_count = len(result["recommendations"])
+
+    logger.info(
+        "{} call_topic_recommendation_llm complete user_id={} response_keys={} "
+        "recommendation_count={}",
+        _LOG_PREFIX,
+        user_id,
+        sorted(result.keys()),
+        recommendation_count,
+    )
+    return result
+
+
+def _coerce_llm_dict(response: Any) -> dict[str, Any]:
+    """Normalize provider output to a dict."""
+    if isinstance(response, dict):
+        return response
+    if isinstance(response, str):
+        try:
+            parsed = json.loads(response)
+        except json.JSONDecodeError as exc:
+            logger.error(
+                "{} LLM returned invalid JSON string error={}",
+                _LOG_PREFIX,
+                exc,
+            )
+            raise TopicRecommendationLLMError(
+                "LLM returned invalid JSON string",
+                error_kind="invalid_json",
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise TopicRecommendationLLMError(
+                "LLM JSON response must be an object",
+                error_kind="invalid_json",
+            )
+        return parsed
+    raise TopicRecommendationLLMError(
+        f"Unexpected LLM response type: {type(response).__name__}",
+        error_kind="invalid_response",
+    )

--- a/backend/services/integrations/linkedin/topic_recommendation_service.py
+++ b/backend/services/integrations/linkedin/topic_recommendation_service.py
@@ -1,0 +1,409 @@
+"""
+Phase 6 — topic recommendation orchestration (cache-first generate).
+
+Gates on profile completeness and AI intelligence presence; coordinates LLM + validation + persistence.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Optional, TypedDict
+
+from loguru import logger
+
+from prompts.linkedin.topic_recommendation_prompt import (
+    TOPIC_RECOMMENDATION_SYSTEM_PROMPT,
+    build_topic_recommendation_user_prompt,
+)
+from services.integrations.linkedin.profile_repository import (
+    ProfileRepository,
+    compute_ai_intelligence_hash,
+)
+from services.integrations.linkedin.profile_validation_types import ProfileValidationResult
+from services.integrations.linkedin.topic_recommendation_llm import (
+    TopicRecommendationGenerateFn,
+    TopicRecommendationLLMError,
+    call_topic_recommendation_llm,
+)
+from services.integrations.linkedin.topic_recommendation_validator import (
+    TopicRecommendationValidationError,
+    build_stored_topic_recommendations,
+    extract_recommendations_list,
+    normalize_topic_recommendation_raw,
+    validate_topic_recommendation_payload,
+)
+from services.llm_providers.gemini_provider import gemini_structured_json_response
+
+_LOG_PREFIX = "[TopicRecommendation]"
+
+VALIDATION_RETRY_USER_SUFFIX = (
+    "\n\nPrevious response failed schema validation. "
+    "Return valid JSON only matching the required schema exactly with exactly five recommendations."
+)
+
+
+class TopicRecommendationError(Exception):
+    """Base error for topic recommendation orchestration."""
+
+
+class TopicRecommendationAcquireMeta(TypedDict, total=False):
+    """Metadata for topic recommendation acquisition."""
+
+    source: Literal["cache", "generated"]
+    recommendations_updated_at: Optional[str]
+
+
+def get_or_generate_topic_recommendations(
+    user_id: str,
+    ai_profile_intelligence: dict[str, Any],
+    *,
+    profile_validation: ProfileValidationResult,
+    repository: Optional[ProfileRepository] = None,
+    force_regenerate: bool = False,
+    generate_fn: TopicRecommendationGenerateFn = gemini_structured_json_response,
+) -> tuple[Optional[list[dict[str, Any]]], TopicRecommendationAcquireMeta]:
+    """
+    Return cached or newly generated topic recommendations.
+
+    Skips LLM when profile is incomplete or intelligence is missing.
+
+    Args:
+        user_id: ALwrity user ID
+        ai_profile_intelligence: Phase 5 AI profile intelligence dict
+        profile_validation: Phase 3 validation result (completeness gate)
+        repository: Optional ``ProfileRepository`` (for testing)
+        force_regenerate: Bypass cache and regenerate via LLM
+        generate_fn: Injectable LLM adapter (for testing)
+
+    Returns:
+        Tuple of (recommendations list or ``None`` when gated, acquire meta)
+
+    Raises:
+        TopicRecommendationLLMError: When LLM fails after validation retry
+        TopicRecommendationValidationError: When validation fails after retry
+        ValueError: When analysis row is missing during generation
+        TopicRecommendationError: When persistence fails
+    """
+    logger.info(
+        "{} ============================================================",
+        _LOG_PREFIX,
+    )
+    logger.info(
+        "{} Starting recommendation generation user_id={}",
+        _LOG_PREFIX,
+        user_id,
+    )
+    logger.info(
+        "{} Gate check is_profile_complete={} intelligence_present={} force_regenerate={}",
+        _LOG_PREFIX,
+        profile_validation.get("is_profile_complete"),
+        isinstance(ai_profile_intelligence, dict) and bool(ai_profile_intelligence),
+        force_regenerate,
+    )
+
+    if not profile_validation.get("is_profile_complete"):
+        logger.info(
+            "{} Skipping recommendations — profile incomplete user_id={} missing_fields={}",
+            _LOG_PREFIX,
+            user_id,
+            profile_validation.get("missing_fields"),
+        )
+        return None, {"recommendations_updated_at": None}
+
+    if not isinstance(ai_profile_intelligence, dict) or not ai_profile_intelligence:
+        logger.info(
+            "{} Skipping recommendations — AI profile intelligence missing user_id={}",
+            _LOG_PREFIX,
+            user_id,
+        )
+        return None, {"recommendations_updated_at": None}
+
+    repo = repository or ProfileRepository()
+    row = repo.get_analysis_row(user_id)
+    if not row:
+        logger.error(
+            "{} No analysis row for recommendations user_id={}",
+            _LOG_PREFIX,
+            user_id,
+        )
+        raise ValueError(
+            f"No linkedin_analysis_context row for user_id={user_id!r}; "
+            "acquire normalized profile first"
+        )
+
+    intelligence_hash = compute_ai_intelligence_hash(ai_profile_intelligence)
+    logger.info(
+        "{} Intelligence hash computed user_id={} hash={}",
+        _LOG_PREFIX,
+        user_id,
+        intelligence_hash[:12],
+    )
+
+    if not force_regenerate:
+        cached = repo.get_topic_recommendations(user_id, row=row)
+        if cached and _is_recommendations_cache_valid(
+            cached,
+            intelligence_hash=intelligence_hash,
+            row=row,
+            user_id=user_id,
+        ):
+            recommendations = extract_recommendations_list(cached)
+            meta: TopicRecommendationAcquireMeta = {
+                "source": "cache",
+                "recommendations_updated_at": row.get("recommendations_updated_at"),
+            }
+            logger.info(
+                "{} Cache hit user_id={} recommendations_updated_at={} count={}",
+                _LOG_PREFIX,
+                user_id,
+                meta.get("recommendations_updated_at"),
+                len(recommendations),
+            )
+            logger.info(
+                "{} Five recommendations served from cache user_id={}",
+                _LOG_PREFIX,
+                user_id,
+            )
+            return recommendations, meta
+
+        logger.info(
+            "{} Cache miss user_id={} cached_present={}",
+            _LOG_PREFIX,
+            user_id,
+            cached is not None,
+        )
+    else:
+        logger.info(
+            "{} force_regenerate=True — bypassing cache user_id={}",
+            _LOG_PREFIX,
+            user_id,
+        )
+
+    stored = _generate_and_persist_recommendations(
+        user_id,
+        ai_profile_intelligence,
+        intelligence_hash=intelligence_hash,
+        repository=repo,
+        generate_fn=generate_fn,
+    )
+    recommendations = extract_recommendations_list(stored)
+    updated_row = repo.get_analysis_row(user_id)
+    rec_updated = updated_row.get("recommendations_updated_at") if updated_row else None
+
+    generated_meta: TopicRecommendationAcquireMeta = {
+        "source": "generated",
+        "recommendations_updated_at": rec_updated,
+    }
+    logger.info(
+        "{} Recommendation generation finished source=generated user_id={} count={}",
+        _LOG_PREFIX,
+        user_id,
+        len(recommendations),
+    )
+    return recommendations, generated_meta
+
+
+def _is_recommendations_cache_valid(
+    cached: dict[str, Any],
+    *,
+    intelligence_hash: str,
+    row: dict[str, Any],
+    user_id: str,
+) -> bool:
+    """Return True when cached recommendations match the current AI profile intelligence."""
+    meta = cached.get("meta")
+    if not isinstance(meta, dict):
+        logger.warning(
+            "{} Cache invalid — missing meta user_id={}",
+            _LOG_PREFIX,
+            user_id,
+        )
+        return False
+
+    stored_hash = meta.get("built_from_intelligence_hash")
+    if not isinstance(stored_hash, str) or stored_hash != intelligence_hash:
+        logger.info(
+            "{} Cache invalid — intelligence hash mismatch user_id={} stored={} current={}",
+            _LOG_PREFIX,
+            user_id,
+            stored_hash[:12] if isinstance(stored_hash, str) and stored_hash else None,
+            intelligence_hash[:12],
+        )
+        return False
+
+    ai_updated_at = row.get("ai_intelligence_updated_at")
+    rec_updated_at = row.get("recommendations_updated_at")
+    if (
+        isinstance(ai_updated_at, str)
+        and isinstance(rec_updated_at, str)
+        and ai_updated_at > rec_updated_at
+    ):
+        logger.info(
+            "{} Cache invalid — ai_intelligence_updated_at newer user_id={} "
+            "ai_updated_at={} rec_updated_at={}",
+            _LOG_PREFIX,
+            user_id,
+            ai_updated_at,
+            rec_updated_at,
+        )
+        return False
+
+    recommendations = cached.get("recommendations")
+    if not isinstance(recommendations, list) or len(recommendations) != 5:
+        logger.warning(
+            "{} Cache invalid — recommendations count user_id={} count={}",
+            _LOG_PREFIX,
+            user_id,
+            len(recommendations) if isinstance(recommendations, list) else None,
+        )
+        return False
+
+    logger.debug(
+        "{} Cache valid user_id={} hash={}",
+        _LOG_PREFIX,
+        user_id,
+        intelligence_hash[:12],
+    )
+    return True
+
+
+def _generate_and_persist_recommendations(
+    user_id: str,
+    ai_profile_intelligence: dict[str, Any],
+    *,
+    intelligence_hash: str,
+    repository: ProfileRepository,
+    generate_fn: TopicRecommendationGenerateFn,
+) -> dict[str, Any]:
+    """Run LLM (with one validation retry), validate, assign IDs, and persist."""
+    logger.info("{} Reading AI Profile Intelligence user_id={}", _LOG_PREFIX, user_id)
+    logger.info("{} Preparing LLM prompt user_id={}", _LOG_PREFIX, user_id)
+    user_prompt = build_topic_recommendation_user_prompt(ai_profile_intelligence)
+    logger.info(
+        "{} User prompt ready user_id={} prompt_len={}",
+        _LOG_PREFIX,
+        user_id,
+        len(user_prompt),
+    )
+
+    raw = _call_llm_with_validation_retry(
+        user_id=user_id,
+        user_prompt=user_prompt,
+        generate_fn=generate_fn,
+    )
+
+    logger.info("{} Validating recommendations user_id={}", _LOG_PREFIX, user_id)
+    payload = validate_topic_recommendation_payload(raw)
+    stored = build_stored_topic_recommendations(
+        payload,
+        intelligence_hash=intelligence_hash,
+    )
+    logger.info(
+        "{} Assigning recommendation IDs complete user_id={} count={}",
+        _LOG_PREFIX,
+        user_id,
+        len(stored.get("recommendations", [])),
+    )
+    logger.info(
+        "{} Persisting topic_recommendations_json user_id={} hash={}",
+        _LOG_PREFIX,
+        user_id,
+        intelligence_hash[:12],
+    )
+    try:
+        repository.save_topic_recommendations(
+            user_id,
+            stored,
+            intelligence_hash=intelligence_hash,
+        )
+    except ValueError as exc:
+        logger.exception(
+            "{} Failed to persist recommendations user_id={}: {}",
+            _LOG_PREFIX,
+            user_id,
+            exc,
+        )
+        raise TopicRecommendationError(
+            "Unable to persist topic recommendations"
+        ) from exc
+
+    logger.info(
+        "{} Five recommendations generated successfully user_id={}",
+        _LOG_PREFIX,
+        user_id,
+    )
+    return stored
+
+
+def _call_llm_with_validation_retry(
+    *,
+    user_id: str,
+    user_prompt: str,
+    generate_fn: TopicRecommendationGenerateFn,
+) -> dict[str, Any]:
+    """Call LLM once; retry once when validation fails on the parsed response."""
+    logger.info("{} Sending request to LLM user_id={}", _LOG_PREFIX, user_id)
+    raw = call_topic_recommendation_llm(
+        system_prompt=TOPIC_RECOMMENDATION_SYSTEM_PROMPT,
+        user_prompt=user_prompt,
+        user_id=user_id,
+        generate_fn=generate_fn,
+    )
+    logger.info(
+        "{} Recommendations received user_id={} keys={}",
+        _LOG_PREFIX,
+        user_id,
+        sorted(raw.keys()) if isinstance(raw, dict) else None,
+    )
+
+    normalized = normalize_topic_recommendation_raw(raw) if isinstance(raw, dict) else raw
+
+    try:
+        validate_topic_recommendation_payload(normalized)
+        logger.info("{} Validation passed on first attempt user_id={}", _LOG_PREFIX, user_id)
+        return normalized
+    except TopicRecommendationValidationError as first_error:
+        logger.warning(
+            "{} Validation failed — retrying LLM once user_id={} code={}: {}",
+            _LOG_PREFIX,
+            user_id,
+            first_error.validation_code,
+            first_error,
+        )
+
+    retry_prompt = f"{user_prompt}{VALIDATION_RETRY_USER_SUFFIX}"
+    logger.info("{} Sending validation retry to LLM user_id={}", _LOG_PREFIX, user_id)
+    retry_raw = call_topic_recommendation_llm(
+        system_prompt=TOPIC_RECOMMENDATION_SYSTEM_PROMPT,
+        user_prompt=retry_prompt,
+        user_id=user_id,
+        generate_fn=generate_fn,
+    )
+    logger.info(
+        "{} Retry recommendations received user_id={} keys={}",
+        _LOG_PREFIX,
+        user_id,
+        sorted(retry_raw.keys()) if isinstance(retry_raw, dict) else None,
+    )
+
+    retry_normalized = (
+        normalize_topic_recommendation_raw(retry_raw)
+        if isinstance(retry_raw, dict)
+        else retry_raw
+    )
+
+    try:
+        validate_topic_recommendation_payload(retry_normalized)
+        logger.info("{} Validation passed on retry user_id={}", _LOG_PREFIX, user_id)
+        return retry_normalized
+    except TopicRecommendationValidationError as retry_error:
+        logger.exception(
+            "{} Validation failed after retry user_id={} code={}: {}",
+            _LOG_PREFIX,
+            user_id,
+            retry_error.validation_code,
+            retry_error,
+        )
+        raise TopicRecommendationValidationError(
+            f"Topic recommendations failed validation after retry ({retry_error})",
+            validation_code=retry_error.validation_code,
+        ) from retry_error

--- a/backend/services/integrations/linkedin/topic_recommendation_types.py
+++ b/backend/services/integrations/linkedin/topic_recommendation_types.py
@@ -1,0 +1,86 @@
+"""
+Phase 6 — topic recommendation Pydantic types and JSON schema export.
+
+Defines LLM output shape (without ``id`` or ``meta``) and stored payload with server-side meta.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+TOPIC_RECOMMENDATION_SCHEMA_VERSION = 1
+TOPIC_RECOMMENDATION_COUNT = 5
+DEFAULT_TOPIC_RECOMMENDATION_MODEL = "gemini-2.5-flash"
+
+RecommendedFormat = Literal["LinkedIn Post", "LinkedIn Article"]
+GrowthImpact = Literal["High", "Medium", "Low"]
+
+RECOMMENDED_FORMATS: tuple[RecommendedFormat, ...] = (
+    "LinkedIn Post",
+    "LinkedIn Article",
+)
+GROWTH_IMPACTS: tuple[GrowthImpact, ...] = ("High", "Medium", "Low")
+
+
+class TopicRecommendationItemPayload(BaseModel):
+    """Single LLM recommendation item (no server ``id``)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str
+    why_this_fits: str
+    recommended_format: RecommendedFormat
+    target_audience: list[str] = Field(min_length=1)
+    growth_impact: GrowthImpact
+
+
+class TopicRecommendationLLMResponse(BaseModel):
+    """Structured LLM output for topic recommendations."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    recommendations: list[TopicRecommendationItemPayload] = Field(min_length=5, max_length=5)
+
+
+class TopicRecommendationItem(BaseModel):
+    """API/stored recommendation item with server-assigned ``id``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    title: str
+    why_this_fits: str
+    recommended_format: RecommendedFormat
+    target_audience: list[str] = Field(min_length=1)
+    growth_impact: GrowthImpact
+
+
+class TopicRecommendationMeta(BaseModel):
+    """Server-owned metadata for cached topic recommendations."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    built_from_intelligence_hash: str = ""
+    schema_version: int = Field(default=TOPIC_RECOMMENDATION_SCHEMA_VERSION)
+    model: str = Field(default=DEFAULT_TOPIC_RECOMMENDATION_MODEL)
+
+
+class StoredTopicRecommendations(BaseModel):
+    """Full persisted recommendations object including server ``meta``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    meta: TopicRecommendationMeta
+    recommendations: list[TopicRecommendationItem] = Field(min_length=5, max_length=5)
+
+
+def topic_recommendation_json_schema() -> dict[str, Any]:
+    """
+    Return JSON schema for Gemini structured output (LLM fields only).
+
+    Returns:
+        JSON schema dict suitable for ``gemini_structured_json_response``
+    """
+    return TopicRecommendationLLMResponse.model_json_schema()

--- a/backend/services/integrations/linkedin/topic_recommendation_validator.py
+++ b/backend/services/integrations/linkedin/topic_recommendation_validator.py
@@ -1,0 +1,438 @@
+"""
+Phase 6 — pure topic recommendation validation (no LLM, no persistence).
+
+Parses LLM output with Pydantic and applies post-checks before meta/id attachment.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from loguru import logger
+from pydantic import ValidationError
+
+from services.integrations.linkedin.field_coercion import clean_str
+from services.integrations.linkedin.topic_recommendation_types import (
+    DEFAULT_TOPIC_RECOMMENDATION_MODEL,
+    GROWTH_IMPACTS,
+    RECOMMENDED_FORMATS,
+    TOPIC_RECOMMENDATION_COUNT,
+    TOPIC_RECOMMENDATION_SCHEMA_VERSION,
+    StoredTopicRecommendations,
+    TopicRecommendationItem,
+    TopicRecommendationItemPayload,
+    TopicRecommendationLLMResponse,
+    TopicRecommendationMeta,
+)
+
+_LOG_PREFIX = "[TopicRecommendation]"
+
+_ITEM_SCALAR_FIELDS: tuple[str, ...] = ("title", "why_this_fits")
+
+
+class TopicRecommendationValidationError(Exception):
+    """Raised when topic recommendation LLM output fails validation."""
+
+    def __init__(self, message: str, *, validation_code: str = "validation_failed") -> None:
+        super().__init__(message)
+        self.validation_code = validation_code
+
+
+def _normalize_recommended_format(value: Any) -> str:
+    """Map common LLM format variants to allowed enum values."""
+    if not isinstance(value, str):
+        if value is None:
+            logger.warning(
+                "{} normalize recommended_format missing value — defaulting to LinkedIn Post",
+                _LOG_PREFIX,
+            )
+            return "LinkedIn Post"
+        cleaned_non_str = clean_str(value)
+        if cleaned_non_str in RECOMMENDED_FORMATS:
+            return cleaned_non_str
+        logger.warning(
+            "{} normalize recommended_format non-string value={} — defaulting to LinkedIn Post",
+            _LOG_PREFIX,
+            type(value).__name__,
+        )
+        return "LinkedIn Post"
+
+    cleaned = clean_str(value)
+    if cleaned in RECOMMENDED_FORMATS:
+        return cleaned
+    lower = cleaned.lower()
+    if "article" in lower or "long-form" in lower or "longform" in lower or "blog" in lower:
+        return "LinkedIn Article"
+    if "post" in lower or "short" in lower or "update" in lower or "text" in lower:
+        return "LinkedIn Post"
+    if cleaned == "":
+        logger.warning(
+            "{} normalize recommended_format empty value — defaulting to LinkedIn Post",
+            _LOG_PREFIX,
+        )
+        return "LinkedIn Post"
+
+    logger.warning(
+        "{} normalize recommended_format unrecognized value={!r} — defaulting to LinkedIn Post",
+        _LOG_PREFIX,
+        cleaned,
+    )
+    return "LinkedIn Post"
+
+
+def _normalize_growth_impact(value: Any) -> str:
+    """Map common LLM growth-impact variants to allowed enum values."""
+    if not isinstance(value, str):
+        if value is None:
+            logger.warning(
+                "{} normalize growth_impact missing value — defaulting to Medium",
+                _LOG_PREFIX,
+            )
+            return "Medium"
+        cleaned_non_str = clean_str(value)
+        if cleaned_non_str in GROWTH_IMPACTS:
+            return cleaned_non_str
+        logger.warning(
+            "{} normalize growth_impact non-string value={} — defaulting to Medium",
+            _LOG_PREFIX,
+            type(value).__name__,
+        )
+        return "Medium"
+
+    cleaned = clean_str(value)
+    if cleaned in GROWTH_IMPACTS:
+        return cleaned
+    lower = cleaned.lower()
+    for impact in GROWTH_IMPACTS:
+        if impact.lower() == lower:
+            return impact
+    if "high" in lower:
+        return "High"
+    if "low" in lower:
+        return "Low"
+    if "medium" in lower or "moderate" in lower:
+        return "Medium"
+    if cleaned == "":
+        logger.warning(
+            "{} normalize growth_impact empty value — defaulting to Medium",
+            _LOG_PREFIX,
+        )
+        return "Medium"
+
+    logger.warning(
+        "{} normalize growth_impact unrecognized value={!r} — defaulting to Medium",
+        _LOG_PREFIX,
+        cleaned,
+    )
+    return "Medium"
+
+
+def _normalize_recommendation_item(raw_item: Any) -> dict[str, Any]:
+    """Best-effort normalize a single recommendation object."""
+    if not isinstance(raw_item, dict):
+        return {
+            "title": "",
+            "why_this_fits": "",
+            "recommended_format": "",
+            "target_audience": [],
+            "growth_impact": "",
+        }
+
+    audience_raw = raw_item.get("target_audience")
+    audience: list[str] = []
+    if isinstance(audience_raw, list):
+        audience = [
+            cleaned
+            for item in audience_raw
+            if isinstance(item, str) and (cleaned := clean_str(item))
+        ]
+
+    return {
+        "title": clean_str(raw_item.get("title")),
+        "why_this_fits": clean_str(raw_item.get("why_this_fits")),
+        "recommended_format": _normalize_recommended_format(raw_item.get("recommended_format")),
+        "target_audience": audience,
+        "growth_impact": _normalize_growth_impact(raw_item.get("growth_impact")),
+    }
+
+
+def normalize_topic_recommendation_raw(raw: dict[str, Any]) -> dict[str, Any]:
+    """
+    Best-effort normalize LLM JSON before strict Pydantic validation.
+
+    Strips strings, normalizes enum-like fields, filters empty audience labels,
+    and drops unexpected keys.
+    """
+    recommendations_raw = raw.get("recommendations")
+    if not isinstance(recommendations_raw, list):
+        return {"recommendations": []}
+
+    normalized_items = [_normalize_recommendation_item(item) for item in recommendations_raw]
+    if len(normalized_items) > TOPIC_RECOMMENDATION_COUNT:
+        logger.warning(
+            "{} normalize_topic_recommendation_raw truncating count={} to {}",
+            _LOG_PREFIX,
+            len(normalized_items),
+            TOPIC_RECOMMENDATION_COUNT,
+        )
+        normalized_items = normalized_items[:TOPIC_RECOMMENDATION_COUNT]
+
+    logger.debug(
+        "{} normalize_topic_recommendation_raw count={}",
+        _LOG_PREFIX,
+        len(normalized_items),
+    )
+    return {"recommendations": normalized_items}
+
+
+def _first_pydantic_field_hint(exc: ValidationError) -> str:
+    """Extract a concise field hint from a Pydantic validation error."""
+    for error in exc.errors():
+        loc = error.get("loc") or ()
+        field = ".".join(str(part) for part in loc if part != "__root__")
+        msg = error.get("msg", "invalid value")
+        if field:
+            return f"{field}: {msg}"
+        return str(msg)
+    return "schema validation failed"
+
+
+def validate_topic_recommendation_payload(raw: Any) -> TopicRecommendationLLMResponse:
+    """
+    Validate raw LLM output into ``TopicRecommendationLLMResponse``.
+
+    Applies Pydantic parsing (``extra='forbid'``) and deterministic post-checks.
+
+    Args:
+        raw: Parsed JSON object from the LLM
+
+    Returns:
+        Validated LLM response model
+
+    Raises:
+        TopicRecommendationValidationError: When parsing or post-checks fail
+    """
+    logger.info("{} validate_topic_recommendation_payload start", _LOG_PREFIX)
+
+    if not isinstance(raw, dict):
+        logger.error(
+            "{} validate_topic_recommendation_payload not a dict type={}",
+            _LOG_PREFIX,
+            type(raw).__name__,
+        )
+        raise TopicRecommendationValidationError(
+            "Topic recommendations must be a JSON object",
+            validation_code="invalid_type",
+        )
+
+    raw = normalize_topic_recommendation_raw(raw)
+
+    try:
+        payload = TopicRecommendationLLMResponse.model_validate(raw)
+    except ValidationError as exc:
+        field_hint = _first_pydantic_field_hint(exc)
+        logger.exception(
+            "{} validate_topic_recommendation_payload pydantic error hint={}: {}",
+            _LOG_PREFIX,
+            field_hint,
+            exc,
+        )
+        raise TopicRecommendationValidationError(
+            f"Topic recommendations failed schema validation ({field_hint})",
+            validation_code="schema_validation",
+        ) from exc
+
+    if len(payload.recommendations) != TOPIC_RECOMMENDATION_COUNT:
+        logger.error(
+            "{} validate_topic_recommendation_payload wrong count={} expected={}",
+            _LOG_PREFIX,
+            len(payload.recommendations),
+            TOPIC_RECOMMENDATION_COUNT,
+        )
+        raise TopicRecommendationValidationError(
+            f"Topic recommendations must contain exactly {TOPIC_RECOMMENDATION_COUNT} items",
+            validation_code="wrong_count",
+        )
+
+    for index, item in enumerate(payload.recommendations):
+        _run_item_post_checks(item, index=index)
+
+    logger.info(
+        "{} validate_topic_recommendation_payload ok count={}",
+        _LOG_PREFIX,
+        len(payload.recommendations),
+    )
+    return payload
+
+
+def build_stored_topic_recommendations(
+    payload: TopicRecommendationLLMResponse,
+    *,
+    intelligence_hash: str = "",
+    model: str = DEFAULT_TOPIC_RECOMMENDATION_MODEL,
+) -> dict[str, Any]:
+    """
+    Assign server-side ``id`` values, attach ``meta``, and return a persistence-ready dict.
+
+    Args:
+        payload: Validated LLM output
+        intelligence_hash: Canonical hash of source ``AIProfileIntelligence``
+        model: LLM model identifier used for generation
+
+    Returns:
+        Dict matching ``StoredTopicRecommendations`` shape
+    """
+    logger.info(
+        "{} build_stored_topic_recommendations intelligence_hash={} model={} count={}",
+        _LOG_PREFIX,
+        intelligence_hash[:12] if intelligence_hash else None,
+        model,
+        len(payload.recommendations),
+    )
+
+    items_with_ids: list[TopicRecommendationItem] = []
+    for index, item in enumerate(payload.recommendations):
+        recommendation_id = str(uuid.uuid4())
+        logger.debug(
+            "{} assign recommendation id index={} id={}",
+            _LOG_PREFIX,
+            index,
+            recommendation_id,
+        )
+        items_with_ids.append(
+            TopicRecommendationItem(
+                id=recommendation_id,
+                **item.model_dump(),
+            )
+        )
+
+    stored = StoredTopicRecommendations(
+        meta=TopicRecommendationMeta(
+            built_from_intelligence_hash=intelligence_hash,
+            schema_version=TOPIC_RECOMMENDATION_SCHEMA_VERSION,
+            model=model,
+        ),
+        recommendations=items_with_ids,
+    )
+    logger.info(
+        "{} build_stored_topic_recommendations complete ids_assigned={}",
+        _LOG_PREFIX,
+        len(items_with_ids),
+    )
+    return stored.model_dump()
+
+
+def extract_recommendations_list(stored: dict[str, Any]) -> list[dict[str, Any]]:
+    """
+    Extract the recommendations array from a stored payload dict.
+
+    Args:
+        stored: Stored topic recommendations dict
+
+    Returns:
+        List of recommendation dicts with ``id`` fields
+    """
+    recommendations = stored.get("recommendations")
+    if not isinstance(recommendations, list):
+        logger.error(
+            "{} extract_recommendations_list invalid recommendations type={}",
+            _LOG_PREFIX,
+            type(recommendations).__name__,
+        )
+        return []
+    return [item for item in recommendations if isinstance(item, dict)]
+
+
+def _run_item_post_checks(item: TopicRecommendationItemPayload, *, index: int) -> None:
+    """Apply scalar and list item rules beyond Pydantic type checks."""
+    data = item.model_dump()
+
+    for field_name in _ITEM_SCALAR_FIELDS:
+        value = data[field_name]
+        cleaned = clean_str(value)
+        if cleaned == "":
+            logger.error(
+                "{} post-check empty scalar field={} index={}",
+                _LOG_PREFIX,
+                field_name,
+                index,
+            )
+            raise TopicRecommendationValidationError(
+                f"Topic recommendation[{index}] field {field_name!r} must not be empty",
+                validation_code="empty_scalar",
+            )
+        if cleaned != value:
+            logger.error(
+                "{} post-check untrimmed scalar field={} index={}",
+                _LOG_PREFIX,
+                field_name,
+                index,
+            )
+            raise TopicRecommendationValidationError(
+                f"Topic recommendation[{index}] field {field_name!r} must not contain "
+                "leading or trailing whitespace",
+                validation_code="untrimmed_scalar",
+            )
+
+    if data["recommended_format"] not in RECOMMENDED_FORMATS:
+        logger.error(
+            "{} post-check invalid recommended_format={} index={} allowed={}",
+            _LOG_PREFIX,
+            data["recommended_format"],
+            index,
+            RECOMMENDED_FORMATS,
+        )
+        raise TopicRecommendationValidationError(
+            f"Topic recommendation[{index}] recommended_format is invalid",
+            validation_code="invalid_format",
+        )
+
+    if data["growth_impact"] not in GROWTH_IMPACTS:
+        logger.error(
+            "{} post-check invalid growth_impact={} index={} allowed={}",
+            _LOG_PREFIX,
+            data["growth_impact"],
+            index,
+            GROWTH_IMPACTS,
+        )
+        raise TopicRecommendationValidationError(
+            f"Topic recommendation[{index}] growth_impact is invalid",
+            validation_code="invalid_growth_impact",
+        )
+
+    audience = data["target_audience"]
+    if not audience:
+        logger.error(
+            "{} post-check empty target_audience index={}",
+            _LOG_PREFIX,
+            index,
+        )
+        raise TopicRecommendationValidationError(
+            f"Topic recommendation[{index}] target_audience must not be empty",
+            validation_code="empty_audience",
+        )
+
+    for audience_index, audience_item in enumerate(audience):
+        if not isinstance(audience_item, str):
+            logger.error(
+                "{} post-check audience item not string index={} audience_index={}",
+                _LOG_PREFIX,
+                index,
+                audience_index,
+            )
+            raise TopicRecommendationValidationError(
+                f"Topic recommendation[{index}] target_audience items must be strings",
+                validation_code="invalid_audience_item",
+            )
+        if clean_str(audience_item) == "":
+            logger.error(
+                "{} post-check empty audience item index={} audience_index={}",
+                _LOG_PREFIX,
+                index,
+                audience_index,
+            )
+            raise TopicRecommendationValidationError(
+                f"Topic recommendation[{index}] target_audience contains an empty item",
+                validation_code="empty_audience_item",
+            )

--- a/backend/services/integrations/linkedin/types.py
+++ b/backend/services/integrations/linkedin/types.py
@@ -1,0 +1,193 @@
+"""
+Normalized types for LinkedIn Growth Engine (provider-agnostic).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Literal, Optional
+
+DEFAULT_ZERNIO_API_URL = "https://zernio.com/api/v1"
+DEFAULT_UNIPILE_DSN = "api30.unipile.com:16037"
+
+
+ProviderMode = Literal["zernio", "native", "unipile"]
+ProfileAggregation = Literal["TOTAL", "DAILY"]
+OrgMetricType = Literal["total_value", "time_series"]
+
+
+class LinkedInNotConnectedError(Exception):
+    """Raised when no LinkedIn credentials are available for a user."""
+
+
+@dataclass(frozen=True)
+class LinkedInCredentials:
+    """
+    LinkedIn credentials for all provider modes (Zernio, Unipile, Native).
+
+    Fields are provider-specific:
+    - Zernio: zernio_api_key, zernio_profile_id, zernio_account_id
+    - Unipile: unipile_account_id, unipile_org_account_id (no API key stored, uses env var)
+    - Native: linkedin_access_token, linkedin_refresh_token
+    """
+
+    provider_mode: ProviderMode
+    # Zernio fields (legacy, maintained for backward compatibility)
+    zernio_api_key: Optional[str] = None
+    zernio_profile_id: Optional[str] = None
+    zernio_account_id: Optional[str] = None
+    zernio_org_account_id: Optional[str] = None
+    zernio_api_url: str = DEFAULT_ZERNIO_API_URL
+    # Unipile fields (Phase 1)
+    unipile_account_id: Optional[str] = None
+    unipile_org_account_id: Optional[str] = None
+    unipile_dsn: str = DEFAULT_UNIPILE_DSN
+    # Native OAuth fields
+    linkedin_access_token: Optional[str] = None
+    linkedin_refresh_token: Optional[str] = None
+    # Common fields
+    account_name: Optional[str] = None
+    profile_urn: Optional[str] = None
+    source: Literal["database", "environment"] = "database"
+
+    @classmethod
+    def from_db_row(
+        cls,
+        row: dict[str, Any],
+        *,
+        decrypted: bool = True,
+    ) -> LinkedInCredentials:
+        """
+        Create LinkedInCredentials from a database row dictionary.
+
+        Handles all provider modes (zernio, unipile, native) with appropriate
+        field mapping for each.
+        """
+        provider_mode = row.get("provider_mode", "zernio")
+
+        return cls(
+            provider_mode=provider_mode,
+            # Zernio fields
+            zernio_api_key=row.get("zernio_api_key"),
+            zernio_profile_id=row.get("zernio_profile_id"),
+            zernio_account_id=row.get("zernio_account_id"),
+            zernio_org_account_id=row.get("zernio_org_account_id"),
+            zernio_api_url=row.get("zernio_api_url")
+            or os.getenv("ZERNIO_API_URL", DEFAULT_ZERNIO_API_URL),
+            # Unipile fields (Phase 1)
+            unipile_account_id=row.get("unipile_account_id"),
+            unipile_org_account_id=row.get("unipile_org_account_id"),
+            unipile_dsn=row.get("unipile_dsn")
+            or os.getenv("UNIPILE_DSN", DEFAULT_UNIPILE_DSN),
+            # Native fields
+            linkedin_access_token=row.get("linkedin_access_token"),
+            linkedin_refresh_token=row.get("linkedin_refresh_token"),
+            # Common fields
+            account_name=row.get("account_name"),
+            profile_urn=row.get("profile_urn"),
+            source="database",
+        )
+
+    @property
+    def primary_account_id(self) -> Optional[str]:
+        """
+        Get the primary account ID for the current provider mode.
+
+        Returns:
+            Account ID for zernio, unipile, or native mode
+        """
+        if self.provider_mode == "unipile":
+            return self.unipile_account_id
+        # Default to Zernio for 'zernio' and legacy records
+        return self.zernio_account_id
+
+    @property
+    def org_account_id(self) -> Optional[str]:
+        """
+        Get the organization account ID for the current provider mode.
+
+        Returns:
+            Organization account ID or primary account ID as fallback
+        """
+        if self.provider_mode == "unipile":
+            return self.unipile_org_account_id or self.unipile_account_id
+        # Default to Zernio for 'zernio' and legacy records
+        return self.zernio_org_account_id or self.zernio_account_id
+
+
+@dataclass(frozen=True)
+class LinkedInAccount:
+    account_id: str
+    account_type: Optional[str] = None
+    username: Optional[str] = None
+    avatar_url: Optional[str] = None
+    platform: str = "linkedin"
+
+
+@dataclass(frozen=True)
+class LinkedInOrganization:
+    organization_id: str
+    name: Optional[str] = None
+    urn: Optional[str] = None
+    logo_url: Optional[str] = None
+
+
+@dataclass
+class CreatePostRequest:
+    account_id: str
+    content: str
+    organization_urn: Optional[str] = None
+    first_comment: Optional[str] = None
+    media_urls: list[str] = field(default_factory=list)
+    scheduled_at: Optional[str] = None
+
+
+@dataclass
+class CreatePostResult:
+    success: bool
+    post_id: Optional[str] = None
+    post_urn: Optional[str] = None
+    raw: dict[str, Any] = field(default_factory=dict)
+    error: Optional[str] = None
+
+
+@dataclass
+class MediaUploadResult:
+    success: bool
+    media_id: Optional[str] = None
+    url: Optional[str] = None
+    raw: dict[str, Any] = field(default_factory=dict)
+    error: Optional[str] = None
+
+
+@dataclass
+class CommentInfo:
+    comment_id: str
+    text: Optional[str] = None
+    author: Optional[str] = None
+    created_at: Optional[str] = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ReplyResult:
+    success: bool
+    comment_id: Optional[str] = None
+    raw: dict[str, Any] = field(default_factory=dict)
+    error: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class DuplicateCheckResult:
+    is_duplicate: bool
+    content_hash: str
+    matched_asset_id: Optional[int] = None
+    reason: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class MediaValidationResult:
+    valid: bool
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)

--- a/backend/services/integrations/linkedin/unipile_client.py
+++ b/backend/services/integrations/linkedin/unipile_client.py
@@ -1,0 +1,526 @@
+"""
+Low-level Unipile HTTP client for LinkedIn Growth Engine.
+
+This client provides minimal functionality for Phase 1:
+- Generate hosted auth link for LinkedIn connection
+- Fetch account details
+- List connected accounts
+- Delete/disconnect account
+
+Analytics and publishing methods are stubbed for future phases.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Optional
+from urllib.parse import quote
+
+import httpx
+from loguru import logger
+
+from services.integrations.linkedin.zernio_client import avatar_url_from_item
+
+
+DEFAULT_UNIPILE_DSN = "api30.unipile.com:16037"
+
+
+class UnipileAPIError(RuntimeError):
+    """Raised when the Unipile API returns an error response."""
+
+    def __init__(self, message: str, *, status_code: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _auth_headers(api_key: str) -> dict[str, str]:
+    """Build authentication headers for Unipile API."""
+    return {
+        "X-API-KEY": api_key,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+
+def _raise_for_error(response: httpx.Response) -> None:
+    """Raise UnipileAPIError for non-success status codes."""
+    if response.status_code < 400:
+        return
+    raise UnipileAPIError(
+        f"Unipile API returned HTTP {response.status_code}: {response.text}",
+        status_code=response.status_code,
+    )
+
+
+def _normalize_account_list(data: Any) -> list[dict[str, Any]]:
+    """
+    Normalize Unipile list-accounts response into a flat list of account dicts.
+
+    Unipile may return paginated objects under different keys or a top-level array.
+    """
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+
+    if not isinstance(data, dict):
+        return []
+
+    for key in ("items", "accounts", "data", "objects"):
+        candidate = data.get(key)
+        if isinstance(candidate, list):
+            return [item for item in candidate if isinstance(item, dict)]
+
+    return []
+
+
+def profile_identifier_from_owner(owner: dict[str, Any]) -> Optional[str]:
+    """
+    Extract a LinkedIn profile identifier from an AccountOwnerProfile payload.
+
+    Unipile accepts ``public_identifier`` or ``provider_id`` on
+    ``GET /api/v1/users/{identifier}``.
+
+    Args:
+        owner: Raw dict from ``GET /api/v1/users/me``
+
+    Returns:
+        Identifier string, or None when neither field is present
+    """
+    if not isinstance(owner, dict):
+        return None
+    for key in ("public_identifier", "provider_id"):
+        value = owner.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def avatar_url_from_user_profile(item: dict[str, Any]) -> Optional[str]:
+    """
+    Extract profile photo URL from a Unipile UserProfile payload.
+
+    Prefers large variants when available (LinkedIn CDN URLs from Users API).
+    """
+    if not isinstance(item, dict):
+        return None
+
+    for key in (
+        "profile_picture_url_large",
+        "public_picture_url_large",
+        "profile_picture_url",
+        "public_picture_url",
+        "profile_picture",
+        "avatar_url",
+        "picture_url",
+    ):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip().startswith("http"):
+            return value.strip()
+
+    return avatar_url_from_item(item)
+
+
+@dataclass(frozen=True)
+class HostedAuthLinkResult:
+    """Result from creating a hosted auth link."""
+
+    auth_url: str
+    expires_at: datetime
+
+
+class UnipileClient:
+    """Async HTTP client for Unipile LinkedIn endpoints."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        dsn: Optional[str] = None,
+        timeout: float = 30.0,
+    ):
+        """
+        Initialize Unipile client.
+
+        Args:
+            api_key: Unipile API key. Defaults to UNIPILE_API_KEY env var.
+            dsn: Unipile DSN (e.g., api1.unipile.com:13211). Defaults to UNIPILE_DSN env var.
+            timeout: Request timeout in seconds.
+        """
+        self._api_key = api_key or os.getenv("UNIPILE_API_KEY", "")
+        if not self._api_key:
+            logger.warning("Unipile API key not configured")
+
+        self._dsn = dsn or os.getenv("UNIPILE_DSN", DEFAULT_UNIPILE_DSN)
+        self._base_url = f"https://{self._dsn}"
+        self._timeout = timeout
+
+    def _get_full_url(self, path: str) -> str:
+        """Build full URL from API path."""
+        return f"{self._base_url.rstrip('/')}/{path.lstrip('/')}"
+
+    async def create_hosted_auth_link(
+        self,
+        user_id: str,
+        success_redirect_url: str,
+        failure_redirect_url: str,
+        notify_url: str,
+        providers: list[str] = None,
+        expires_minutes: int = 120,
+    ) -> HostedAuthLinkResult:
+        """
+        Generate a hosted auth link for LinkedIn connection.
+
+        This creates a Unipile-hosted authentication page that handles
+        the LinkedIn OAuth flow. The user will be redirected to
+        success_redirect_url or failure_redirect_url after completion.
+
+        Args:
+            user_id: Internal user ID (stored as 'name' in Unipile for matching)
+            success_redirect_url: URL to redirect on successful auth
+            failure_redirect_url: URL to redirect on failed auth
+            notify_url: Webhook URL for account status notifications
+            providers: List of providers to show (default: ["LINKEDIN"])
+            expires_minutes: Link expiration time (default: 120 minutes)
+
+        Returns:
+            HostedAuthLinkResult with auth_url and expiration time
+
+        Raises:
+            UnipileAPIError: If the API request fails
+            ValueError: If API key is not configured
+        """
+        if not self._api_key:
+            raise ValueError("Unipile API key is required")
+
+        providers = providers or ["LINKEDIN"]
+        expires_at = datetime.utcnow() + timedelta(minutes=expires_minutes)
+
+        # Format expiresOn to exactly 3 decimal places (milliseconds) as required by Unipile API
+        # Unipile's regex pattern requires: YYYY-MM-DDTHH:MM:SS.sssZ (exactly 3 digits)
+        expires_ms = expires_at.microsecond // 1000
+        expires_on_formatted = expires_at.strftime("%Y-%m-%dT%H:%M:%S") + f".{expires_ms:03d}Z"
+
+        url = self._get_full_url("/api/v1/hosted/accounts/link")
+        payload: dict[str, Any] = {
+            "type": "create",
+            "providers": providers,
+            "api_url": self._base_url,
+            "expiresOn": expires_on_formatted,
+            "success_redirect_url": success_redirect_url,
+            "failure_redirect_url": failure_redirect_url,
+            "notify_url": notify_url,
+            "name": user_id,  # Unipile returns this in callbacks for user matching
+            "bypass_success_screen": True,
+        }
+
+        logger.info(
+            f"[UnipileClient] Creating hosted auth link for user={user_id}, "
+            f"providers={providers}, expires_at={expires_at.isoformat()}"
+        )
+
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.post(
+                url,
+                json=payload,
+                headers=_auth_headers(self._api_key),
+            )
+            _raise_for_error(response)
+            data = response.json()
+
+        # Try multiple possible field names for the auth URL
+        # Unipile API may return 'link', 'url', 'auth_url', or 'hosted_auth_url'
+        auth_url = data.get("link") or data.get("url") or data.get("auth_url") or data.get("hosted_auth_url")
+        if not auth_url:
+            logger.warning(
+                f"[UnipileClient] Response missing expected auth URL field. "
+                f"Available fields: {list(data.keys())}"
+            )
+            raise UnipileAPIError(
+                f"Unipile response missing auth URL field. Available fields: {list(data.keys())}",
+                status_code=response.status_code,
+            )
+
+        logger.info(f"[UnipileClient] Hosted auth link created for user={user_id}")
+
+        return HostedAuthLinkResult(auth_url=auth_url, expires_at=expires_at)
+
+    async def get_account(self, account_id: str) -> dict[str, Any]:
+        """
+        Fetch account details from Unipile.
+
+        Args:
+            account_id: Unipile account ID
+
+        Returns:
+            Account details dictionary
+
+        Raises:
+            UnipileAPIError: If the account is not found or request fails
+        """
+        if not self._api_key:
+            raise ValueError("Unipile API key is required")
+
+        url = self._get_full_url(f"/api/v1/accounts/{account_id}")
+
+        logger.debug(f"[UnipileClient] Fetching account {account_id}")
+
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(url, headers=_auth_headers(self._api_key))
+            _raise_for_error(response)
+            return response.json()
+
+    async def get_own_profile(self, account_id: str) -> dict[str, Any]:
+        """
+        Fetch the connected account owner's lightweight LinkedIn profile.
+
+        Uses Unipile Users API ``GET /api/v1/users/me`` scoped to the account.
+        Returns ``AccountOwnerProfile`` (identity, photos, counts) — not the
+        section-rich ``UserProfile``. For full sections use ``get_user_profile``
+        with the owner's ``public_identifier`` or ``provider_id``.
+
+        Args:
+            account_id: Unipile account ID for the connected LinkedIn account
+
+        Returns:
+            AccountOwnerProfile dictionary from Unipile
+
+        Raises:
+            UnipileAPIError: If the request fails
+            ValueError: If API key is not configured
+        """
+        if not self._api_key:
+            raise ValueError("Unipile API key is required")
+
+        url = self._get_full_url("/api/v1/users/me")
+        params: dict[str, str] = {"account_id": account_id}
+
+        logger.debug(
+            f"[UnipileClient] Fetching own profile account_id={account_id}"
+        )
+
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(
+                url, params=params, headers=_auth_headers(self._api_key)
+            )
+            _raise_for_error(response)
+            data = response.json()
+
+        if isinstance(data, dict):
+            logger.info(
+                f"[UnipileClient] Own profile fetched account_id={account_id} "
+                f"object={data.get('object')!r} "
+                f"public_identifier={data.get('public_identifier')!r} "
+                f"keys={list(data.keys())}"
+            )
+        return data
+
+    async def get_user_profile(
+        self,
+        account_id: str,
+        identifier: str,
+        *,
+        linkedin_sections: Optional[str] = None,
+        notify: Optional[bool] = None,
+    ) -> dict[str, Any]:
+        """
+        Fetch a LinkedIn user profile by public identifier or provider id.
+
+        Uses ``GET /api/v1/users/{identifier}`` which returns ``UserProfile``.
+        Pass ``linkedin_sections=*`` for experience, skills, education, about, etc.
+
+        Args:
+            account_id: Unipile account ID
+            identifier: LinkedIn public identifier (e.g. ``johndoe``) or provider id
+            linkedin_sections: Optional sections query (e.g. ``*`` for full profile)
+            notify: When ``False``, avoids notifying the profile owner on visit
+
+        Returns:
+            UserProfile dictionary from Unipile
+
+        Raises:
+            UnipileAPIError: If the request fails
+            ValueError: If API key is not configured
+        """
+        if not self._api_key:
+            raise ValueError("Unipile API key is required")
+
+        encoded_identifier = quote(identifier, safe="")
+        url = self._get_full_url(f"/api/v1/users/{encoded_identifier}")
+        params: dict[str, Any] = {"account_id": account_id}
+        if linkedin_sections is not None:
+            params["linkedin_sections"] = linkedin_sections
+        if notify is not None:
+            params["notify"] = notify
+
+        logger.debug(
+            f"[UnipileClient] Fetching user profile account_id={account_id} "
+            f"identifier={identifier} linkedin_sections={linkedin_sections!r} "
+            f"notify={notify!r}"
+        )
+
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(
+                url, params=params, headers=_auth_headers(self._api_key)
+            )
+            _raise_for_error(response)
+            data = response.json()
+
+        if isinstance(data, dict):
+            logger.info(
+                f"[UnipileClient] User profile fetched account_id={account_id} "
+                f"identifier={identifier} linkedin_sections={linkedin_sections!r} "
+                f"object={data.get('object')!r} is_self={data.get('is_self')!r} "
+                f"keys={list(data.keys())}"
+            )
+        return data
+
+    async def list_accounts(
+        self, provider: Optional[str] = "LINKEDIN"
+    ) -> list[dict[str, Any]]:
+        """
+        List connected accounts from Unipile.
+
+        Args:
+            provider: Filter by provider (e.g., "LINKEDIN"). None for all.
+
+        Returns:
+            List of account dictionaries
+        """
+        if not self._api_key:
+            raise ValueError("Unipile API key is required")
+
+        url = self._get_full_url("/api/v1/accounts")
+        params: dict[str, str] = {}
+        if provider:
+            params["provider"] = provider
+
+        logger.debug(f"[UnipileClient] Listing accounts, provider={provider}")
+
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(
+                url, params=params, headers=_auth_headers(self._api_key)
+            )
+            _raise_for_error(response)
+            data = response.json()
+
+        raw_keys = list(data.keys()) if isinstance(data, dict) else ["<list>"]
+        items = _normalize_account_list(data)
+
+        if not items:
+            logger.warning(
+                f"[UnipileClient] list_accounts returned HTTP 200 but parsed 0 accounts "
+                f"(raw_keys={raw_keys}, provider={provider})"
+            )
+        else:
+            logger.info(
+                f"[UnipileClient] Listed {len(items)} accounts (raw_keys={raw_keys}, provider={provider})"
+            )
+
+        return items
+
+    async def delete_account(self, account_id: str) -> bool:
+        """
+        Delete/disconnect an account from Unipile.
+
+        Args:
+            account_id: Unipile account ID to delete
+
+        Returns:
+            True if deletion was successful, False otherwise
+        """
+        if not self._api_key:
+            logger.warning("Cannot delete account: Unipile API key not configured")
+            return False
+
+        url = self._get_full_url(f"/api/v1/accounts/{account_id}")
+
+        logger.info(f"[UnipileClient] Deleting account {account_id}")
+
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                response = await client.delete(url, headers=_auth_headers(self._api_key))
+                if response.status_code < 400:
+                    logger.info(f"[UnipileClient] Account {account_id} deleted successfully")
+                    return True
+                else:
+                    logger.warning(
+                        f"[UnipileClient] Failed to delete account {account_id}: "
+                        f"HTTP {response.status_code}"
+                    )
+                    return False
+        except Exception as e:
+            logger.error(f"[UnipileClient] Error deleting account {account_id}: {e}")
+            return False
+
+    async def reconnect_account(
+        self,
+        account_id: str,
+        success_redirect_url: str,
+        failure_redirect_url: str,
+        notify_url: str,
+        expires_minutes: int = 120,
+    ) -> HostedAuthLinkResult:
+        """
+        Generate a reconnection link for an existing disconnected account.
+
+        Args:
+            account_id: Existing Unipile account ID to reconnect
+            success_redirect_url: URL to redirect on successful reconnection
+            failure_redirect_url: URL to redirect on failed reconnection
+            notify_url: Webhook URL for account status notifications
+            expires_minutes: Link expiration time (default: 120 minutes)
+
+        Returns:
+            HostedAuthLinkResult with reconnection URL
+        """
+        if not self._api_key:
+            raise ValueError("Unipile API key is required")
+
+        expires_at = datetime.utcnow() + timedelta(minutes=expires_minutes)
+
+        # Format expiresOn to exactly 3 decimal places (milliseconds) as required by Unipile API
+        # Unipile's regex pattern requires: YYYY-MM-DDTHH:MM:SS.sssZ (exactly 3 digits)
+        expires_ms = expires_at.microsecond // 1000
+        expires_on_formatted = expires_at.strftime("%Y-%m-%dT%H:%M:%S") + f".{expires_ms:03d}Z"
+
+        url = self._get_full_url("/api/v1/hosted/accounts/link")
+        payload: dict[str, Any] = {
+            "type": "reconnect",
+            "reconnect_account": account_id,
+            "api_url": self._base_url,
+            "expiresOn": expires_on_formatted,
+            "success_redirect_url": success_redirect_url,
+            "failure_redirect_url": failure_redirect_url,
+            "notify_url": notify_url,
+        }
+
+        logger.info(
+            f"[UnipileClient] Creating reconnection link for account={account_id}, "
+            f"expires_at={expires_at.isoformat()}"
+        )
+
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.post(
+                url,
+                json=payload,
+                headers=_auth_headers(self._api_key),
+            )
+            _raise_for_error(response)
+            data = response.json()
+
+        # Try multiple possible field names for the auth URL
+        # Unipile API may return 'link', 'url', 'auth_url', or 'hosted_auth_url'
+        auth_url = data.get("link") or data.get("url") or data.get("auth_url") or data.get("hosted_auth_url")
+        if not auth_url:
+            logger.warning(
+                f"[UnipileClient] Response missing expected auth URL field. "
+                f"Available fields: {list(data.keys())}"
+            )
+            raise UnipileAPIError(
+                f"Unipile response missing auth URL field. Available fields: {list(data.keys())}",
+                status_code=response.status_code,
+            )
+
+        logger.info(f"[UnipileClient] Reconnection link created for account={account_id}")
+
+        return HostedAuthLinkResult(auth_url=auth_url, expires_at=expires_at)

--- a/backend/services/integrations/linkedin/unipile_provider.py
+++ b/backend/services/integrations/linkedin/unipile_provider.py
@@ -1,0 +1,716 @@
+"""
+Unipile implementation of LinkedInSocialProvider for account connection (Phase 1).
+
+This provider implements the LinkedInSocialProvider protocol using Unipile's API.
+Phase 1 focuses on connection/disconnection only. Analytics and publishing methods
+raise NotImplementedError and will be implemented in subsequent phases.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+from loguru import logger
+
+from services.integrations.linkedin.protocol import LinkedInSocialProvider
+from services.integrations.linkedin.types import (
+    CommentInfo,
+    CreatePostRequest,
+    CreatePostResult,
+    LinkedInAccount,
+    LinkedInNotConnectedError,
+    LinkedInOrganization,
+    MediaUploadResult,
+    OrgMetricType,
+    ProfileAggregation,
+    ReplyResult,
+)
+from services.integrations.linkedin.unipile_client import (
+    UnipileClient,
+    UnipileAPIError,
+    avatar_url_from_user_profile,
+    profile_identifier_from_owner,
+)
+from services.integrations.linkedin.zernio_client import avatar_url_from_item
+from services.integrations.linkedin_oauth import LinkedInOAuthService
+
+
+# Error messages for Phase 1 (methods not yet implemented)
+_ANALYTICS_NOT_IMPLEMENTED = (
+    "LinkedIn analytics via Unipile is not implemented in Phase 1. "
+    "This feature is planned for Phase 3."
+)
+_PUBLISHING_NOT_IMPLEMENTED = (
+    "LinkedIn publishing via Unipile is not implemented in Phase 1. "
+    "This feature is planned for Phase 4."
+)
+_COMMENTS_NOT_IMPLEMENTED = (
+    "LinkedIn comment management via Unipile is not implemented in Phase 1. "
+    "This feature is planned for Phase 4."
+)
+_ORGANIZATIONS_NOT_IMPLEMENTED = (
+    "LinkedIn organization management via Unipile is not implemented in Phase 1. "
+    "This feature is planned for Phase 2."
+)
+
+
+def _is_internal_user_id(value: Optional[str]) -> bool:
+    """Return True when a value looks like ALwrity's internal Clerk user id."""
+    if not value or not isinstance(value, str):
+        return False
+    normalized = value.strip()
+    return normalized.startswith("user_")
+
+
+def unipile_avatar_url_from_item(item: dict[str, Any]) -> Optional[str]:
+    """Extract avatar URL from a Unipile account or user profile payload."""
+    url = avatar_url_from_user_profile(item)
+    if url:
+        return url
+
+    profile = item.get("profile")
+    if isinstance(profile, dict):
+        nested = avatar_url_from_user_profile(profile)
+        if nested:
+            return nested
+
+    return avatar_url_from_item(item)
+
+
+def unipile_display_name_from_item(
+    item: dict[str, Any],
+    *,
+    user_id: str,
+    stored_account_name: Optional[str] = None,
+) -> Optional[str]:
+    """
+    Resolve a human-readable LinkedIn display name from Unipile account data.
+
+    Unipile hosted-auth stores ALwrity's internal user id in ``name``; that value
+    must not be shown as the LinkedIn profile name.
+    """
+    for key in ("username", "display_name", "profile_name"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            candidate = value.strip()
+            if not _is_internal_user_id(candidate) and candidate != user_id:
+                return candidate
+
+    profile = item.get("profile")
+    if isinstance(profile, dict):
+        nested = unipile_display_name_from_item(
+            profile,
+            user_id=user_id,
+            stored_account_name=None,
+        )
+        if nested:
+            return nested
+
+    name = item.get("name")
+    if isinstance(name, str) and name.strip():
+        candidate = name.strip()
+        if not _is_internal_user_id(candidate) and candidate != user_id:
+            return candidate
+
+    if stored_account_name and not _is_internal_user_id(stored_account_name):
+        return stored_account_name.strip()
+
+    return None
+
+
+class UnipileProvider:
+    """
+    LinkedIn platform operations via Unipile REST API (Phase 1 - Connection Only).
+
+    This provider implements connection/disconnection functionality using
+    Unipile's Hosted Auth Wizard. Analytics, publishing, and comment
+    management are stubbed and will be implemented in future phases.
+
+    Provider name: 'unipile'
+    """
+
+    provider_name = "unipile"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        dsn: Optional[str] = None,
+        oauth_service: Optional[LinkedInOAuthService] = None,
+    ):
+        """
+        Initialize Unipile provider.
+
+        Args:
+            api_key: Unipile API key. Defaults to UNIPILE_API_KEY env var.
+            dsn: Unipile DSN. Defaults to UNIPILE_DSN env var.
+            oauth_service: OAuth service for credential lookup and stored names.
+        """
+        self._client = UnipileClient(api_key=api_key, dsn=dsn)
+        self._oauth = oauth_service or LinkedInOAuthService()
+        logger.info("[UnipileProvider] Initialized (Phase 1 - Connection Only)")
+
+    def _account_id_from_item(self, item: dict[str, Any]) -> Optional[str]:
+        raw = item.get("id") or item.get("account_id")
+        return str(raw) if raw else None
+
+    def _item_matches_user(
+        self,
+        item: dict[str, Any],
+        *,
+        user_id: str,
+        user_account_ids: set[str],
+    ) -> bool:
+        account_id = self._account_id_from_item(item)
+        if account_id and account_id in user_account_ids:
+            return True
+        hosted_name = item.get("name")
+        return isinstance(hosted_name, str) and hosted_name == user_id
+
+    async def _resolve_avatar_url(
+        self,
+        account_id: str,
+        *sources: dict[str, Any],
+    ) -> Optional[str]:
+        """
+        Resolve LinkedIn profile photo URL for a Unipile account.
+
+        Tries account/list payloads first, then Account API, then Users API (``/users/me``).
+        """
+        for source in sources:
+            url = unipile_avatar_url_from_item(source)
+            if url:
+                return url
+
+        account_detail: dict[str, Any] = {}
+        try:
+            account_detail = await self._client.get_account(account_id)
+            url = unipile_avatar_url_from_item(account_detail)
+            if url:
+                logger.info(
+                    f"[UnipileProvider] Avatar resolved via get_account "
+                    f"account_id={account_id}"
+                )
+                return url
+        except UnipileAPIError as exc:
+            logger.debug(
+                f"[UnipileProvider] get_account avatar lookup failed "
+                f"account_id={account_id}: {exc}"
+            )
+        except Exception as exc:
+            logger.debug(
+                f"[UnipileProvider] get_account avatar lookup error "
+                f"account_id={account_id}: {exc}"
+            )
+
+        try:
+            profile = await self._client.get_own_profile(account_id)
+            url = unipile_avatar_url_from_item(profile)
+            if url:
+                logger.info(
+                    f"[UnipileProvider] Avatar resolved via users/me "
+                    f"account_id={account_id}"
+                )
+                return url
+            logger.warning(
+                f"[UnipileProvider] users/me returned no avatar account_id={account_id} "
+                f"keys={list(profile.keys()) if isinstance(profile, dict) else profile}"
+            )
+        except UnipileAPIError as exc:
+            logger.warning(
+                f"[UnipileProvider] get_own_profile failed account_id={account_id}: {exc}"
+            )
+        except Exception as exc:
+            logger.warning(
+                f"[UnipileProvider] get_own_profile error account_id={account_id}: {exc}"
+            )
+
+        for id_key in ("public_identifier", "provider_id", "username"):
+            identifier = account_detail.get(id_key)
+            if not isinstance(identifier, str) or not identifier.strip():
+                continue
+            try:
+                profile = await self._client.get_user_profile(
+                    account_id, identifier.strip()
+                )
+                url = unipile_avatar_url_from_item(profile)
+                if url:
+                    logger.info(
+                        f"[UnipileProvider] Avatar resolved via users/{id_key} "
+                        f"account_id={account_id}"
+                    )
+                    return url
+            except UnipileAPIError as exc:
+                logger.debug(
+                    f"[UnipileProvider] get_user_profile failed account_id={account_id} "
+                    f"identifier={identifier}: {exc}"
+                )
+            except Exception as exc:
+                logger.debug(
+                    f"[UnipileProvider] get_user_profile error account_id={account_id}: {exc}"
+                )
+
+        return None
+
+    async def _build_account_from_item(
+        self,
+        item: dict[str, Any],
+        *,
+        user_id: str,
+        stored_account_name: Optional[str],
+    ) -> Optional[LinkedInAccount]:
+        account_id = self._account_id_from_item(item)
+        if not account_id:
+            logger.warning(f"[UnipileProvider] Skipping account with no ID: {item}")
+            return None
+
+        account_type = item.get("account_type") or item.get("type") or "personal"
+        username = unipile_display_name_from_item(
+            item,
+            user_id=user_id,
+            stored_account_name=stored_account_name,
+        )
+
+        if not username:
+            try:
+                detail = await self._client.get_account(account_id)
+                username = unipile_display_name_from_item(
+                    detail,
+                    user_id=user_id,
+                    stored_account_name=stored_account_name,
+                )
+            except Exception as exc:
+                logger.debug(
+                    f"[UnipileProvider] get_account name enrichment failed "
+                    f"account_id={account_id}: {exc}"
+                )
+
+        avatar_url = await self._resolve_avatar_url(account_id, item)
+
+        return LinkedInAccount(
+            account_id=account_id,
+            account_type=str(account_type),
+            username=username,
+            avatar_url=avatar_url,
+            platform="linkedin",
+        )
+
+    async def list_accounts(self, user_id: str) -> list[LinkedInAccount]:
+        """
+        List connected LinkedIn accounts from Unipile for the current user.
+
+        Args:
+            user_id: Internal user ID (for logging/matching purposes)
+
+        Returns:
+            List of LinkedInAccount objects
+        """
+        logger.info(f"[UnipileProvider] Listing accounts for user={user_id}")
+
+        try:
+            creds = self._oauth.resolve_credentials(user_id)
+        except LinkedInNotConnectedError:
+            logger.warning(
+                f"[UnipileProvider] list_accounts skipped — user not connected user={user_id}"
+            )
+            raise
+
+        stored_account_name = creds.account_name
+        user_account_ids = {
+            account_id
+            for account_id in (creds.unipile_account_id, creds.unipile_org_account_id)
+            if account_id
+        }
+
+        try:
+            items = await self._client.list_accounts(provider="LINKEDIN")
+            matched_items = [
+                item
+                for item in items
+                if isinstance(item, dict)
+                and self._item_matches_user(
+                    item,
+                    user_id=user_id,
+                    user_account_ids=user_account_ids,
+                )
+            ]
+
+            accounts: list[LinkedInAccount] = []
+            for item in matched_items:
+                account = await self._build_account_from_item(
+                    item,
+                    user_id=user_id,
+                    stored_account_name=stored_account_name,
+                )
+                if account:
+                    accounts.append(account)
+
+            if not accounts and creds.unipile_account_id:
+                logger.info(
+                    f"[UnipileProvider] list_accounts fallback to stored account_id="
+                    f"{creds.unipile_account_id} user={user_id}"
+                )
+                try:
+                    detail = await self._client.get_account(creds.unipile_account_id)
+                    account = await self._build_account_from_item(
+                        detail,
+                        user_id=user_id,
+                        stored_account_name=stored_account_name,
+                    )
+                    if account:
+                        accounts.append(account)
+                except Exception as exc:
+                    logger.warning(
+                        f"[UnipileProvider] Stored account fetch failed user={user_id}: {exc}"
+                    )
+                    accounts.append(
+                        LinkedInAccount(
+                            account_id=creds.unipile_account_id,
+                            account_type="personal",
+                            username=(
+                                stored_account_name
+                                if stored_account_name
+                                and not _is_internal_user_id(stored_account_name)
+                                else None
+                            ),
+                            platform="linkedin",
+                        )
+                    )
+
+            enriched_accounts: list[LinkedInAccount] = []
+            for account in accounts:
+                if account.avatar_url:
+                    enriched_accounts.append(account)
+                    continue
+                avatar_url = await self._resolve_avatar_url(account.account_id)
+                enriched_accounts.append(
+                    LinkedInAccount(
+                        account_id=account.account_id,
+                        account_type=account.account_type,
+                        username=account.username,
+                        avatar_url=avatar_url,
+                        platform=account.platform,
+                    )
+                )
+            accounts = enriched_accounts
+
+            if (
+                creds.unipile_org_account_id
+                and creds.unipile_org_account_id != creds.unipile_account_id
+                and not any(
+                    account.account_id == creds.unipile_org_account_id for account in accounts
+                )
+            ):
+                accounts.append(
+                    LinkedInAccount(
+                        account_id=creds.unipile_org_account_id,
+                        account_type="organization",
+                        username=(
+                            stored_account_name
+                            if stored_account_name
+                            and not _is_internal_user_id(stored_account_name)
+                            else None
+                        ),
+                        platform="linkedin",
+                    )
+                )
+
+            logger.info(
+                f"[UnipileProvider] Found {len(accounts)} LinkedIn accounts for user={user_id}"
+            )
+            return accounts
+
+        except UnipileAPIError as e:
+            logger.error(
+                f"[UnipileProvider] Failed to list accounts for user={user_id}: {e}"
+            )
+            return []
+        except Exception as e:
+            logger.exception(
+                f"[UnipileProvider] Unexpected error listing accounts for user={user_id}: {e}"
+            )
+            return []
+
+    async def fetch_own_linkedin_profile(
+        self,
+        user_id: str,
+        *,
+        linkedin_sections: str = "*",
+    ) -> dict[str, Any]:
+        """
+        Fetch the connected user's full LinkedIn UserProfile from Unipile.
+
+        Uses a two-step v1 flow:
+        1. ``GET /api/v1/users/me`` → ``AccountOwnerProfile`` (resolve identifier)
+        2. ``GET /api/v1/users/{identifier}?linkedin_sections=*`` → ``UserProfile``
+
+        The ``linkedin_sections`` parameter is only valid on step 2 per Unipile OpenAPI.
+
+        Args:
+            user_id: Internal ALwrity user ID (Clerk)
+            linkedin_sections: Unipile sections query (default ``*`` for full profile)
+
+        Returns:
+            Raw Unipile UserProfile dictionary
+
+        Raises:
+            LinkedInNotConnectedError: If user has no Unipile account connected
+            UnipileAPIError: If the Unipile API request fails or identifier is missing
+        """
+        logger.info(
+            f"[UnipileProvider] fetch_own_linkedin_profile user={user_id} "
+            f"linkedin_sections={linkedin_sections!r}"
+        )
+
+        creds = self._oauth.resolve_credentials(user_id)
+        account_id = creds.unipile_account_id
+        if not account_id:
+            raise LinkedInNotConnectedError(
+                "No Unipile LinkedIn account connected. "
+                "Connect via hosted OAuth before fetching profile."
+            )
+
+        logger.info(
+            f"[UnipileProvider] Step 1/2 — AccountOwnerProfile via /users/me "
+            f"account_id={account_id} user={user_id}"
+        )
+        owner = await self._client.get_own_profile(account_id)
+        if not isinstance(owner, dict):
+            raise UnipileAPIError(
+                f"Unexpected /users/me response type: {type(owner).__name__}"
+            )
+
+        identifier = profile_identifier_from_owner(owner)
+        if not identifier:
+            raise UnipileAPIError(
+                f"AccountOwnerProfile missing public_identifier and provider_id "
+                f"for account_id={account_id}"
+            )
+
+        logger.info(
+            f"[UnipileProvider] Step 2/2 — UserProfile via /users/{{identifier}} "
+            f"account_id={account_id} identifier={identifier!r} "
+            f"linkedin_sections={linkedin_sections!r}"
+        )
+        return await self._client.get_user_profile(
+            account_id,
+            identifier,
+            linkedin_sections=linkedin_sections,
+            notify=False,
+        )
+
+    async def list_organizations(
+        self, user_id: str, account_id: str
+    ) -> list[LinkedInOrganization]:
+        """
+        List LinkedIn organizations (company pages) accessible to the account.
+
+        Phase 1: Not implemented. Returns empty list.
+        Phase 2: Will implement organization listing.
+        """
+        logger.warning(
+            "[UnipileProvider] list_organizations not implemented (Phase 1) user_id={} "
+            "account_id={} — returning empty list",
+            user_id,
+            account_id,
+        )
+        return []
+
+    async def get_profile_aggregate_analytics(
+        self,
+        user_id: str,
+        account_id: str,
+        aggregation: ProfileAggregation = "TOTAL",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        metrics: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        """
+        Fetch profile aggregate analytics.
+
+        Phase 1: Not implemented. Raises NotImplementedError.
+        Phase 3: Will implement analytics fetching.
+        """
+        logger.warning(
+            f"[UnipileProvider] get_profile_aggregate_analytics called but not implemented (Phase 1)"
+        )
+        raise NotImplementedError(_ANALYTICS_NOT_IMPLEMENTED)
+
+    async def get_org_aggregate_analytics(
+        self,
+        user_id: str,
+        account_id: str,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
+        metric_type: OrgMetricType = "total_value",
+        metrics: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        """
+        Fetch organization aggregate analytics.
+
+        Phase 1: Not implemented. Raises NotImplementedError.
+        Phase 3: Will implement organization analytics.
+        """
+        logger.warning(
+            f"[UnipileProvider] get_org_aggregate_analytics called but not implemented (Phase 1)"
+        )
+        raise NotImplementedError(_ANALYTICS_NOT_IMPLEMENTED)
+
+    async def get_post_analytics(
+        self,
+        user_id: str,
+        account_id: str,
+        urn: str,
+    ) -> dict[str, Any]:
+        """
+        Fetch analytics for a specific post.
+
+        Phase 1: Not implemented. Raises NotImplementedError.
+        Phase 3: Will implement post analytics.
+        """
+        logger.warning(
+            f"[UnipileProvider] get_post_analytics called but not implemented (Phase 1)"
+        )
+        raise NotImplementedError(_ANALYTICS_NOT_IMPLEMENTED)
+
+    async def resolve_account_avatar_url(
+        self, user_id: str, account: LinkedInAccount
+    ) -> Optional[str]:
+        """
+        Resolve the avatar URL for a LinkedIn account.
+
+        Args:
+            user_id: Internal user ID
+            account: LinkedInAccount to get avatar for
+
+        Returns:
+            Avatar URL string or None if not available
+        """
+        # Return cached avatar if available
+        if account.avatar_url:
+            return account.avatar_url
+
+        return await self._resolve_avatar_url(account.account_id)
+
+    async def create_post(
+        self, user_id: str, request: CreatePostRequest
+    ) -> CreatePostResult:
+        """
+        Create a LinkedIn post.
+
+        Phase 1: Not implemented. Raises NotImplementedError.
+        Phase 4: Will implement publishing.
+        """
+        logger.warning(
+            f"[UnipileProvider] create_post called but not implemented (Phase 1)"
+        )
+        raise NotImplementedError(_PUBLISHING_NOT_IMPLEMENTED)
+
+    async def upload_media(
+        self,
+        user_id: str,
+        account_id: str,
+        file_path: str,
+        media_type: str,
+    ) -> MediaUploadResult:
+        """
+        Upload media for a LinkedIn post.
+
+        Phase 1: Not implemented. Raises NotImplementedError.
+        Phase 4: Will implement media upload.
+        """
+        logger.warning(
+            f"[UnipileProvider] upload_media called but not implemented (Phase 1)"
+        )
+        raise NotImplementedError(_PUBLISHING_NOT_IMPLEMENTED)
+
+    async def schedule_post(
+        self, user_id: str, request: CreatePostRequest
+    ) -> CreatePostResult:
+        """
+        Schedule a LinkedIn post.
+
+        Phase 1: Not implemented. Raises NotImplementedError.
+        Phase 4: Will implement scheduling.
+        """
+        logger.warning(
+            f"[UnipileProvider] schedule_post called but not implemented (Phase 1)"
+        )
+        raise NotImplementedError(_PUBLISHING_NOT_IMPLEMENTED)
+
+    async def list_comments(
+        self, user_id: str, account_id: str, post_urn: str
+    ) -> list[CommentInfo]:
+        """
+        List comments on a LinkedIn post.
+
+        Phase 1: Not implemented. Raises NotImplementedError.
+        Phase 4: Will implement comment listing.
+        """
+        logger.warning(
+            f"[UnipileProvider] list_comments called but not implemented (Phase 1)"
+        )
+        raise NotImplementedError(_COMMENTS_NOT_IMPLEMENTED)
+
+    async def reply_to_comment(
+        self,
+        user_id: str,
+        account_id: str,
+        post_urn: str,
+        comment_id: str,
+        text: str,
+    ) -> ReplyResult:
+        """
+        Reply to a LinkedIn comment.
+
+        Phase 1: Not implemented. Raises NotImplementedError.
+        Phase 4: Will implement comment replies.
+        """
+        logger.warning(
+            f"[UnipileProvider] reply_to_comment called but not implemented (Phase 1)"
+        )
+        raise NotImplementedError(_COMMENTS_NOT_IMPLEMENTED)
+
+    # Phase 1 helper methods for connection management
+
+    async def generate_auth_url(
+        self,
+        user_id: str,
+        success_redirect_url: str,
+        failure_redirect_url: str,
+        notify_url: str,
+    ) -> str:
+        """
+        Generate Unipile hosted auth URL for LinkedIn connection.
+
+        This is a Phase 1 helper method for initiating the OAuth flow.
+
+        Args:
+            user_id: Internal user ID
+            success_redirect_url: Callback URL for successful auth
+            failure_redirect_url: Callback URL for failed auth
+            notify_url: Webhook URL for status notifications
+
+        Returns:
+            Unipile hosted auth URL string
+        """
+        result = await self._client.create_hosted_auth_link(
+            user_id=user_id,
+            success_redirect_url=success_redirect_url,
+            failure_redirect_url=failure_redirect_url,
+            notify_url=notify_url,
+            providers=["LINKEDIN"],
+        )
+        return result.auth_url
+
+    async def disconnect_account(self, account_id: str) -> bool:
+        """
+        Disconnect a LinkedIn account from Unipile.
+
+        Args:
+            account_id: Unipile account ID to disconnect
+
+        Returns:
+            True if disconnection was successful
+        """
+        return await self._client.delete_account(account_id)

--- a/backend/services/integrations/linkedin/zernio_client.py
+++ b/backend/services/integrations/linkedin/zernio_client.py
@@ -1,0 +1,387 @@
+"""
+Low-level Zernio HTTP client for LinkedIn Growth Engine.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+import httpx
+from loguru import logger
+
+from services.integrations.linkedin.types import DEFAULT_ZERNIO_API_URL, LinkedInCredentials
+
+DEFAULT_ZERNIO_API_URL = "https://zernio.com/api/v1"
+
+
+def zernio_base_url() -> str:
+    return os.getenv("ZERNIO_API_URL", DEFAULT_ZERNIO_API_URL).rstrip("/")
+
+
+class ZernioAPIError(RuntimeError):
+    """Raised when the Zernio API returns an error response."""
+
+    def __init__(self, message: str, *, status_code: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _auth_headers(api_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+
+def _raise_for_error(response: httpx.Response) -> None:
+    if response.status_code < 400:
+        return
+    raise ZernioAPIError(
+        f"Zernio API returned HTTP {response.status_code}: {response.text}",
+        status_code=response.status_code,
+    )
+
+
+def _parse_account_items(raw: Any) -> list[dict[str, Any]]:
+    if isinstance(raw, list):
+        items = raw
+    elif isinstance(raw, dict):
+        items = raw.get("accounts", raw.get("data", []))
+    else:
+        items = []
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def account_id_from_item(item: dict[str, Any]) -> str:
+    return str(item.get("_id") or item.get("id") or item.get("accountId") or "")
+
+
+def account_type_from_item(item: dict[str, Any]) -> Optional[str]:
+    return item.get("accountType") or item.get("type")
+
+
+def account_name_from_item(item: dict[str, Any]) -> Optional[str]:
+    return item.get("displayName") or item.get("username") or item.get("name")
+
+
+def avatar_url_from_item(item: dict[str, Any]) -> Optional[str]:
+    for key in (
+        "profilePicture",
+        "profile_picture",
+        "avatarUrl",
+        "avatar_url",
+        "logoUrl",
+        "logo_url",
+    ):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+class ZernioClient:
+    """Async HTTP client for Zernio LinkedIn endpoints."""
+
+    def __init__(self, credentials: LinkedInCredentials, timeout: float = 30.0):
+        if not credentials.zernio_api_key:
+            raise ValueError("Zernio API key is required")
+        self._api_key = credentials.zernio_api_key
+        self._base_url = credentials.zernio_api_url.rstrip("/")
+        self._profile_id = credentials.zernio_profile_id
+        self._timeout = timeout
+
+    async def list_accounts(
+        self,
+        *,
+        profile_id: Optional[str] = None,
+        platform: str = "linkedin",
+        global_scope: bool = False,
+    ) -> dict[str, Any]:
+        url = f"{self._base_url}/accounts"
+        params: dict[str, str] = {"platform": platform}
+        if not global_scope:
+            resolved_profile = (
+                profile_id if profile_id is not None else self._profile_id
+            )
+            if resolved_profile:
+                params["profileId"] = resolved_profile
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(
+                url,
+                params=params,
+                headers=_auth_headers(self._api_key),
+            )
+        _raise_for_error(response)
+        return response.json()
+
+    async def list_organizations(self, account_id: str) -> dict[str, Any]:
+        url = f"{self._base_url}/accounts/{account_id}/linkedin-organizations"
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(url, headers=_auth_headers(self._api_key))
+        _raise_for_error(response)
+        return response.json()
+
+    async def get_account(self, account_id: str) -> dict[str, Any]:
+        """Fetch a single connected account (profile picture, metadata)."""
+        url = f"{self._base_url}/accounts/{account_id}"
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(url, headers=_auth_headers(self._api_key))
+        _raise_for_error(response)
+        return response.json()
+
+    async def fetch_profile_aggregate_analytics(
+        self,
+        account_id: str,
+        aggregation: str = "TOTAL",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        metrics: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        params: dict[str, str] = {"aggregation": aggregation}
+        if start_date:
+            params["startDate"] = start_date
+        if end_date:
+            params["endDate"] = end_date
+        if metrics:
+            params["metrics"] = ",".join(metrics)
+
+        url = f"{self._base_url}/accounts/{account_id}/linkedin-aggregate-analytics"
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(
+                url, params=params, headers=_auth_headers(self._api_key)
+            )
+        _raise_for_error(response)
+        return response.json()
+
+    async def fetch_org_aggregate_analytics(
+        self,
+        account_id: str,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
+        metric_type: str = "total_value",
+        metrics: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        params: dict[str, str] = {
+            "accountId": account_id,
+            "metricType": metric_type,
+        }
+        if since:
+            params["since"] = since
+        if until:
+            params["until"] = until
+        if metrics:
+            params["metrics"] = ",".join(metrics)
+
+        url = f"{self._base_url}/analytics/linkedin/org-aggregate-analytics"
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(
+                url, params=params, headers=_auth_headers(self._api_key)
+            )
+        _raise_for_error(response)
+        return response.json()
+
+    async def fetch_post_analytics(self, account_id: str, urn: str) -> dict[str, Any]:
+        url = f"{self._base_url}/accounts/{account_id}/linkedin-post-analytics"
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(
+                url,
+                params={"urn": urn},
+                headers=_auth_headers(self._api_key),
+            )
+        _raise_for_error(response)
+        return response.json()
+
+    async def delete_account(self, account_id: str) -> dict[str, Any]:
+        """Disconnect and remove a connected social account from Zernio."""
+        url = f"{self._base_url}/accounts/{account_id}"
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.delete(url, headers=_auth_headers(self._api_key))
+        _raise_for_error(response)
+        if response.content:
+            return response.json()
+        return {"message": "Account disconnected successfully"}
+
+
+def create_profile_sync(
+    api_key: str,
+    base_url: str,
+    name: str,
+    *,
+    description: Optional[str] = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Create a Zernio profile (Quickstart Step 1)."""
+    import requests
+
+    url = f"{base_url.rstrip('/')}/profiles"
+    payload: dict[str, str] = {"name": name}
+    if description:
+        payload["description"] = description
+    response = requests.post(
+        url,
+        json=payload,
+        headers=_auth_headers(api_key),
+        timeout=timeout,
+    )
+    if response.status_code >= 400:
+        raise ZernioAPIError(
+            f"Zernio create profile returned HTTP {response.status_code}: {response.text}"
+        )
+    data = response.json()
+    profile = data.get("profile") if isinstance(data.get("profile"), dict) else data
+    profile_id = profile.get("_id") or profile.get("id") or data.get("_id")
+    if not profile_id:
+        raise ZernioAPIError("Zernio create profile response missing profile _id")
+    return {"profileId": str(profile_id), "profile": profile}
+
+
+def list_accounts_sync(
+    api_key: str,
+    base_url: str,
+    profile_id: Optional[str] = None,
+    *,
+    platform: str = "linkedin",
+    global_scope: bool = False,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """List connected accounts for a profile, or all LinkedIn accounts when global_scope=True."""
+    import requests
+
+    url = f"{base_url.rstrip('/')}/accounts"
+    params: dict[str, str] = {"platform": platform}
+    if not global_scope and profile_id:
+        params["profileId"] = profile_id
+    response = requests.get(
+        url,
+        params=params,
+        headers=_auth_headers(api_key),
+        timeout=timeout,
+    )
+    if response.status_code >= 400:
+        raise ZernioAPIError(
+            f"Zernio list accounts returned HTTP {response.status_code}: {response.text}"
+        )
+    return response.json()
+
+
+def get_connect_url_sync(
+    api_key: str,
+    base_url: str,
+    profile_id: str,
+    redirect_url: str,
+    *,
+    headless: bool = True,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Sync helper for OAuth connect URL (used by LinkedInOAuthService)."""
+    import requests
+
+    url = f"{base_url.rstrip('/')}/connect/linkedin"
+    params: dict[str, str] = {
+        "profileId": profile_id,
+        "redirect_url": redirect_url,
+    }
+    if headless:
+        params["headless"] = "true"
+    logger.warning(
+        f"[LinkedInConnect] connect url headless={headless} profile_id={profile_id}"
+    )
+    response = requests.get(
+        url,
+        params=params,
+        headers=_auth_headers(api_key),
+        timeout=timeout,
+    )
+    if response.status_code >= 400:
+        raise ZernioAPIError(
+            f"Zernio connect URL returned HTTP {response.status_code}: {response.text}",
+            status_code=response.status_code,
+        )
+    data = response.json()
+    auth_url = data.get("authUrl") or data.get("auth_url")
+    if not auth_url:
+        raise ZernioAPIError("Zernio connect response missing authUrl")
+    return {"authUrl": auth_url, "state": data.get("state")}
+
+
+def parse_select_linkedin_account_response(data: dict[str, Any]) -> dict[str, Any]:
+    """Extract connected account fields from select-organization response."""
+    account = data.get("account") if isinstance(data.get("account"), dict) else {}
+    account_id = (
+        account.get("accountId")
+        or account.get("account_id")
+        or account.get("_id")
+        or account.get("id")
+    )
+    return {
+        "account_id": str(account_id) if account_id else None,
+        "display_name": account.get("displayName") or account.get("username"),
+        "account_type": account.get("accountType") or account.get("account_type"),
+        "account": account,
+    }
+
+
+def select_linkedin_organization_sync(
+    api_key: str,
+    base_url: str,
+    profile_id: str,
+    temp_token: str,
+    user_profile: dict[str, Any],
+    *,
+    account_type: str = "personal",
+    selected_organization: Optional[dict[str, Any]] = None,
+    redirect_url: Optional[str] = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Finalize LinkedIn connect after headless OAuth (personal or organization)."""
+    import requests
+
+    url = f"{base_url.rstrip('/')}/connect/linkedin/select-organization"
+    body: dict[str, Any] = {
+        "profileId": profile_id,
+        "tempToken": temp_token,
+        "userProfile": user_profile,
+        "accountType": account_type,
+    }
+    if selected_organization:
+        body["selectedOrganization"] = selected_organization
+    if redirect_url:
+        body["redirect_url"] = redirect_url
+
+    response = requests.post(
+        url,
+        json=body,
+        headers=_auth_headers(api_key),
+        timeout=timeout,
+    )
+    if response.status_code >= 400:
+        raise ZernioAPIError(
+            f"Zernio select-organization returned HTTP {response.status_code}: {response.text}"
+        )
+    return response.json()
+
+
+def delete_account_sync(
+    api_key: str,
+    base_url: str,
+    account_id: str,
+    *,
+    timeout: float = 30.0,
+) -> bool:
+    """Best-effort sync disconnect for M4 (non-fatal on failure)."""
+    import requests
+
+    url = f"{base_url.rstrip('/')}/accounts/{account_id}"
+    try:
+        response = requests.delete(
+            url,
+            headers=_auth_headers(api_key),
+            timeout=timeout,
+        )
+        return response.status_code < 400
+    except Exception:
+        return False

--- a/backend/services/integrations/linkedin/zernio_provider.py
+++ b/backend/services/integrations/linkedin/zernio_provider.py
@@ -1,0 +1,293 @@
+"""
+Zernio implementation of LinkedInSocialProvider.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from loguru import logger
+
+from services.integrations.linkedin_oauth import LinkedInOAuthService
+from services.integrations.linkedin.content_deduplicator import ContentDeduplicator
+from services.integrations.linkedin.media_validator import LinkedInMediaValidator
+from services.integrations.linkedin.publish_preflight import (
+    run_publish_preflight,
+    run_upload_preflight,
+)
+from services.integrations.linkedin.types import (
+    CommentInfo,
+    CreatePostRequest,
+    CreatePostResult,
+    LinkedInAccount,
+    LinkedInOrganization,
+    MediaUploadResult,
+    OrgMetricType,
+    ProfileAggregation,
+    ReplyResult,
+)
+from services.integrations.linkedin.zernio_client import (
+    ZernioAPIError,
+    ZernioClient,
+    avatar_url_from_item,
+    _parse_account_items,
+)
+from services.integrations.linkedin.account_resolution import (
+    LOG_PREFIX as ACCOUNTS_LOG_PREFIX,
+    summarize_zernio_account_items,
+    zernio_items_to_accounts,
+)
+
+_PHASE2_MSG = "LinkedIn publishing is not implemented in Phase 1 (deferred to Phase 2)."
+
+
+class ZernioProvider:
+    """LinkedIn platform operations via Zernio REST API."""
+
+    provider_name = "zernio"
+
+    def __init__(
+        self,
+        oauth_service: Optional[LinkedInOAuthService] = None,
+        deduplicator: Optional[ContentDeduplicator] = None,
+        media_validator: Optional[LinkedInMediaValidator] = None,
+    ):
+        self._oauth = oauth_service or LinkedInOAuthService()
+        self._deduplicator = deduplicator or ContentDeduplicator()
+        self._media_validator = media_validator or LinkedInMediaValidator()
+
+    async def _client_for_user(self, user_id: str) -> ZernioClient:
+        creds = self._oauth.resolve_credentials(user_id)
+        return ZernioClient(creds)
+
+    def _resolve_account_id(
+        self, user_id: str, account_id: Optional[str], *, prefer_org: bool = False
+    ) -> str:
+        if account_id:
+            return account_id
+        creds = self._oauth.resolve_credentials(user_id)
+        if prefer_org:
+            resolved = creds.zernio_org_account_id
+            if not resolved:
+                raise ValueError(
+                    "No LinkedIn organization account is connected; "
+                    "connect a company page before requesting org analytics"
+                )
+        else:
+            resolved = creds.primary_account_id
+        if not resolved:
+            raise ValueError("account_id is required and no default is configured")
+        return resolved
+
+    async def list_accounts(self, user_id: str) -> list[LinkedInAccount]:
+        creds = self._oauth.resolve_credentials(user_id)
+        accounts: list[LinkedInAccount] = []
+
+        async def _load_items(
+            scope: str, *, global_scope: bool = False, profile_id: Optional[str] = None
+        ) -> list[dict]:
+            client = ZernioClient(creds)
+            raw = await client.list_accounts(
+                profile_id=profile_id, global_scope=global_scope
+            )
+            items = _parse_account_items(raw)
+            logger.warning(
+                f"{ACCOUNTS_LOG_PREFIX} list_accounts user_id={user_id} "
+                f"scope={scope} profile_id={profile_id or 'none'} count={len(items)} "
+                f"items={summarize_zernio_account_items(items)}"
+            )
+            return items
+
+        try:
+            items = await _load_items("profile", profile_id=creds.zernio_profile_id)
+            if len(items) < 2:
+                global_items = await _load_items("global", global_scope=True)
+                if len(global_items) > len(items):
+                    logger.warning(
+                        f"{ACCOUNTS_LOG_PREFIX} list_accounts retry user_id={user_id} "
+                        f"reason=profile_count_lt_2 global_count={len(global_items)}"
+                    )
+                    items = global_items
+            accounts = zernio_items_to_accounts(items)
+            for account in accounts:
+                logger.debug(
+                    f"{ACCOUNTS_LOG_PREFIX} list_accounts item user_id={user_id} "
+                    f"id={account.account_id} resolved_type={account.account_type}"
+                )
+        except ZernioAPIError as e:
+            logger.warning(
+                f"{ACCOUNTS_LOG_PREFIX} list_accounts failed user_id={user_id} "
+                f"fallback=synthesized_from_creds error={e}"
+            )
+
+        if not accounts:
+            if creds.zernio_account_id:
+                accounts.append(
+                    LinkedInAccount(
+                        account_id=creds.zernio_account_id,
+                        account_type="personal",
+                        username=creds.account_name,
+                        platform="linkedin",
+                    )
+                )
+            if creds.zernio_org_account_id and creds.zernio_org_account_id != (
+                creds.zernio_account_id or ""
+            ):
+                accounts.append(
+                    LinkedInAccount(
+                        account_id=creds.zernio_org_account_id,
+                        account_type="organization",
+                        username=creds.account_name,
+                        platform="linkedin",
+                    )
+                )
+            if accounts:
+                logger.info(
+                    f"{ACCOUNTS_LOG_PREFIX} list_accounts synthesized user_id={user_id} "
+                    f"count={len(accounts)}"
+                )
+        return accounts
+
+    async def list_organizations(
+        self, user_id: str, account_id: str
+    ) -> list[LinkedInOrganization]:
+        client = await self._client_for_user(user_id)
+        resolved_id = self._resolve_account_id(user_id, account_id)
+        raw = await client.list_organizations(resolved_id)
+        items = raw if isinstance(raw, list) else raw.get("organizations", raw.get("data", []))
+        orgs: list[LinkedInOrganization] = []
+        if not isinstance(items, list):
+            return orgs
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            org_id = str(item.get("id") or item.get("organizationId", ""))
+            urn = item.get("urn") or item.get("organizationUrn")
+            if not urn and org_id:
+                urn = f"urn:li:organization:{org_id}"
+            orgs.append(
+                LinkedInOrganization(
+                    organization_id=org_id,
+                    name=item.get("name") or item.get("localizedName"),
+                    urn=urn,
+                    logo_url=avatar_url_from_item(item),
+                )
+            )
+        return orgs
+
+    async def get_profile_aggregate_analytics(
+        self,
+        user_id: str,
+        account_id: str,
+        aggregation: ProfileAggregation = "TOTAL",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        metrics: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        client = await self._client_for_user(user_id)
+        resolved_id = self._resolve_account_id(user_id, account_id)
+        return await client.fetch_profile_aggregate_analytics(
+            resolved_id,
+            aggregation=aggregation,
+            start_date=start_date,
+            end_date=end_date,
+            metrics=metrics,
+        )
+
+    async def get_org_aggregate_analytics(
+        self,
+        user_id: str,
+        account_id: str,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
+        metric_type: OrgMetricType = "total_value",
+        metrics: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        client = await self._client_for_user(user_id)
+        resolved_id = self._resolve_account_id(user_id, account_id, prefer_org=True)
+        return await client.fetch_org_aggregate_analytics(
+            resolved_id,
+            since=since,
+            until=until,
+            metric_type=metric_type,
+            metrics=metrics,
+        )
+
+    async def get_post_analytics(
+        self,
+        user_id: str,
+        account_id: str,
+        urn: str,
+    ) -> dict[str, Any]:
+        client = await self._client_for_user(user_id)
+        resolved_id = self._resolve_account_id(user_id, account_id)
+        return await client.fetch_post_analytics(resolved_id, urn)
+
+    async def resolve_account_avatar_url(
+        self, user_id: str, account: LinkedInAccount
+    ) -> Optional[str]:
+        """Return avatar URL from account list data or Zernio GET /accounts/{id}."""
+        if account.avatar_url:
+            return account.avatar_url
+        try:
+            client = await self._client_for_user(user_id)
+            raw = await client.get_account(account.account_id)
+            item = raw.get("account") if isinstance(raw.get("account"), dict) else raw
+            if isinstance(item, dict):
+                return avatar_url_from_item(item)
+        except Exception as exc:
+            logger.warning(
+                f"Avatar fetch failed for account {account.account_id}: {exc}"
+            )
+        return None
+
+    async def create_post(
+        self, user_id: str, request: CreatePostRequest
+    ) -> CreatePostResult:
+        await run_publish_preflight(
+            user_id,
+            request,
+            deduplicator=self._deduplicator,
+            media_validator=self._media_validator,
+        )
+        raise NotImplementedError(_PHASE2_MSG)
+
+    async def upload_media(
+        self,
+        user_id: str,
+        account_id: str,
+        file_path: str,
+        media_type: str,
+    ) -> MediaUploadResult:
+        await run_upload_preflight(
+            file_path,
+            media_type,
+            media_validator=self._media_validator,
+        )
+        raise NotImplementedError(_PHASE2_MSG)
+
+    async def schedule_post(
+        self, user_id: str, request: CreatePostRequest
+    ) -> CreatePostResult:
+        await run_publish_preflight(
+            user_id,
+            request,
+            deduplicator=self._deduplicator,
+            media_validator=self._media_validator,
+        )
+        raise NotImplementedError(_PHASE2_MSG)
+
+    async def list_comments(
+        self, user_id: str, account_id: str, post_urn: str
+    ) -> list[CommentInfo]:
+        raise NotImplementedError(_PHASE2_MSG)
+
+    async def reply_to_comment(
+        self,
+        user_id: str,
+        account_id: str,
+        post_urn: str,
+        comment_id: str,
+        text: str,
+    ) -> ReplyResult:
+        raise NotImplementedError(_PHASE2_MSG)

--- a/backend/services/integrations/linkedin_oauth.py
+++ b/backend/services/integrations/linkedin_oauth.py
@@ -1,0 +1,1754 @@
+"""
+LinkedIn OAuth / credential service for Growth Engine.
+
+Supports Zernio per-user profiles + OAuth connect and native LinkedIn OAuth tokens,
+with Fernet encryption and per-user SQLite.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import sqlite3
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+from urllib.parse import quote, unquote, urlencode, urlparse
+
+import requests
+from cryptography.fernet import Fernet, InvalidToken
+from loguru import logger
+
+from services.database import get_user_db_path
+from services.integrations.linkedin.types import (
+    LinkedInCredentials,
+    LinkedInNotConnectedError,
+)
+from services.integrations.linkedin.zernio_client import (
+    account_id_from_item,
+    account_name_from_item,
+    account_type_from_item,
+    create_profile_sync,
+    get_connect_url_sync,
+    parse_select_linkedin_account_response,
+    select_linkedin_organization_sync,
+    zernio_base_url,
+    _parse_account_items,
+)
+from services.integrations.linkedin.account_resolution import (
+    fetch_linkedin_account_items,
+    partition_zernio_account_items,
+    summarize_zernio_account_items,
+)
+
+_PLACEHOLDER_BACKEND_URL_TOKENS = ("your-backend-ngrok", "example.com", "placeholder")
+
+
+def _is_placeholder_backend_url(url: str) -> bool:
+    """Return True when a backend/ngrok URL is unset or a documentation placeholder."""
+    normalized = url.strip().lower()
+    if not normalized:
+        return True
+    return any(token in normalized for token in _PLACEHOLDER_BACKEND_URL_TOKENS)
+
+
+class LinkedInOAuthService:
+    """Manages LinkedIn Growth Engine credentials (Zernio, Unipile, or native OAuth)."""
+
+    _TOKEN_SELECT_COLUMNS = """
+        id, user_id, provider_mode, zernio_api_key, zernio_account_id,
+        zernio_org_account_id, linkedin_access_token, linkedin_refresh_token,
+        expires_at, account_name, profile_urn, is_active, created_at, updated_at,
+        zernio_profile_id, unipile_account_id, unipile_org_account_id
+    """
+
+    def __init__(self, db_path: Optional[str] = None):
+        self.db_path = db_path
+        self.token_encryption_key = (
+            os.getenv("LINKEDIN_TOKEN_ENCRYPTION_KEY")
+            or os.getenv("OAUTH_TOKEN_ENCRYPTION_KEY")
+        )
+        self._fernet = self._initialize_fernet()
+        self._migration_done: set[str] = set()
+
+    def _initialize_fernet(self) -> Optional[Fernet]:
+        if not self.token_encryption_key:
+            logger.warning(
+                "LinkedIn token encryption key not configured; "
+                "per-user credential storage will be unavailable."
+            )
+            return None
+        try:
+            return Fernet(self.token_encryption_key.encode("utf-8"))
+        except Exception:
+            logger.error("LinkedIn token encryption key is invalid.")
+            return None
+
+    def _encrypt_token(self, token: Optional[str]) -> Optional[str]:
+        if not token:
+            return None
+        if not self._fernet:
+            raise ValueError(
+                "Token encryption unavailable: set LINKEDIN_TOKEN_ENCRYPTION_KEY "
+                "or OAUTH_TOKEN_ENCRYPTION_KEY"
+            )
+        return self._fernet.encrypt(token.encode("utf-8")).decode("utf-8")
+
+    def _decrypt_token(self, token_blob: Optional[str]) -> Optional[str]:
+        if not token_blob:
+            return None
+        if not self._fernet:
+            raise ValueError("Token decryption unavailable: missing encryption key")
+        try:
+            return self._fernet.decrypt(token_blob.encode("utf-8")).decode("utf-8")
+        except InvalidToken:
+            logger.error("LinkedIn token decryption failed (invalid token blob)")
+            return None
+
+    def _is_likely_encrypted_blob(self, value: Optional[str]) -> bool:
+        return bool(value and value.startswith("gAAAAA"))
+
+    def _get_db_path(self, user_id: str) -> str:
+        if self.db_path:
+            return self.db_path
+        return get_user_db_path(user_id)
+
+    def _init_db(self, user_id: str) -> None:
+        db_path = self._get_db_path(user_id)
+        os.makedirs(os.path.dirname(db_path), exist_ok=True)
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS linkedin_oauth_tokens (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id TEXT NOT NULL,
+                    provider_mode TEXT NOT NULL,
+                    zernio_api_key TEXT,
+                    zernio_account_id TEXT,
+                    zernio_org_account_id TEXT,
+                    linkedin_access_token TEXT,
+                    linkedin_refresh_token TEXT,
+                    expires_at TIMESTAMP,
+                    account_name TEXT,
+                    profile_urn TEXT,
+                    is_active BOOLEAN DEFAULT TRUE,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    zernio_profile_id TEXT,
+                    unipile_account_id TEXT,
+                    unipile_org_account_id TEXT
+                )
+                """
+            )
+            cursor.execute("PRAGMA table_info(linkedin_oauth_tokens)")
+            existing_cols = {row[1] for row in cursor.fetchall()}
+            if "zernio_profile_id" not in existing_cols:
+                cursor.execute(
+                    "ALTER TABLE linkedin_oauth_tokens ADD COLUMN zernio_profile_id TEXT"
+                )
+            # Add Unipile columns (Phase 2 migration)
+            if "unipile_account_id" not in existing_cols:
+                cursor.execute(
+                    "ALTER TABLE linkedin_oauth_tokens ADD COLUMN unipile_account_id TEXT"
+                )
+            if "unipile_org_account_id" not in existing_cols:
+                cursor.execute(
+                    "ALTER TABLE linkedin_oauth_tokens ADD COLUMN unipile_org_account_id TEXT"
+                )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS linkedin_oauth_states (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id TEXT NOT NULL,
+                    state TEXT NOT NULL UNIQUE,
+                    code_verifier TEXT,
+                    expires_at TIMESTAMP NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    used_at TIMESTAMP
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_linkedin_oauth_user_active
+                ON linkedin_oauth_tokens (user_id, is_active)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS linkedin_analysis_context (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id TEXT NOT NULL UNIQUE,
+                    unipile_account_id TEXT NOT NULL,
+
+                    normalized_profile_json TEXT,
+                    raw_userprofile_json TEXT,
+                    profile_content_hash TEXT,
+                    fetched_at TIMESTAMP,
+
+                    profile_context_json TEXT,
+                    profile_validation_json TEXT,
+                    user_completion_json TEXT,
+                    ai_profile_intelligence_json TEXT,
+                    topic_recommendations_json TEXT,
+
+                    profile_context_updated_at TIMESTAMP,
+                    ai_intelligence_updated_at TIMESTAMP,
+                    recommendations_updated_at TIMESTAMP,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            cursor.execute("PRAGMA table_info(linkedin_analysis_context)")
+            analysis_cols = {row[1] for row in cursor.fetchall()}
+            if "topic_recommendations_json" not in analysis_cols:
+                cursor.execute(
+                    "ALTER TABLE linkedin_analysis_context "
+                    "ADD COLUMN topic_recommendations_json TEXT"
+                )
+            if "recommendations_updated_at" not in analysis_cols:
+                cursor.execute(
+                    "ALTER TABLE linkedin_analysis_context "
+                    "ADD COLUMN recommendations_updated_at TIMESTAMP"
+                )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_linkedin_analysis_user
+                ON linkedin_analysis_context (user_id)
+                """
+            )
+            conn.commit()
+
+    def _migrate_plaintext_tokens_if_needed(
+        self, conn: sqlite3.Connection, user_id: str
+    ) -> None:
+        if not self._fernet or user_id in self._migration_done:
+            return
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, zernio_api_key, linkedin_access_token, linkedin_refresh_token
+            FROM linkedin_oauth_tokens WHERE user_id = ?
+            """,
+            (user_id,),
+        )
+        migrated = 0
+        for token_id, zernio_key, access, refresh in cursor.fetchall():
+            updates: Dict[str, Optional[str]] = {}
+            if zernio_key and not self._is_likely_encrypted_blob(zernio_key):
+                updates["zernio_api_key"] = self._encrypt_token(zernio_key)
+            if access and not self._is_likely_encrypted_blob(access):
+                updates["linkedin_access_token"] = self._encrypt_token(access)
+            if refresh and not self._is_likely_encrypted_blob(refresh):
+                updates["linkedin_refresh_token"] = self._encrypt_token(refresh)
+            if not updates:
+                continue
+            set_clause = ", ".join(f"{k} = ?" for k in updates)
+            cursor.execute(
+                f"""
+                UPDATE linkedin_oauth_tokens
+                SET {set_clause}, updated_at = datetime('now')
+                WHERE id = ? AND user_id = ?
+                """,
+                (*updates.values(), token_id, user_id),
+            )
+            migrated += 1
+        if migrated:
+            conn.commit()
+            logger.info(
+                f"LinkedIn OAuth token migration for user {user_id}; rows={migrated}"
+            )
+        self._migration_done.add(user_id)
+
+    def _row_to_credentials(self, row: tuple) -> LinkedInCredentials:
+        (
+            _id,
+            _user_id,
+            provider_mode,
+            zernio_api_key,
+            zernio_account_id,
+            zernio_org_account_id,
+            linkedin_access_token,
+            linkedin_refresh_token,
+            _expires_at,
+            account_name,
+            profile_urn,
+            _is_active,
+            _created_at,
+            _updated_at,
+            *rest,
+        ) = row
+        # Handle optional columns that may not exist in older rows
+        zernio_profile_id = rest[0] if len(rest) > 0 else None
+        unipile_account_id = rest[1] if len(rest) > 1 else None
+        unipile_org_account_id = rest[2] if len(rest) > 2 else None
+
+        def _maybe_decrypt(value: Optional[str]) -> Optional[str]:
+            if not value:
+                return None
+            if self._is_likely_encrypted_blob(value):
+                return self._decrypt_token(value)
+            return value
+
+        return LinkedInCredentials.from_db_row(
+            {
+                "provider_mode": provider_mode,
+                "zernio_api_key": _maybe_decrypt(zernio_api_key),
+                "zernio_profile_id": zernio_profile_id,
+                "zernio_account_id": zernio_account_id,
+                "zernio_org_account_id": zernio_org_account_id,
+                "unipile_account_id": unipile_account_id,
+                "unipile_org_account_id": unipile_org_account_id,
+                "linkedin_access_token": _maybe_decrypt(linkedin_access_token),
+                "linkedin_refresh_token": _maybe_decrypt(linkedin_refresh_token),
+                "account_name": account_name,
+                "profile_urn": profile_urn,
+            }
+        )
+
+    def _get_active_token_row(self, user_id: str) -> Optional[tuple]:
+        self._init_db(user_id)
+        db_path = self._get_db_path(user_id)
+        if not os.path.exists(db_path):
+            return None
+        with sqlite3.connect(db_path) as conn:
+            self._migrate_plaintext_tokens_if_needed(conn, user_id)
+            cursor = conn.cursor()
+            cursor.execute(
+                f"""
+                SELECT {self._TOKEN_SELECT_COLUMNS}
+                FROM linkedin_oauth_tokens
+                WHERE user_id = ? AND is_active = 1
+                ORDER BY created_at DESC
+                LIMIT 1
+                """,
+                (user_id,),
+            )
+            return cursor.fetchone()
+
+    def store_zernio_credentials(
+        self,
+        user_id: str,
+        zernio_api_key: str,
+        zernio_account_id: str,
+        zernio_org_account_id: Optional[str] = None,
+        account_name: Optional[str] = None,
+        profile_urn: Optional[str] = None,
+        zernio_profile_id: Optional[str] = None,
+    ) -> bool:
+        try:
+            self._init_db(user_id)
+            enc_key = self._encrypt_token(zernio_api_key)
+            resolved_profile_id = zernio_profile_id or self._get_stored_zernio_profile_id(
+                user_id
+            )
+            db_path = self._get_db_path(user_id)
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "UPDATE linkedin_oauth_tokens SET is_active = 0 WHERE user_id = ?",
+                    (user_id,),
+                )
+                cursor.execute(
+                    """
+                    INSERT INTO linkedin_oauth_tokens (
+                        user_id, provider_mode, zernio_api_key, zernio_account_id,
+                        zernio_org_account_id, account_name, profile_urn, is_active,
+                        zernio_profile_id
+                    ) VALUES (?, 'zernio', ?, ?, ?, ?, ?, 1, ?)
+                    """,
+                    (
+                        user_id,
+                        enc_key,
+                        zernio_account_id,
+                        zernio_org_account_id,
+                        account_name,
+                        profile_urn,
+                        resolved_profile_id,
+                    ),
+                )
+                conn.commit()
+            return True
+        except Exception as e:
+            logger.error(f"Failed to store Zernio credentials for user {user_id}: {e}")
+            return False
+
+    def store_native_tokens(
+        self,
+        user_id: str,
+        access_token: str,
+        refresh_token: Optional[str] = None,
+        expires_at: Optional[str] = None,
+        account_name: Optional[str] = None,
+        profile_urn: Optional[str] = None,
+    ) -> bool:
+        try:
+            self._init_db(user_id)
+            enc_access = self._encrypt_token(access_token)
+            enc_refresh = self._encrypt_token(refresh_token) if refresh_token else None
+            db_path = self._get_db_path(user_id)
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "UPDATE linkedin_oauth_tokens SET is_active = 0 WHERE user_id = ?",
+                    (user_id,),
+                )
+                cursor.execute(
+                    """
+                    INSERT INTO linkedin_oauth_tokens (
+                        user_id, provider_mode, linkedin_access_token,
+                        linkedin_refresh_token, expires_at, account_name, profile_urn, is_active
+                    ) VALUES (?, 'native', ?, ?, ?, ?, ?, 1)
+                    """,
+                    (
+                        user_id,
+                        enc_access,
+                        enc_refresh,
+                        expires_at,
+                        account_name,
+                        profile_urn,
+                    ),
+                )
+                conn.commit()
+            return True
+        except Exception as e:
+            logger.error(f"Failed to store native LinkedIn tokens for user {user_id}: {e}")
+            return False
+
+    def store_unipile_credentials(
+        self,
+        user_id: str,
+        unipile_account_id: str,
+        unipile_org_account_id: Optional[str] = None,
+        account_name: Optional[str] = None,
+        profile_urn: Optional[str] = None,
+    ) -> bool:
+        """
+        Store Unipile account credentials after successful OAuth.
+
+        Unipile stores OAuth tokens server-side; we only need to store
+        the account_id reference for API calls.
+
+        Args:
+            user_id: Internal user ID
+            unipile_account_id: Unipile account ID from callback
+            unipile_org_account_id: Optional organization account ID
+            account_name: Display name for the account
+            profile_urn: LinkedIn profile URN
+
+        Returns:
+            True if credentials stored successfully
+        """
+        try:
+            self._init_db(user_id)
+            db_path = self._get_db_path(user_id)
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.cursor()
+                # Deactivate existing tokens
+                cursor.execute(
+                    "UPDATE linkedin_oauth_tokens SET is_active = 0 WHERE user_id = ?",
+                    (user_id,),
+                )
+                # Insert new Unipile credentials
+                cursor.execute(
+                    """
+                    INSERT INTO linkedin_oauth_tokens (
+                        user_id, provider_mode, unipile_account_id,
+                        unipile_org_account_id, account_name, profile_urn, is_active
+                    ) VALUES (?, 'unipile', ?, ?, ?, ?, 1)
+                    """,
+                    (
+                        user_id,
+                        unipile_account_id,
+                        unipile_org_account_id,
+                        account_name,
+                        profile_urn,
+                    ),
+                )
+                conn.commit()
+            logger.info(
+                f"[LinkedInConnect] Stored Unipile credentials for user={user_id}, "
+                f"account_id={unipile_account_id}"
+            )
+            return True
+        except Exception as e:
+            logger.error(f"Failed to store Unipile credentials for user {user_id}: {e}")
+            return False
+
+    def _parse_expires_at(self, expires_at_str: Optional[str]) -> Tuple[bool, Optional[datetime]]:
+        """Return (is_valid_not_expired, expires_at_dt)."""
+        if not expires_at_str:
+            return True, None
+        try:
+            expires_at = datetime.fromisoformat(
+                str(expires_at_str).replace("Z", "+00:00")
+            )
+            if expires_at.tzinfo is not None:
+                expires_at = expires_at.replace(tzinfo=None)
+            return expires_at > datetime.now(), expires_at
+        except Exception:
+            return False, None
+
+    def _token_row_metadata(self, row: tuple) -> Dict[str, Any]:
+        """Build monitoring-safe token metadata (no decrypted secrets)."""
+        (
+            token_id,
+            _user_id,
+            provider_mode,
+            _zernio_api_key,
+            zernio_account_id,
+            zernio_org_account_id,
+            _linkedin_access_token,
+            linkedin_refresh_token,
+            expires_at,
+            account_name,
+            profile_urn,
+            is_active,
+            created_at,
+            _updated_at,
+            zernio_profile_id,
+        ) = row
+        not_expired, expires_dt = self._parse_expires_at(expires_at)
+        has_refresh = bool(linkedin_refresh_token)
+        return {
+            "id": token_id,
+            "provider_mode": provider_mode,
+            "zernio_account_id": zernio_account_id,
+            "zernio_org_account_id": zernio_org_account_id,
+            "zernio_profile_id": zernio_profile_id,
+            "expires_at": expires_at,
+            "account_name": account_name,
+            "profile_urn": profile_urn,
+            "is_active": bool(is_active),
+            "created_at": created_at,
+            "has_refresh_token": has_refresh,
+            "not_expired": not_expired,
+            "expires_at_dt": expires_dt.isoformat() if expires_dt else None,
+        }
+
+    def get_user_token_status(self, user_id: str) -> Dict[str, Any]:
+        """DB-only token status for OAuth monitoring (no env fallback, no secrets)."""
+        try:
+            self._init_db(user_id)
+            db_path = self._get_db_path(user_id)
+            if not os.path.exists(db_path):
+                return self._empty_token_status()
+
+            with sqlite3.connect(db_path) as conn:
+                self._migrate_plaintext_tokens_if_needed(conn, user_id)
+                cursor = conn.cursor()
+                cursor.execute(
+                    f"""
+                    SELECT {self._TOKEN_SELECT_COLUMNS}
+                    FROM linkedin_oauth_tokens
+                    WHERE user_id = ?
+                    ORDER BY created_at DESC
+                    """,
+                    (user_id,),
+                )
+                rows = cursor.fetchall()
+
+            all_tokens: List[Dict[str, Any]] = []
+            active_tokens: List[Dict[str, Any]] = []
+            expired_tokens: List[Dict[str, Any]] = []
+
+            for row in rows:
+                meta = self._token_row_metadata(row)
+                all_tokens.append(meta)
+                if meta["is_active"] and meta["not_expired"]:
+                    active_tokens.append(meta)
+                else:
+                    expired_tokens.append(meta)
+
+            has_refreshable = any(t.get("has_refresh_token") for t in expired_tokens)
+
+            return {
+                "has_tokens": len(all_tokens) > 0,
+                "has_active_tokens": len(active_tokens) > 0,
+                "has_expired_tokens": len(expired_tokens) > 0,
+                "has_refreshable_tokens": has_refreshable,
+                "active_tokens": active_tokens,
+                "expired_tokens": expired_tokens,
+                "total_tokens": len(all_tokens),
+                "last_token_date": all_tokens[0]["created_at"] if all_tokens else None,
+                "provider_mode": active_tokens[0]["provider_mode"]
+                if active_tokens
+                else (expired_tokens[0]["provider_mode"] if expired_tokens else None),
+            }
+        except Exception as e:
+            logger.error(f"Error getting LinkedIn token status for user {user_id}: {e}")
+            return self._empty_token_status()
+
+    def _empty_token_status(self) -> Dict[str, Any]:
+        return {
+            "has_tokens": False,
+            "has_active_tokens": False,
+            "has_expired_tokens": False,
+            "has_refreshable_tokens": False,
+            "active_tokens": [],
+            "expired_tokens": [],
+            "total_tokens": 0,
+            "last_token_date": None,
+            "provider_mode": None,
+        }
+
+    def _resolve_db_credentials(self, user_id: str) -> LinkedInCredentials:
+        """Resolve credentials from per-user DB only (no env fallback)."""
+        row = self._get_active_token_row(user_id)
+        if not row:
+            raise LinkedInNotConnectedError(
+                "No per-user LinkedIn credentials found in database"
+            )
+        creds = self._row_to_credentials(row)
+        if creds.provider_mode == "zernio" and creds.zernio_api_key:
+            return creds
+        if creds.provider_mode == "native" and creds.linkedin_access_token:
+            return creds
+        if creds.provider_mode == "unipile" and creds.unipile_account_id:
+            return creds
+        raise LinkedInNotConnectedError("LinkedIn credentials row is incomplete")
+
+    def resolve_credentials(self, user_id: str) -> LinkedInCredentials:
+        row = self._get_active_token_row(user_id)
+        if not row:
+            raise LinkedInNotConnectedError("No LinkedIn credentials available for user")
+        creds = self._row_to_credentials(row)
+        if creds.provider_mode == "zernio" and creds.zernio_api_key:
+            return creds
+        if creds.provider_mode == "native" and creds.linkedin_access_token:
+            return creds
+        if creds.provider_mode == "unipile" and creds.unipile_account_id:
+            return creds
+        raise LinkedInNotConnectedError("LinkedIn credentials row is incomplete")
+
+    def test_zernio_credentials(self, creds: LinkedInCredentials) -> bool:
+        """Sync health check for Zernio API key (returns True if key is valid)."""
+        if not creds.zernio_api_key:
+            return False
+        base_url = creds.zernio_api_url.rstrip("/")
+        try:
+            response = requests.get(
+                f"{base_url}/accounts",
+                params={"platform": "linkedin"},
+                headers={
+                    "Authorization": f"Bearer {creds.zernio_api_key}",
+                    "Accept": "application/json",
+                },
+                timeout=30,
+            )
+            return response.status_code < 400
+        except Exception as e:
+            logger.error(f"Zernio credential health check failed: {e}")
+            return False
+
+    def refresh_access_token(
+        self, user_id: str, refresh_token: str
+    ) -> Optional[Dict[str, Any]]:
+        """Refresh native LinkedIn OAuth access token."""
+        client_id = os.getenv("LINKEDIN_CLIENT_ID")
+        client_secret = os.getenv("LINKEDIN_CLIENT_SECRET")
+        if not client_id or not client_secret:
+            logger.error("LINKEDIN_CLIENT_ID/SECRET not configured for token refresh")
+            return None
+        try:
+            response = requests.post(
+                "https://www.linkedin.com/oauth/v2/accessToken",
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=30,
+            )
+            if response.status_code != 200:
+                logger.error(
+                    f"LinkedIn token refresh failed: {response.status_code} - {response.text}"
+                )
+                return None
+            token_info = response.json()
+            access_token = token_info.get("access_token")
+            new_refresh = token_info.get("refresh_token", refresh_token)
+            expires_in = token_info.get("expires_in", 3600)
+            expires_at = (datetime.now() + timedelta(seconds=expires_in)).isoformat()
+            if not access_token:
+                return None
+            row = self._get_active_token_row(user_id)
+            account_name = None
+            profile_urn = None
+            if row:
+                account_name = row[9]
+                profile_urn = row[10]
+            self.store_native_tokens(
+                user_id=user_id,
+                access_token=access_token,
+                refresh_token=new_refresh,
+                expires_at=expires_at,
+                account_name=account_name,
+                profile_urn=profile_urn,
+            )
+            return {
+                "access_token": access_token,
+                "expires_in": expires_in,
+                "expires_at": expires_at,
+            }
+        except Exception as e:
+            logger.error(f"LinkedIn refresh_access_token error for user {user_id}: {e}")
+            return None
+
+    def get_valid_credentials(
+        self, user_id: str, *, monitoring: bool = False
+    ) -> LinkedInCredentials:
+        """
+        Return valid credentials for API use or token monitoring.
+
+        When monitoring=True, uses DB-only credentials (no env fallback).
+        For native mode, refreshes expired/expiring tokens when possible.
+        For Zernio mode, validates API key via health check when monitoring.
+        """
+        creds = (
+            self._resolve_db_credentials(user_id)
+            if monitoring
+            else self.resolve_credentials(user_id)
+        )
+
+        if creds.provider_mode == "zernio":
+            if monitoring and not self.test_zernio_credentials(creds):
+                raise LinkedInNotConnectedError("Zernio API key is invalid or expired")
+            return creds
+
+        row = self._get_active_token_row(user_id)
+        if not row:
+            return creds
+        expires_at_str = row[8]
+        not_expired, expires_dt = self._parse_expires_at(expires_at_str)
+        refresh_token = self._row_to_credentials(row).linkedin_refresh_token
+
+        if not_expired:
+            if monitoring and expires_dt:
+                days_until = (expires_dt - datetime.now()).days
+                if days_until < 7 and refresh_token:
+                    result = self.refresh_access_token(user_id, refresh_token)
+                    if result:
+                        return self._resolve_db_credentials(user_id)
+            return creds
+
+        if refresh_token:
+            result = self.refresh_access_token(user_id, refresh_token)
+            if result:
+                return self._resolve_db_credentials(user_id)
+
+        raise LinkedInNotConnectedError(
+            "LinkedIn access token expired and could not be refreshed"
+        )
+
+    def get_connection_status(self, user_id: str) -> Dict[str, Any]:
+        provider = os.getenv("LINKEDIN_PROVIDER", "zernio")
+        row = self._get_active_token_row(user_id)
+        has_db_token = row is not None
+
+        try:
+            creds = self.resolve_credentials(user_id)
+            connected = True
+        except LinkedInNotConnectedError:
+            connected = False
+            creds = None
+
+        accounts: List[Dict[str, Any]] = []
+        if connected and creds:
+            # Handle Zernio accounts
+            if creds.provider_mode == "zernio":
+                if creds.zernio_account_id:
+                    accounts.append(
+                        {
+                            "account_id": creds.zernio_account_id,
+                            "account_type": "personal",
+                            "source": creds.source,
+                        }
+                    )
+                if creds.zernio_org_account_id:
+                    accounts.append(
+                        {
+                            "account_id": creds.zernio_org_account_id,
+                            "account_type": "organization",
+                            "source": creds.source,
+                        }
+                    )
+            # Handle Unipile accounts (Phase 2)
+            elif creds.provider_mode == "unipile":
+                if creds.unipile_account_id:
+                    accounts.append(
+                        {
+                            "account_id": creds.unipile_account_id,
+                            "account_type": "personal",
+                            "source": creds.source,
+                        }
+                    )
+                if creds.unipile_org_account_id:
+                    accounts.append(
+                        {
+                            "account_id": creds.unipile_org_account_id,
+                            "account_type": "organization",
+                            "source": creds.source,
+                        }
+                    )
+
+        account_name = creds.account_name if creds else None
+        if account_name and str(account_name).strip().startswith("user_"):
+            account_name = None
+
+        return {
+            "connected": connected,
+            "provider": provider,
+            "has_per_user_token": has_db_token,
+            "has_env_fallback": False,
+            "accounts": accounts,
+            "account_name": account_name,
+        }
+
+    def revoke_token(self, user_id: str) -> bool:
+        try:
+            self._init_db(user_id)
+            db_path = self._get_db_path(user_id)
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    UPDATE linkedin_oauth_tokens
+                    SET is_active = 0, updated_at = datetime('now')
+                    WHERE user_id = ? AND is_active = 1
+                    """,
+                    (user_id,),
+                )
+                conn.commit()
+                return cursor.rowcount > 0
+        except Exception as e:
+            logger.error(f"Failed to revoke LinkedIn token for user {user_id}: {e}")
+            return False
+
+    async def disconnect_user(self, user_id: str) -> Dict[str, Any]:
+        """Unlink LinkedIn from ALwrity (local tokens only; remote accounts may be deleted based on provider)."""
+        logger.info(f"[LinkedInConnect] disconnect_user start user_id={user_id}")
+
+        # Check if Unipile and attempt to delete remote account
+        provider = os.getenv("LINKEDIN_PROVIDER", "zernio").lower()
+        unipile_account_deleted = False
+
+        if provider == "unipile":
+            try:
+                creds = self.resolve_credentials(user_id)
+                if creds.unipile_account_id:
+                    from services.integrations.linkedin.unipile_client import UnipileClient
+
+                    client = UnipileClient()
+                    unipile_account_deleted = await client.delete_account(creds.unipile_account_id)
+                    logger.info(
+                        f"[LinkedInConnect] Unipile account deletion attempted user_id={user_id} "
+                        f"account_id={creds.unipile_account_id} success={unipile_account_deleted}"
+                    )
+            except Exception as e:
+                logger.warning(
+                    f"[LinkedInConnect] Failed to delete Unipile account for user_id={user_id}: {e}"
+                )
+
+        revoked = self.revoke_token(user_id)
+        status = self.get_connection_status(user_id)
+
+        log_msg = (
+            f"[LinkedInConnect] disconnect_user done user_id={user_id} "
+            f"revoked={revoked} provider={provider}"
+        )
+        if provider == "unipile":
+            log_msg += f" unipile_account_deleted={unipile_account_deleted}"
+        else:
+            log_msg += " zernio_accounts_preserved=true"
+        logger.warning(log_msg)
+
+        return {
+            "success": revoked,
+            "revoked": revoked,
+            "provider": provider,
+            "unipile_account_deleted" if provider == "unipile" else "zernio_account_deleted": unipile_account_deleted if provider == "unipile" else False,
+            "connected": status.get("connected", False),
+            "has_env_fallback": False,
+        }
+
+    def _get_stored_zernio_profile_id(self, user_id: str) -> Optional[str]:
+        self._init_db(user_id)
+        db_path = self._get_db_path(user_id)
+        if not os.path.exists(db_path):
+            return None
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT zernio_profile_id FROM linkedin_oauth_tokens
+                WHERE user_id = ? AND zernio_profile_id IS NOT NULL AND zernio_profile_id != ''
+                ORDER BY created_at DESC
+                LIMIT 1
+                """,
+                (user_id,),
+            )
+            row = cursor.fetchone()
+            return str(row[0]) if row and row[0] else None
+
+    def _persist_zernio_profile_id(self, user_id: str, profile_id: str) -> None:
+        self._init_db(user_id)
+        db_path = self._get_db_path(user_id)
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                UPDATE linkedin_oauth_tokens
+                SET zernio_profile_id = ?, updated_at = datetime('now')
+                WHERE user_id = ? AND is_active = 1
+                """,
+                (profile_id, user_id),
+            )
+            if cursor.rowcount == 0:
+                cursor.execute(
+                    """
+                    INSERT INTO linkedin_oauth_tokens (
+                        user_id, provider_mode, zernio_profile_id, is_active
+                    ) VALUES (?, 'zernio', ?, 0)
+                    """,
+                    (user_id, profile_id),
+                )
+            conn.commit()
+
+    def ensure_zernio_profile(
+        self, user_id: str, *, display_name: Optional[str] = None
+    ) -> str:
+        """Ensure the user has a Zernio profile (Quickstart Step 1)."""
+        existing = self._get_stored_zernio_profile_id(user_id)
+        if existing:
+            return existing
+
+        api_key = os.getenv("ZERNIO_API_KEY")
+        if not api_key:
+            raise ValueError("ZERNIO_API_KEY is not configured")
+
+        profile_label = display_name or f"ALwrity - {user_id}"
+        result = create_profile_sync(
+            api_key,
+            zernio_base_url(),
+            profile_label,
+            description="ALwrity LinkedIn social profile",
+        )
+        profile_id = result["profileId"]
+        self._persist_zernio_profile_id(user_id, profile_id)
+        logger.info(f"Created Zernio profile {profile_id} for user {user_id}")
+        return profile_id
+
+    def sync_zernio_accounts(self, user_id: str) -> List[Dict[str, Any]]:
+        """Sync LinkedIn accounts from Zernio for the user's profile (Quickstart Step 3)."""
+        api_key = os.getenv("ZERNIO_API_KEY")
+        if not api_key:
+            raise ValueError("ZERNIO_API_KEY is not configured")
+
+        profile_id = self._get_stored_zernio_profile_id(user_id)
+        if not profile_id:
+            raise ValueError("No Zernio profile found for user; run ensure_zernio_profile first")
+
+        items, list_source = fetch_linkedin_account_items(
+            api_key, zernio_base_url(), profile_id
+        )
+        if not items:
+            raise ValueError("No LinkedIn accounts found for this Zernio profile")
+
+        logger.warning(
+            f"[LinkedInConnect] sync start user_id={user_id} profile_id={profile_id} "
+            f"list_source={list_source} raw_count={len(items)} "
+            f"items={summarize_zernio_account_items(items)}"
+        )
+
+        personal_item, org_item = partition_zernio_account_items(items)
+        partition_method = "partition"
+        if org_item is None and len(items) >= 2:
+            logger.warning(
+                f"[LinkedInConnect] sync partition missing org user_id={user_id} "
+                f"account_types={[account_type_from_item(i) for i in items]}"
+            )
+
+        primary_item = personal_item
+        if primary_item is None:
+            primary_item = items[0]
+            partition_method = "fallback_first_item"
+        elif org_item is primary_item and len(items) > 1:
+            primary_item = next((i for i in items if i is not org_item), primary_item)
+            partition_method = "fallback_non_org_primary"
+
+        logger.warning(
+            f"[LinkedInConnect] sync partition user_id={user_id} method={partition_method} "
+            f"personal_id={account_id_from_item(personal_item) if personal_item else None} "
+            f"org_id={account_id_from_item(org_item) if org_item else None}"
+        )
+
+        if not primary_item:
+            primary_item = items[0]
+        primary_id = account_id_from_item(primary_item)
+        if not primary_id:
+            raise ValueError("Zernio account list missing account id")
+
+        org_id = None
+        if org_item and org_item is not primary_item:
+            org_id = account_id_from_item(org_item) or None
+
+        account_name = account_name_from_item(primary_item)
+        stored = self.store_zernio_credentials(
+            user_id=user_id,
+            zernio_api_key=api_key,
+            zernio_account_id=primary_id,
+            zernio_org_account_id=org_id,
+            account_name=account_name,
+            zernio_profile_id=profile_id,
+        )
+        if not stored:
+            raise RuntimeError("Failed to store synced Zernio credentials")
+
+        logger.warning(
+            f"[LinkedInConnect] sync stored user_id={user_id} profile_id={profile_id} "
+            f"personal_id={primary_id} org_id={org_id}"
+        )
+
+        synced: List[Dict[str, Any]] = []
+        for item in items:
+            aid = account_id_from_item(item)
+            if not aid:
+                continue
+            synced.append(
+                {
+                    "account_id": aid,
+                    "account_type": account_type_from_item(item),
+                    "username": account_name_from_item(item),
+                }
+            )
+        return synced
+
+    def try_sync_zernio_accounts(self, user_id: str) -> bool:
+        """Best-effort sync from Zernio; returns True when sync succeeded."""
+        try:
+            self.sync_zernio_accounts(user_id)
+            return True
+        except Exception as e:
+            logger.warning(
+                f"[LinkedInConnect] Zernio account sync skipped user_id={user_id}: {e}"
+            )
+            return False
+
+    def _resolve_public_backend_url(self) -> str:
+        """
+        Resolve the public backend base URL for Unipile OAuth redirects and webhooks.
+
+        Priority: LINKEDIN_SOCIAL_REDIRECT_URI origin → NGROK_URL → BACKEND_URL
+        (each skipped if placeholder) → localhost for local browser callbacks.
+        """
+        configured_redirect = os.getenv("LINKEDIN_SOCIAL_REDIRECT_URI", "").strip()
+        if configured_redirect:
+            parsed = urlparse(configured_redirect)
+            if parsed.scheme and parsed.netloc:
+                origin = f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
+                if not _is_placeholder_backend_url(origin):
+                    logger.info(
+                        f"[LinkedInConnect] Using public backend URL from "
+                        f"LINKEDIN_SOCIAL_REDIRECT_URI origin={origin}"
+                    )
+                    return origin
+                logger.warning(
+                    f"[LinkedInConnect] Ignoring placeholder LINKEDIN_SOCIAL_REDIRECT_URI "
+                    f"origin={origin}"
+                )
+
+        ngrok_url = os.getenv("NGROK_URL", "").strip().rstrip("/")
+        if ngrok_url:
+            if not _is_placeholder_backend_url(ngrok_url):
+                logger.info(f"[LinkedInConnect] Using public backend URL from NGROK_URL={ngrok_url}")
+                return ngrok_url
+            logger.warning(f"[LinkedInConnect] Ignoring placeholder NGROK_URL={ngrok_url}")
+
+        backend_url = os.getenv("BACKEND_URL", "").strip().rstrip("/")
+        if backend_url:
+            if not _is_placeholder_backend_url(backend_url):
+                logger.info(
+                    f"[LinkedInConnect] Using public backend URL from BACKEND_URL={backend_url}"
+                )
+                return backend_url
+            logger.warning(f"[LinkedInConnect] Ignoring placeholder BACKEND_URL={backend_url}")
+
+        logger.warning(
+            "[LinkedInConnect] No valid BACKEND_URL/NGROK_URL configured; "
+            "using http://localhost:8000 for Unipile browser callbacks. "
+            "Set NGROK_URL for notify_url webhooks from Unipile servers."
+        )
+        return "http://localhost:8000"
+
+    async def try_sync_unipile_accounts(self, user_id: str) -> bool:
+        """
+        Best-effort sync from Unipile when credentials exist remotely but not in ALwrity.
+
+        Matches accounts by hosted-auth ``name`` (ALwrity user id). If no match is found
+        but running LinkedIn accounts exist on Unipile, links the most recently created
+        account as a recovery path for failed callback redirects.
+        """
+        if os.getenv("LINKEDIN_PROVIDER", "zernio").lower() != "unipile":
+            return False
+
+        try:
+            self.resolve_credentials(user_id)
+            return True
+        except LinkedInNotConnectedError:
+            pass
+
+        from services.integrations.linkedin.unipile_client import UnipileClient
+
+        client = UnipileClient()
+        try:
+            items = await client.list_accounts(provider="LINKEDIN")
+        except Exception as exc:
+            logger.warning(
+                f"[LinkedInConnect] Unipile account sync skipped user_id={user_id}: {exc}"
+            )
+            return False
+
+        if not items:
+            logger.warning(
+                f"[LinkedInConnect] Unipile sync found 0 accounts for user_id={user_id} "
+                "despite successful list_accounts API call"
+            )
+            return False
+
+        def _account_id(item: Dict[str, Any]) -> Optional[str]:
+            raw = item.get("id") or item.get("account_id")
+            return str(raw) if raw else None
+
+        def _is_running(item: Dict[str, Any]) -> bool:
+            status = str(item.get("status") or item.get("state") or "").upper()
+            return status in ("OK", "RUNNING", "CONNECTED", "CREATION_SUCCESS", "SYNC_SUCCESS", "")
+
+        candidates = [item for item in items if _account_id(item) and _is_running(item)]
+        if not candidates:
+            candidates = [item for item in items if _account_id(item)]
+
+        for item in candidates:
+            account_id = _account_id(item)
+            if not account_id:
+                continue
+            hosted_name = item.get("name")
+            if hosted_name == user_id:
+                logger.info(
+                    f"[LinkedInConnect] Unipile sync matched account_id={account_id} "
+                    f"for user_id={user_id} via list name"
+                )
+                return await self.handle_unipile_callback(
+                    user_id=user_id,
+                    account_id=account_id,
+                    status="success",
+                )
+
+        for item in candidates:
+            account_id = _account_id(item)
+            if not account_id:
+                continue
+            try:
+                detail = await client.get_account(account_id)
+            except Exception as exc:
+                logger.debug(
+                    f"[LinkedInConnect] Unipile get_account failed account_id={account_id}: {exc}"
+                )
+                continue
+            for key in ("name", "client_name", "reference", "external_id"):
+                if detail.get(key) == user_id:
+                    logger.info(
+                        f"[LinkedInConnect] Unipile sync matched account_id={account_id} "
+                        f"for user_id={user_id} via detail.{key}"
+                    )
+                    return await self.handle_unipile_callback(
+                        user_id=user_id,
+                        account_id=account_id,
+                        status="success",
+                    )
+
+        candidates.sort(
+            key=lambda item: str(item.get("created_at") or item.get("created_on") or ""),
+            reverse=True,
+        )
+        latest_account_id = _account_id(candidates[0])
+        if not latest_account_id:
+            return False
+
+        logger.warning(
+            f"[LinkedInConnect] Unipile sync recovery linking latest account "
+            f"account_id={latest_account_id} to user_id={user_id} "
+            f"(remote_count={len(candidates)})"
+        )
+        return await self.handle_unipile_callback(
+            user_id=user_id,
+            account_id=latest_account_id,
+            status="success",
+        )
+
+    def _get_redirect_uri(self) -> str:
+        configured = os.getenv("LINKEDIN_SOCIAL_REDIRECT_URI")
+        if configured and not _is_placeholder_backend_url(configured.strip()):
+            return configured.strip()
+        backend_url = self._resolve_public_backend_url()
+        return f"{backend_url}/api/linkedin-social/callback"
+
+    def _build_oauth_state(self, user_id: str, state: Optional[str] = None) -> str:
+        if state and ":" in state:
+            return state
+        token = state or secrets.token_urlsafe(32)
+        return f"{user_id}:{token}"
+
+    def _extract_user_id_from_state(self, state: str) -> Optional[str]:
+        if ":" not in state:
+            return None
+        return state.split(":", 1)[0]
+
+    def _get_unipile_redirect_urls(self, user_id: str) -> Dict[str, str]:
+        """Build Unipile redirect URLs for OAuth callback and webhook notification."""
+        backend_url = self._resolve_public_backend_url()
+        encoded_name = quote(user_id, safe="")
+        callback_base = f"{backend_url}/api/linkedin-social/callback"
+        return {
+            "success": (
+                f"{callback_base}?provider=unipile&status=success&name={encoded_name}"
+            ),
+            "failure": (
+                f"{callback_base}?provider=unipile&status=error&name={encoded_name}"
+            ),
+            "notify": f"{backend_url}/api/unipile/webhook",
+        }
+
+    async def generate_authorization_url(
+        self, user_id: str, state: Optional[str] = None
+    ) -> Dict[str, str]:
+        """Return OAuth authorization URL for Zernio, Unipile, or native LinkedIn based on LINKEDIN_PROVIDER."""
+        provider = os.getenv("LINKEDIN_PROVIDER", "zernio").lower()
+        oauth_state = self._build_oauth_state(user_id, state)
+
+        if provider == "zernio":
+            api_key = os.getenv("ZERNIO_API_KEY")
+            if not api_key:
+                logger.error(f"[LinkedInConnect] ZERNIO_API_KEY missing user_id={user_id}")
+                raise ValueError("ZERNIO_API_KEY is not configured")
+
+            profile_id = self.ensure_zernio_profile(user_id)
+            logger.info(
+                f"[LinkedInConnect] generating Zernio auth URL user_id={user_id} "
+                f"profile_id={profile_id}"
+            )
+
+            redirect_uri = self._get_redirect_uri()
+            redirect_with_state = (
+                f"{redirect_uri}?alwrity_state={quote(oauth_state, safe='')}"
+            )
+            base_url = zernio_base_url()
+            connect_data = get_connect_url_sync(
+                api_key,
+                base_url,
+                profile_id,
+                redirect_with_state,
+            )
+            if not self.store_oauth_state(user_id, oauth_state):
+                raise RuntimeError("Failed to persist OAuth state")
+            return {
+                "auth_url": connect_data["authUrl"],
+                "state": oauth_state,
+                "provider": "zernio",
+            }
+
+        if provider == "unipile":
+            api_key = os.getenv("UNIPILE_API_KEY")
+            if not api_key:
+                logger.error(f"[LinkedInConnect] UNIPILE_API_KEY missing user_id={user_id}")
+                raise ValueError("UNIPILE_API_KEY is not configured")
+
+            logger.info(f"[LinkedInConnect] generating Unipile auth URL user_id={user_id}")
+
+            # Import Unipile client here to avoid circular imports
+            from services.integrations.linkedin.unipile_client import UnipileClient
+
+            client = UnipileClient()
+            redirect_urls = self._get_unipile_redirect_urls(user_id)
+            backend_url = self._resolve_public_backend_url()
+            logger.info(
+                f"[LinkedInConnect] Unipile redirect base_url={backend_url} user_id={user_id} "
+                f"success={redirect_urls['success']}"
+            )
+
+            try:
+                result = await client.create_hosted_auth_link(
+                    user_id=user_id,
+                    success_redirect_url=redirect_urls["success"],
+                    failure_redirect_url=redirect_urls["failure"],
+                    notify_url=redirect_urls["notify"],
+                    providers=["LINKEDIN"],
+                )
+            except Exception as e:
+                logger.error(f"[LinkedInConnect] Failed to create Unipile auth link: {e}")
+                raise ValueError(f"Failed to generate Unipile auth URL: {e}")
+
+            logger.info(f"[LinkedInConnect] Unipile auth URL generated for user={user_id}")
+            return {
+                "auth_url": result.auth_url,
+                "state": user_id,  # Unipile uses 'name' param for user matching
+                "provider": "unipile",
+            }
+
+        client_id = os.getenv("LINKEDIN_CLIENT_ID")
+        if not client_id:
+            raise ValueError("LINKEDIN_CLIENT_ID is not configured for native OAuth")
+
+        code_verifier = (
+            base64.urlsafe_b64encode(secrets.token_bytes(32))
+            .decode("utf-8")
+            .rstrip("=")
+        )
+        code_challenge = (
+            base64.urlsafe_b64encode(
+                hashlib.sha256(code_verifier.encode("utf-8")).digest()
+            )
+            .decode("utf-8")
+            .rstrip("=")
+        )
+        redirect_uri = self._get_redirect_uri()
+        scopes = "r_liteprofile r_emailaddress w_member_social"
+        params = urlencode(
+            {
+                "response_type": "code",
+                "client_id": client_id,
+                "redirect_uri": redirect_uri,
+                "scope": scopes,
+                "state": oauth_state,
+                "code_challenge": code_challenge,
+                "code_challenge_method": "S256",
+            }
+        )
+        if not self.store_oauth_state(user_id, oauth_state, code_verifier=code_verifier):
+            raise RuntimeError("Failed to persist OAuth state")
+
+        return {
+            "auth_url": f"https://www.linkedin.com/oauth/v2/authorization?{params}",
+            "state": oauth_state,
+            "provider": "native",
+        }
+
+    def _log_zernio_callback_params(
+        self, user_id: str, query_params: Mapping[str, str]
+    ) -> None:
+        """Log callback query keys/values once (secrets redacted) for OAuth debugging."""
+        redacted_keys = {"temptoken", "temp_token", "code", "access_token"}
+        safe: Dict[str, str] = {}
+        for key, value in query_params.items():
+            if key.lower() in redacted_keys:
+                safe[key] = "<redacted>" if value else value
+            else:
+                safe[key] = value
+        logger.info(
+            f"[LinkedInConnect] Zernio callback query params user_id={user_id} params={safe}"
+        )
+
+    @staticmethod
+    def _parse_headless_user_profile(query_params: Mapping[str, str]) -> dict[str, Any]:
+        raw = query_params.get("userProfile") or query_params.get("user_profile") or ""
+        if not raw:
+            logger.warning("[LinkedInConnect] headless callback missing userProfile")
+            return {}
+        try:
+            return json.loads(unquote(raw))
+        except (json.JSONDecodeError, TypeError) as exc:
+            logger.warning(f"[LinkedInConnect] headless userProfile parse failed: {exc}")
+            return {}
+
+    def _validate_zernio_callback_state(
+        self, user_id: str, query_params: Mapping[str, str]
+    ) -> bool:
+        alwrity_state = query_params.get("alwrity_state")
+        if not alwrity_state:
+            return True
+        state_user = self._extract_user_id_from_state(alwrity_state)
+        if state_user and state_user != user_id:
+            logger.error(
+                f"[LinkedInConnect] OAuth state user mismatch user_id={user_id} "
+                f"state_user={state_user}"
+            )
+            return False
+        if not self._oauth_state_is_valid(user_id, alwrity_state):
+            logger.error(f"[LinkedInConnect] invalid or expired OAuth state user_id={user_id}")
+            return False
+        self.consume_oauth_state(user_id, alwrity_state)
+        return True
+
+    def finalize_headless_personal_connect(
+        self, user_id: str, query_params: Mapping[str, str]
+    ) -> bool:
+        """Complete headless LinkedIn OAuth by selecting personal account server-side."""
+        self._log_zernio_callback_params(user_id, query_params)
+
+        if not self._validate_zernio_callback_state(user_id, query_params):
+            return False
+
+        temp_token = query_params.get("tempToken") or query_params.get("temp_token")
+        if not temp_token:
+            logger.error(f"[LinkedInConnect] headless callback missing tempToken user_id={user_id}")
+            return False
+
+        api_key = os.getenv("ZERNIO_API_KEY")
+        if not api_key:
+            logger.error(f"[LinkedInConnect] ZERNIO_API_KEY missing during callback user_id={user_id}")
+            return False
+
+        profile_id = (
+            query_params.get("profileId")
+            or query_params.get("profile_id")
+            or self._get_stored_zernio_profile_id(user_id)
+        )
+        if not profile_id:
+            logger.error(f"[LinkedInConnect] headless callback missing profileId user_id={user_id}")
+            return False
+
+        user_profile = self._parse_headless_user_profile(query_params)
+        try:
+            result = select_linkedin_organization_sync(
+                api_key,
+                zernio_base_url(),
+                profile_id,
+                temp_token,
+                user_profile,
+                account_type="personal",
+            )
+        except Exception as exc:
+            logger.error(
+                f"[LinkedInConnect] headless select-organization failed user_id={user_id}: {exc}"
+            )
+            return False
+
+        parsed = parse_select_linkedin_account_response(result)
+        account_id = parsed.get("account_id")
+        if not account_id:
+            logger.error(
+                f"[LinkedInConnect] headless select-organization missing accountId "
+                f"user_id={user_id}"
+            )
+            return False
+
+        account_name = parsed.get("display_name")
+        stored = self.store_zernio_credentials(
+            user_id=user_id,
+            zernio_api_key=api_key,
+            zernio_account_id=account_id,
+            zernio_org_account_id=None,
+            account_name=account_name,
+            zernio_profile_id=profile_id,
+        )
+        if not stored:
+            logger.error(f"[LinkedInConnect] headless credential store failed user_id={user_id}")
+            return False
+
+        logger.warning(
+            f"[LinkedInConnect] headless personal connected user_id={user_id} "
+            f"account_id={account_id} account_type={parsed.get('account_type')}"
+        )
+        return True
+
+    def _oauth_state_is_valid(self, user_id: str, state: str) -> bool:
+        try:
+            self._init_db(user_id)
+            db_path = self._get_db_path(user_id)
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    SELECT expires_at, used_at
+                    FROM linkedin_oauth_states
+                    WHERE user_id = ? AND state = ?
+                    """,
+                    (user_id, state),
+                )
+                row = cursor.fetchone()
+                if not row:
+                    return False
+                expires_at_str, used_at = row
+                if used_at:
+                    return False
+                try:
+                    expires_at = datetime.fromisoformat(str(expires_at_str))
+                    if expires_at < datetime.now():
+                        return False
+                except Exception:
+                    return False
+                return True
+        except Exception as e:
+            logger.error(f"Failed to validate LinkedIn OAuth state for user {user_id}: {e}")
+            return False
+
+    def consume_oauth_state(self, user_id: str, state: str) -> Optional[str]:
+        """Validate and consume one-time OAuth state; returns code_verifier if present."""
+        if not self._oauth_state_is_valid(user_id, state):
+            return None
+        try:
+            self._init_db(user_id)
+            db_path = self._get_db_path(user_id)
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    SELECT id, code_verifier
+                    FROM linkedin_oauth_states
+                    WHERE user_id = ? AND state = ?
+                    """,
+                    (user_id, state),
+                )
+                row = cursor.fetchone()
+                if not row:
+                    return None
+                row_id, code_verifier = row
+                cursor.execute(
+                    """
+                    UPDATE linkedin_oauth_states
+                    SET used_at = CURRENT_TIMESTAMP
+                    WHERE id = ?
+                    """,
+                    (row_id,),
+                )
+                conn.commit()
+                return code_verifier
+        except Exception as e:
+            logger.error(f"Failed to consume LinkedIn OAuth state for user {user_id}: {e}")
+            return None
+
+    def peek_oauth_state_user(self, state: str) -> Optional[str]:
+        """Return user_id for a valid unused OAuth state without consuming it."""
+        user_id = self._extract_user_id_from_state(state)
+        if not user_id:
+            return None
+        if self._oauth_state_is_valid(user_id, state):
+            return user_id
+        return None
+
+    def consume_oauth_state_for_user(self, state: str) -> Optional[str]:
+        """Validate OAuth state and return the owning user_id."""
+        user_id = self._extract_user_id_from_state(state)
+        if not user_id:
+            return None
+        if not self._oauth_state_is_valid(user_id, state):
+            return None
+        self.consume_oauth_state(user_id, state)
+        return user_id
+
+    def handle_zernio_connect_callback(
+        self, user_id: str, query_params: Mapping[str, str]
+    ) -> bool:
+        """Persist Zernio credentials after connect redirect (headless or standard)."""
+        temp_token = query_params.get("tempToken") or query_params.get("temp_token")
+        if temp_token:
+            return self.finalize_headless_personal_connect(user_id, query_params)
+
+        self._log_zernio_callback_params(user_id, query_params)
+
+        connected = query_params.get("connected")
+        account_id = query_params.get("accountId") or query_params.get("account_id")
+        if not account_id and connected != "linkedin":
+            return False
+
+        api_key = os.getenv("ZERNIO_API_KEY")
+        if not api_key:
+            logger.error(f"[LinkedInConnect] ZERNIO_API_KEY missing during callback user_id={user_id}")
+            return False
+
+        if not self._validate_zernio_callback_state(user_id, query_params):
+            return False
+
+        try:
+            self.sync_zernio_accounts(user_id)
+            logger.info(f"[LinkedInConnect] Zernio account sync succeeded user_id={user_id}")
+            return True
+        except Exception as e:
+            logger.error(f"[LinkedInConnect] Zernio account sync failed user_id={user_id}: {e}")
+            if not account_id:
+                return False
+            username = query_params.get("username")
+            profile_id = self._get_stored_zernio_profile_id(user_id)
+            return self.store_zernio_credentials(
+                user_id=user_id,
+                zernio_api_key=api_key,
+                zernio_account_id=account_id,
+                account_name=username,
+                zernio_profile_id=profile_id,
+            )
+
+    def handle_native_oauth_callback(
+        self, user_id: str, code: str, state: str
+    ) -> Optional[Dict[str, Any]]:
+        """Exchange native LinkedIn OAuth code for tokens and store them."""
+        state_user = self._extract_user_id_from_state(state)
+        if state_user and state_user != user_id:
+            logger.error("LinkedIn OAuth state user mismatch")
+            return None
+
+        code_verifier = self.consume_oauth_state(user_id, state)
+        if not code_verifier:
+            logger.error("Invalid or expired LinkedIn OAuth state")
+            return None
+
+        client_id = os.getenv("LINKEDIN_CLIENT_ID")
+        client_secret = os.getenv("LINKEDIN_CLIENT_SECRET")
+        if not client_id or not client_secret:
+            logger.error("LINKEDIN_CLIENT_ID/SECRET not configured")
+            return None
+
+        redirect_uri = self._get_redirect_uri()
+        try:
+            response = requests.post(
+                "https://www.linkedin.com/oauth/v2/accessToken",
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": redirect_uri,
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "code_verifier": code_verifier,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=30,
+            )
+            if response.status_code != 200:
+                logger.error(
+                    f"LinkedIn OAuth token exchange failed: "
+                    f"{response.status_code} - {response.text}"
+                )
+                return None
+            token_info = response.json()
+            access_token = token_info.get("access_token")
+            if not access_token:
+                return None
+            refresh_token = token_info.get("refresh_token")
+            expires_in = token_info.get("expires_in", 3600)
+            expires_at = (datetime.now() + timedelta(seconds=expires_in)).isoformat()
+            stored = self.store_native_tokens(
+                user_id=user_id,
+                access_token=access_token,
+                refresh_token=refresh_token,
+                expires_at=expires_at,
+            )
+            if not stored:
+                return None
+            return {
+                "access_token": access_token,
+                "expires_in": expires_in,
+                "expires_at": expires_at,
+            }
+        except Exception as e:
+            logger.error(f"LinkedIn native OAuth callback error for user {user_id}: {e}")
+            return None
+
+    async def handle_unipile_callback(
+        self,
+        user_id: str,
+        account_id: str,
+        status: str,
+        error_message: Optional[str] = None,
+    ) -> bool:
+        """
+        Handle Unipile OAuth callback and store credentials.
+
+        This method is called after the user completes authentication on
+        the Unipile hosted auth page. Unipile redirects to our callback
+        with the account_id and status.
+
+        Args:
+            user_id: Internal user ID (passed as 'name' param to Unipile)
+            account_id: Unipile account ID from successful auth
+            status: 'success' or 'error'
+            error_message: Error details if status is 'error'
+
+        Returns:
+            True if credentials stored successfully
+        """
+        if status != "success":
+            logger.error(
+                f"[LinkedInConnect] Unipile callback failed for user={user_id}: {error_message}"
+            )
+            return False
+
+        if not account_id:
+            logger.error(f"[LinkedInConnect] Unipile callback missing account_id for user={user_id}")
+            return False
+
+        # Fetch account details from Unipile to get account name
+        from services.integrations.linkedin.unipile_client import UnipileClient
+
+        client = UnipileClient()
+        account_name = None
+        profile_urn = None
+
+        try:
+            account_data = await client.get_account(account_id)
+            from services.integrations.linkedin.unipile_provider import (
+                unipile_display_name_from_item,
+            )
+
+            account_name = unipile_display_name_from_item(
+                account_data,
+                user_id=user_id,
+            )
+            profile_urn = account_data.get("profile_urn") or account_data.get("urn")
+            logger.info(
+                f"[LinkedInConnect] Fetched Unipile account details for user={user_id}, "
+                f"account_name={account_name}"
+            )
+        except Exception as e:
+            logger.warning(
+                f"[LinkedInConnect] Could not fetch Unipile account details for user={user_id}: {e}. "
+                "Proceeding with account_id only."
+            )
+
+        # Store credentials
+        stored = self.store_unipile_credentials(
+            user_id=user_id,
+            unipile_account_id=account_id,
+            account_name=account_name,
+            profile_urn=profile_urn,
+        )
+
+        if stored:
+            logger.info(
+                f"[LinkedInConnect] Unipile callback succeeded for user={user_id}, account_id={account_id}"
+            )
+        else:
+            logger.error(f"[LinkedInConnect] Failed to store Unipile credentials for user={user_id}")
+
+        return stored
+
+    def store_oauth_state(
+        self,
+        user_id: str,
+        state: str,
+        code_verifier: Optional[str] = None,
+        ttl_seconds: int = 600,
+    ) -> bool:
+        try:
+            self._init_db(user_id)
+            expires_at = datetime.now() + timedelta(seconds=ttl_seconds)
+            db_path = self._get_db_path(user_id)
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    INSERT OR REPLACE INTO linkedin_oauth_states
+                    (user_id, state, code_verifier, expires_at, created_at, used_at)
+                    VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, NULL)
+                    """,
+                    (user_id, state, code_verifier, expires_at.isoformat()),
+                )
+                conn.commit()
+            return True
+        except Exception as e:
+            logger.error(f"Failed to store LinkedIn OAuth state for user {user_id}: {e}")
+            return False

--- a/backend/services/integrations/oauth_callback_utils.py
+++ b/backend/services/integrations/oauth_callback_utils.py
@@ -65,13 +65,20 @@ def build_oauth_callback_html(
           var payload = {payload_json};
           var targetOrigin = {target_origin_json};
           var destination = window.opener || window.parent;
-          if (destination && targetOrigin) {{
-            try {{
-              destination.postMessage(payload, targetOrigin);
-              window.close();
-              return;
-            }} catch (_e) {{}}
+          if (destination) {{
+            if (targetOrigin) {{
+              try {{
+                destination.postMessage(payload, targetOrigin);
+              }} catch (_e) {{}}
+            }} else {{
+              try {{
+                destination.postMessage(payload, '*');
+              }} catch (_e2) {{}}
+            }}
           }}
+          try {{
+            window.close();
+          }} catch (_e3) {{}}
         }})();
       </script>
     </body>

--- a/backend/services/llm_providers/gemini_provider.py
+++ b/backend/services/llm_providers/gemini_provider.py
@@ -279,12 +279,47 @@ def gemini_pro_text_gen(prompt, temperature=0.7, top_p=0.9, top_k=40, max_tokens
         return str(e)
 
 def _dict_to_types_schema(schema: Dict[str, Any]) -> types.Schema:
-    """Convert a lightweight dict schema to google.genai.types.Schema."""
+    """Convert a JSON schema dict to google.genai.types.Schema."""
     if not isinstance(schema, dict):
         raise ValueError("response_schema must be a dict compatible with types.Schema")
 
+    defs: Dict[str, Any] = {}
+    if isinstance(schema.get("$defs"), dict):
+        defs.update(schema["$defs"])
+    if isinstance(schema.get("definitions"), dict):
+        defs.update(schema["definitions"])
+
+    def _resolve_ref(node: Dict[str, Any]) -> Dict[str, Any]:
+        ref = node.get("$ref")
+        if not isinstance(ref, str) or not ref.startswith("#/"):
+            return node
+
+        parts = ref.lstrip("#/").split("/")
+        if parts and parts[0] in ("$defs", "definitions"):
+            parts = parts[1:]
+
+        target: Any = defs
+        for part in parts:
+            if isinstance(target, dict) and part in target:
+                target = target[part]
+            else:
+                logger.warning(
+                    "Gemini schema $ref could not be resolved ref={} part={}",
+                    ref,
+                    part,
+                )
+                return node
+        return target if isinstance(target, dict) else node
+
     def _convert(node: Dict[str, Any]) -> types.Schema:
+        if not isinstance(node, dict):
+            return types.Schema(type=types.Type.STRING)
+
+        if "$ref" in node:
+            node = _resolve_ref(node)
+
         node_type = (node.get("type") or "OBJECT").upper()
+
         if node_type == "OBJECT":
             props = node.get("properties") or {}
             props_types: Dict[str, types.Schema] = {}
@@ -293,22 +328,50 @@ def _dict_to_types_schema(schema: Dict[str, Any]) -> types.Schema:
                     props_types[key] = _convert(prop)
                 else:
                     props_types[key] = types.Schema(type=types.Type.STRING)
-            return types.Schema(type=types.Type.OBJECT, properties=props_types if props_types else None)
-        elif node_type == "ARRAY":
+            kwargs: Dict[str, Any] = {
+                "type": types.Type.OBJECT,
+                "properties": props_types if props_types else None,
+            }
+            required = node.get("required")
+            if isinstance(required, list):
+                kwargs["required"] = [str(item) for item in required]
+            return types.Schema(**kwargs)
+
+        if node_type == "ARRAY":
             items_node = node.get("items")
-            if isinstance(items_node, dict):
-                item_schema = _convert(items_node)
-            else:
-                item_schema = types.Schema(type=types.Type.STRING)
-            return types.Schema(type=types.Type.ARRAY, items=item_schema)
-        elif node_type == "NUMBER":
+            item_schema = (
+                _convert(items_node)
+                if isinstance(items_node, dict)
+                else types.Schema(type=types.Type.STRING)
+            )
+            kwargs: Dict[str, Any] = {"type": types.Type.ARRAY, "items": item_schema}
+            if isinstance(node.get("minItems"), int):
+                kwargs["minItems"] = node["minItems"]
+            if isinstance(node.get("maxItems"), int):
+                kwargs["maxItems"] = node["maxItems"]
+            return types.Schema(**kwargs)
+
+        if node_type == "STRING":
+            kwargs: Dict[str, Any] = {"type": types.Type.STRING}
+            enum_values = node.get("enum")
+            if isinstance(enum_values, list):
+                kwargs["enum"] = [str(value) for value in enum_values]
+            return types.Schema(**kwargs)
+
+        if node_type == "NUMBER":
             return types.Schema(type=types.Type.NUMBER)
-        elif node_type == "INTEGER":
+        if node_type == "INTEGER":
             return types.Schema(type=types.Type.NUMBER)
-        elif node_type == "BOOLEAN":
+        if node_type == "BOOLEAN":
             return types.Schema(type=types.Type.BOOLEAN)
-        else:
-            return types.Schema(type=types.Type.STRING)
+
+        enum_values = node.get("enum")
+        if isinstance(enum_values, list):
+            return types.Schema(
+                type=types.Type.STRING,
+                enum=[str(value) for value in enum_values],
+            )
+        return types.Schema(type=types.Type.STRING)
 
     return _convert(schema)
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -156,6 +156,34 @@ const buildCooldownError = () => {
   );
 };
 
+const isApplicationLevel502 = (error: { response?: { status?: number; data?: unknown } }): boolean => {
+  if (error.response?.status !== 502) {
+    return false;
+  }
+  const data = error.response.data;
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+  const detail = (data as { detail?: unknown }).detail;
+  return typeof detail === 'string' && detail.trim().length > 0;
+};
+
+const shouldOpenBackendCooldown = (error: {
+  response?: { status?: number; data?: unknown };
+}): boolean => {
+  if (!error.response) {
+    return true;
+  }
+  const status = error.response.status;
+  if (status === 503 || status === 504) {
+    return true;
+  }
+  if (status === 502 && isApplicationLevel502(error)) {
+    return false;
+  }
+  return typeof status === 'number' && status >= 500;
+};
+
 export const isBackendCooldownActive = (): boolean => isBackendTemporarilyUnavailable();
 
 export const getBackendCooldownSecondsRemaining = (): number => {
@@ -264,6 +292,32 @@ export class NetworkError extends Error {
   }
 }
 
+export class RequestTimeoutError extends NetworkError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RequestTimeoutError';
+  }
+}
+
+const isAxiosTimeout = (error: { code?: string; message?: string }): boolean =>
+  error.code === 'ECONNABORTED' || /timeout/i.test(error.message ?? '');
+
+const rejectNoResponseError = (error: { code?: string; message?: string }) => {
+  openBackendCooldown(error?.message || 'network_error');
+  if (isAxiosTimeout(error)) {
+    return Promise.reject(
+      new RequestTimeoutError(
+        'Request timed out before the server finished processing. Try again in a moment.'
+      )
+    );
+  }
+  return Promise.reject(
+    new NetworkError(
+      'Unable to connect to the backend server. Please check if the server is running.'
+    )
+  );
+};
+
 // Add response interceptor with automatic token refresh on 401
 apiClient.interceptors.response.use(
   (response) => {
@@ -276,19 +330,21 @@ apiClient.interceptors.response.use(
     // Handle network errors and timeouts (backend not available)
     if (!error.response) {
       // Network error, timeout, or backend not reachable
-      openBackendCooldown(error?.message || 'network_error');
-      const connectionError = new NetworkError(
-        'Unable to connect to the backend server. Please check if the server is running.'
-      );
       console.error('Network/Connection Error:', error.message || error);
-      return Promise.reject(connectionError);
+      return rejectNoResponseError(error);
     }
 
     // Handle server errors (5xx)
     if (error.response.status >= 500) {
-      openBackendCooldown(`http_${error.response.status}`);
+      if (shouldOpenBackendCooldown(error)) {
+        openBackendCooldown(`http_${error.response.status}`);
+      }
+      const detail =
+        typeof error.response.data?.detail === 'string'
+          ? error.response.data.detail
+          : undefined;
       const connectionError = new ConnectionError(
-        'Backend server is experiencing issues. Please try again later.'
+        detail || 'Backend server is experiencing issues. Please try again later.'
       );
       console.error('Server Error:', error.response.status, error.response.data);
       return Promise.reject(connectionError);
@@ -446,10 +502,7 @@ aiApiClient.interceptors.response.use(
     const originalRequest = error.config;
 
     if (!error.response) {
-      openBackendCooldown(error?.message || 'network_error');
-      return Promise.reject(
-        new NetworkError('Unable to connect to the backend server. Please check if the server is running.')
-      );
+      return rejectNoResponseError(error);
     }
 
     if (error.response.status >= 500) {
@@ -569,10 +622,7 @@ longRunningApiClient.interceptors.response.use(
     const originalRequest = error.config;
 
     if (!error.response) {
-      openBackendCooldown(error?.message || 'network_error');
-      return Promise.reject(
-        new NetworkError('Unable to connect to the backend server. Please check if the server is running.')
-      );
+      return rejectNoResponseError(error);
     }
 
     if (error.response.status >= 500) {
@@ -681,10 +731,7 @@ pollingApiClient.interceptors.response.use(
     const originalRequest = error.config;
 
     if (!error.response) {
-      openBackendCooldown(error?.message || 'network_error');
-      return Promise.reject(
-        new NetworkError('Unable to connect to the backend server. Please check if the server is running.')
-      );
+      return rejectNoResponseError(error);
     }
 
     if (error.response.status >= 500) {

--- a/frontend/src/api/linkedinSocial.ts
+++ b/frontend/src/api/linkedinSocial.ts
@@ -1,0 +1,491 @@
+/**
+ * LinkedIn Social API client (Growth Engine — connect, accounts, organizations).
+ * Separate from linkedInWriterApi.ts (content generation).
+ */
+
+import { apiClient, ConnectionError, longRunningApiClient, NetworkError, RequestTimeoutError } from './client';
+
+export interface LinkedInConnectionStatus {
+  connected: boolean;
+  provider: string;
+  has_per_user_token: boolean;
+  accounts: Array<{
+    account_id: string;
+    account_type?: string;
+    source?: string;
+  }>;
+  organizations?: Array<{
+    organization_id: string;
+    name?: string | null;
+    urn?: string | null;
+  }>;
+  account_name?: string | null;
+}
+
+export interface LinkedInAccount {
+  account_id: string;
+  account_type?: string | null;
+  username?: string | null;
+  avatar_url?: string | null;
+  platform: string;
+}
+
+export interface LinkedInOrganization {
+  organization_id: string;
+  name?: string | null;
+  urn?: string | null;
+}
+
+export interface LinkedInAccountsResponse {
+  accounts: LinkedInAccount[];
+  provider: string;
+}
+
+export interface LinkedInOrganizationsResponse {
+  organizations: LinkedInOrganization[];
+  account_id: string;
+}
+
+export interface LinkedInAuthUrlResponse {
+  authorization_url: string;
+  state: string;
+  provider: string;
+  purpose?: string;
+}
+
+export interface LinkedInDisconnectResponse {
+  success: boolean;
+  connected: boolean;
+  message?: string;
+}
+
+export interface LinkedInAnalyticsDateRange {
+  start: string;
+  endExclusive: string;
+  label: string;
+  dataLagDays: number;
+}
+
+export interface LinkedInLandingPersonalAnalytics {
+  accountId: string;
+  avatarUrl?: string | null;
+  analytics: Record<string, number | string | null>;
+  error?: string | null;
+}
+
+export interface LinkedInLandingOrgAnalytics {
+  accountId?: string | null;
+  orgId?: string | null;
+  orgName?: string | null;
+  avatarUrl?: string | null;
+  analytics: Record<string, number | string | null>;
+  error?: string | null;
+}
+
+export interface LinkedInLandingAnalyticsResponse {
+  dateRange: LinkedInAnalyticsDateRange;
+  personal: LinkedInLandingPersonalAnalytics;
+  organization: LinkedInLandingOrgAnalytics | null;
+  dataDelayNote?: string | null;
+  provider: string;
+}
+
+export type LinkedInAnalyticsTab = 'personal' | 'organization';
+
+export type LinkedInAnalyticsPresetDays = 7 | 14 | 28 | 90 | 365;
+
+export type LinkedInPersonalAnalyticsPresetRequest = {
+  presetDays: LinkedInAnalyticsPresetDays;
+};
+
+export type LinkedInPersonalAnalyticsCustomRequest = {
+  startDate: string;
+  endDate: string;
+};
+
+export type LinkedInPersonalAnalyticsRequest =
+  | LinkedInPersonalAnalyticsPresetRequest
+  | LinkedInPersonalAnalyticsCustomRequest;
+
+export interface LinkedInPersonalAnalyticsResponse {
+  dateRange: LinkedInAnalyticsDateRange;
+  personal: LinkedInLandingPersonalAnalytics;
+  provider: string;
+}
+
+export interface LinkedInProfileValidation {
+  is_profile_complete: boolean;
+  completeness_score: number;
+  missing_fields: string[];
+  optional_missing_fields: string[];
+}
+
+export type LinkedInCompletionInputType = 'text' | 'textarea' | 'tags';
+
+export interface LinkedInCompletionQuestion {
+  field_key: string;
+  label: string;
+  input_type: LinkedInCompletionInputType;
+  required: boolean;
+}
+
+export interface LinkedInProfileCompletion {
+  questions: LinkedInCompletionQuestion[];
+}
+
+/** Phase 5 — AI profile understanding (LLM fields only; server meta is separate). */
+export interface LinkedInAIProfileIntelligence {
+  professional_identity: string;
+  primary_expertise: string[];
+  industry: string;
+  experience_level: string;
+  knowledge_domains: string[];
+  writing_opportunities: string[];
+  target_audience: string[];
+  communication_style: string;
+  brand_positioning: string;
+  summary: string;
+}
+
+/** Phase 5 — intelligence cache/generation metadata. */
+export interface LinkedInProfileIntelligenceMeta {
+  source: 'cache' | 'generated';
+  ai_intelligence_updated_at?: string | null;
+}
+
+/** Phase 6 — recommended content format from backend. */
+export type LinkedInRecommendedFormat = 'LinkedIn Post' | 'LinkedIn Article';
+
+/** Phase 6 — estimated growth impact from backend. */
+export type LinkedInGrowthImpact = 'High' | 'Medium' | 'Low';
+
+/** Phase 6 — single personalized topic recommendation. */
+export interface LinkedInTopicRecommendation {
+  id: string;
+  title: string;
+  why_this_fits: string;
+  recommended_format: LinkedInRecommendedFormat;
+  target_audience: string[];
+  growth_impact: LinkedInGrowthImpact;
+}
+
+/** Phase 6 — recommendations cache/generation metadata. */
+export interface LinkedInTopicRecommendationsMeta {
+  source: 'cache' | 'generated';
+  recommendations_updated_at?: string | null;
+}
+
+/** Structured failure from the LinkedIn analysis pipeline (Phases 1–6). */
+export interface LinkedInProfileAnalysisError {
+  failed_phase: number;
+  phase_label: string;
+  error_code: string;
+  user_message: string;
+  debug_message?: string | null;
+}
+
+export interface LinkedInProfileAcquireResponse {
+  profile: Record<string, unknown>;
+  meta: {
+    source: 'cache' | 'unipile';
+    fetched_at?: string | null;
+    profile_content_hash?: string | null;
+  };
+  profile_context: Record<string, unknown>;
+  profile_context_meta: {
+    source: 'cache' | 'built';
+    profile_context_updated_at?: string | null;
+  };
+  profile_validation?: LinkedInProfileValidation | null;
+  profile_completion?: LinkedInProfileCompletion | null;
+  /** Present when profile is complete and Phase 5 intelligence was generated or cached. */
+  ai_profile_intelligence?: LinkedInAIProfileIntelligence | null;
+  ai_profile_intelligence_meta?: LinkedInProfileIntelligenceMeta | null;
+  /** Present when profile is complete and Phase 6 recommendations were generated or cached. */
+  recommendations?: LinkedInTopicRecommendation[] | null;
+  recommendations_meta?: LinkedInTopicRecommendationsMeta | null;
+  recommendations_error?: string | null;
+  last_completed_phase?: number | null;
+  analysis_error?: LinkedInProfileAnalysisError | null;
+}
+
+export interface LinkedInProfileCompleteResponse {
+  profile_context: Record<string, unknown>;
+  profile_validation: LinkedInProfileValidation;
+  profile_completion: LinkedInProfileCompletion;
+  ai_profile_intelligence?: LinkedInAIProfileIntelligence | null;
+  ai_profile_intelligence_meta?: LinkedInProfileIntelligenceMeta | null;
+}
+
+const BASE = '/api/linkedin-social';
+
+export async function getLinkedInConnectionStatus(): Promise<LinkedInConnectionStatus> {
+  const response = await apiClient.get(`${BASE}/connection/status`);
+  return response.data;
+}
+
+export async function getLinkedInAuthUrl(state?: string): Promise<LinkedInAuthUrlResponse> {
+  const response = await apiClient.get(`${BASE}/auth/url`, {
+    params: state ? { state } : undefined,
+  });
+  return response.data;
+}
+
+export async function syncLinkedInAccounts(): Promise<{
+  success: boolean;
+  accounts: LinkedInAccount[];
+}> {
+  const response = await apiClient.post(`${BASE}/sync`);
+  return response.data;
+}
+
+export async function disconnectLinkedIn(): Promise<LinkedInDisconnectResponse> {
+  const response = await apiClient.post(`${BASE}/disconnect`);
+  return response.data;
+}
+
+export function getLinkedInSocialErrorMessage(err: unknown): string {
+  if (err instanceof RequestTimeoutError) {
+    return (
+      'LinkedIn analysis is taking longer than expected. Please wait a moment and try again.'
+    );
+  }
+
+  if (err instanceof NetworkError) {
+    return 'Cannot reach the ALwrity server. Check that the backend is running and try again.';
+  }
+
+  if (err instanceof ConnectionError) {
+    return err.message || 'Backend server is experiencing issues. Please try again later.';
+  }
+
+  if (
+    err instanceof Error &&
+    err.message.includes('Backend is temporarily unavailable')
+  ) {
+    return 'The server is recovering from a prior request. Please try again in a few seconds.';
+  }
+
+  if (err && typeof err === 'object' && 'response' in err) {
+    const axiosErr = err as {
+      response?: { status?: number; data?: { detail?: string } };
+    };
+    const status = axiosErr.response?.status;
+    const detail = axiosErr.response?.data?.detail;
+
+    if (status === 402) {
+      return (
+        'LinkedIn connection requires billing on your Zernio account. ' +
+        'Add a payment method in Zernio, then try connecting again.'
+      );
+    }
+
+    if (status === 412 || status === 403) {
+      return 'Reconnect LinkedIn to grant analytics permissions, then try again.';
+    }
+
+    if (status === 503) {
+      if (typeof detail === 'string' && detail.trim()) {
+        return detail;
+      }
+      return (
+        'AI profile analysis is temporarily unavailable. Please try again in a few minutes.'
+      );
+    }
+
+    if (typeof detail === 'string' && detail.trim()) {
+      if (detail.includes('ZERNIO_API_KEY')) {
+        return 'LinkedIn is not configured on this server. Contact your administrator.';
+      }
+      const lowerDetail = detail.toLowerCase();
+      if (
+        lowerDetail.includes('personal_account_not_supported') ||
+        (lowerDetail.includes('organization account') &&
+          lowerDetail.includes('personal'))
+      ) {
+        return (
+          'Company page analytics requires a LinkedIn organization connection. ' +
+          'Connect your company page, or disconnect and reconnect selecting your organization.'
+        );
+      }
+      return detail;
+    }
+  }
+
+  if (err instanceof Error && err.message) {
+    return err.message;
+  }
+
+  return 'LinkedIn action failed. Please try again or contact support.';
+}
+
+/** @deprecated Use getLinkedInSocialErrorMessage */
+export const getLinkedInConnectErrorMessage = getLinkedInSocialErrorMessage;
+
+export async function listLinkedInAccounts(): Promise<LinkedInAccountsResponse> {
+  const response = await apiClient.get(`${BASE}/accounts`);
+  return response.data;
+}
+
+export async function listLinkedInOrganizations(
+  accountId: string
+): Promise<LinkedInOrganizationsResponse> {
+  const response = await apiClient.get(`${BASE}/organizations`, {
+    params: { account_id: accountId },
+  });
+  return response.data;
+}
+
+/** Rolling last-7-day personal + org analytics for the Writer landing page. */
+export async function getLinkedInLandingAnalytics(): Promise<LinkedInLandingAnalyticsResponse> {
+  const response = await apiClient.get(`${BASE}/analytics/landing`);
+  return response.data;
+}
+
+/** Personal profile aggregate analytics for a selected date range. */
+export async function getLinkedInPersonalAnalytics(
+  request: LinkedInPersonalAnalyticsRequest
+): Promise<LinkedInPersonalAnalyticsResponse> {
+  const params =
+    'presetDays' in request
+      ? { presetDays: request.presetDays }
+      : { startDate: request.startDate, endDate: request.endDate };
+
+  const response = await apiClient.get(`${BASE}/analytics/personal`, { params });
+  return response.data;
+}
+
+/** Normalized profile, context, validation, completion, intelligence, and recommendations (Phases 1–6). */
+export async function getLinkedInProfile(
+  refresh = false,
+  refreshIntelligence = false,
+  refreshRecommendations = false
+): Promise<LinkedInProfileAcquireResponse> {
+  const params: Record<string, boolean> = {};
+  if (refresh) {
+    params.refresh = true;
+  }
+  if (refreshIntelligence) {
+    params.refresh_intelligence = true;
+  }
+  if (refreshRecommendations) {
+    params.refresh_recommendations = true;
+  }
+
+  // Phases 5–6 run Gemini LLM calls; full pipeline can exceed the 60s default timeout.
+  const client =
+    refreshIntelligence || refreshRecommendations ? longRunningApiClient : apiClient;
+
+  const response = await client.get(`${BASE}/profile`, {
+    params: Object.keys(params).length > 0 ? params : undefined,
+  });
+  return response.data;
+}
+
+/** Run the full LinkedIn analysis pipeline (Phases 1–6) for topic suggestions. */
+export async function runLinkedInTopicAnalysis(): Promise<LinkedInProfileAcquireResponse> {
+  console.info('[TopicSuggestion] starting full analysis pipeline (Phases 1–6)');
+  return getLinkedInProfile(true, true, true);
+}
+
+const _PHASE_LABELS: Record<number, string> = {
+  1: 'Acquire Profile Data',
+  2: 'Build Profile Context',
+  3: 'Validate Profile',
+  4: 'Profile Completion',
+  5: 'AI Profile Intelligence',
+  6: 'Topic Recommendations',
+};
+
+/** Map HTTP failures from GET /profile to a structured analysis error for debugging. */
+export function mapProfileHttpErrorToAnalysisError(err: unknown): LinkedInProfileAnalysisError {
+  const fallback: LinkedInProfileAnalysisError = {
+    failed_phase: 1,
+    phase_label: _PHASE_LABELS[1],
+    error_code: 'request_failed',
+    user_message: getLinkedInSocialErrorMessage(err),
+    debug_message: err instanceof Error ? err.message : String(err),
+  };
+
+  if (!err || typeof err !== 'object' || !('response' in err)) {
+    if (err instanceof RequestTimeoutError) {
+      return {
+        failed_phase: 1,
+        phase_label: _PHASE_LABELS[1],
+        error_code: 'request_timeout',
+        user_message: getLinkedInSocialErrorMessage(err),
+        debug_message: err.message,
+      };
+    }
+    return fallback;
+  }
+
+  const axiosErr = err as {
+    response?: { status?: number; data?: { detail?: string } };
+  };
+  const status = axiosErr.response?.status;
+  const detail = axiosErr.response?.data?.detail ?? '';
+
+  if (status === 401) {
+    return {
+      failed_phase: 1,
+      phase_label: _PHASE_LABELS[1],
+      error_code: 'not_connected',
+      user_message: 'LinkedIn account is not connected. Please connect and try again.',
+      debug_message: detail || fallback.debug_message,
+    };
+  }
+  if (status === 502) {
+    return {
+      failed_phase: 1,
+      phase_label: _PHASE_LABELS[1],
+      error_code: 'unipile_fetch_failed',
+      user_message: 'Could not load your LinkedIn profile. Check your connection and try again.',
+      debug_message: detail || fallback.debug_message,
+    };
+  }
+  if (detail.toLowerCase().includes('context')) {
+    return {
+      failed_phase: 2,
+      phase_label: _PHASE_LABELS[2],
+      error_code: 'context_build_failed',
+      user_message: 'Could not process your LinkedIn profile data. Please try again.',
+      debug_message: detail,
+    };
+  }
+  if (detail.toLowerCase().includes('validat')) {
+    return {
+      failed_phase: 3,
+      phase_label: _PHASE_LABELS[3],
+      error_code: 'validation_failed',
+      user_message: 'Could not validate your LinkedIn profile. Please try again.',
+      debug_message: detail,
+    };
+  }
+
+  return {
+    ...fallback,
+    debug_message: detail || fallback.debug_message,
+  };
+}
+
+export function logProfileAnalysisError(
+  context: string,
+  error: LinkedInProfileAnalysisError
+): void {
+  console.error(`[TopicSuggestion] ${context}`, {
+    phase: error.failed_phase,
+    phaseLabel: error.phase_label,
+    errorCode: error.error_code,
+    userMessage: error.user_message,
+    debugMessage: error.debug_message,
+  });
+}
+
+/** Submit profile completion answers and receive updated validation state. */
+export async function completeLinkedInProfile(
+  answers: Record<string, string | string[]>
+): Promise<LinkedInProfileCompleteResponse> {
+  const response = await apiClient.post(`${BASE}/profile/complete`, { answers });
+  return response.data;
+}

--- a/frontend/src/components/LinkedInWriter/LinkedInWriter.tsx
+++ b/frontend/src/components/LinkedInWriter/LinkedInWriter.tsx
@@ -9,6 +9,7 @@ import RegisterLinkedInActions from './RegisterLinkedInActions';
 import RegisterLinkedInEditActions from './RegisterLinkedInEditActions';
 import RegisterLinkedInActionsEnhanced from './RegisterLinkedInActionsEnhanced';
 import { Header, ContentEditor, LoadingIndicator, WelcomeMessage, ProgressTracker, type ProgressStep } from './components';
+import PublishLinkedInPanel from './components/PublishLinkedInPanel';
 import { useCopilotActions } from './components/CopilotActions';
 import { useLinkedInWriter } from './hooks/useLinkedInWriter';
 import { useCopilotPersistence } from './utils/enhancedPersistence';
@@ -487,6 +488,8 @@ Always use the most appropriate tool for the user's request.`.trim();
               </Button>
             </div>
           )}
+
+          {draft && !isGenerating && <PublishLinkedInPanel draft={draft} />}
           
         </>) : (
           /* Welcome Message - Show when no content */

--- a/frontend/src/components/LinkedInWriter/components/LinkedInConnectedProfile.tsx
+++ b/frontend/src/components/LinkedInWriter/components/LinkedInConnectedProfile.tsx
@@ -1,0 +1,341 @@
+import React from 'react';
+import { LinkedIn as LinkedInIcon, Business as BusinessIcon } from '@mui/icons-material';
+import type { LinkedInOrganization } from '../../../api/linkedinSocial';
+import type { LinkedInPostTarget } from '../../../hooks/useLinkedInSocialConnection';
+import type { LinkedInProfileSummary } from '../utils/linkedInProfileSummary';
+import { getInitials } from '../utils/linkedInProfileSummary';
+import { linkedInPlaceholderCardStyles } from './linkedInPlaceholderStyles';
+
+/**
+ * @deprecated Replaced by `LinkedInAnalyticsDashboard` for the Writer landing page.
+ * Kept for reference; styles live in `linkedInPlaceholderStyles.ts`.
+ */
+
+const SELECT_STYLE: React.CSSProperties = {
+  width: '100%',
+  padding: '10px 12px',
+  borderRadius: 10,
+  border: '1px solid #e2e8f0',
+  backgroundColor: '#fff',
+  fontSize: 14,
+  color: '#334155',
+  marginTop: 6,
+};
+
+interface LinkedInConnectedProfileProps {
+  summary: LinkedInProfileSummary;
+  warning?: string | null;
+  organizations?: LinkedInOrganization[];
+  selectedTarget?: LinkedInPostTarget;
+  selectedOrgId?: string;
+  onTargetChange?: (target: LinkedInPostTarget) => void;
+  onOrgChange?: (orgId: string) => void;
+  onDisconnect?: () => void;
+  isDisconnecting?: boolean;
+  disconnectError?: string | null;
+}
+
+export const LinkedInConnectedProfile: React.FC<LinkedInConnectedProfileProps> = ({
+  summary,
+  warning,
+  organizations = [],
+  selectedTarget = 'profile',
+  selectedOrgId = '',
+  onTargetChange,
+  onOrgChange,
+  onDisconnect,
+  isDisconnecting = false,
+  disconnectError,
+}) => {
+  const visiblePages = summary.companyPages;
+  const showPostAs = Boolean(onTargetChange);
+  const showDisconnect = Boolean(onDisconnect);
+
+  return (
+    <div style={linkedInPlaceholderCardStyles.wrapper}>
+      <div style={linkedInPlaceholderCardStyles.inner}>
+        <div
+          style={{
+            position: 'absolute',
+            top: '-50%',
+            left: '-50%',
+            width: '200%',
+            height: '200%',
+            background:
+              'radial-gradient(circle, rgba(10, 102, 194, 0.08) 0%, transparent 70%)',
+            zIndex: 0,
+          }}
+        />
+
+        <div style={{ position: 'relative', zIndex: 1 }}>
+          {showDisconnect && (
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                marginBottom: 12,
+              }}
+            >
+              <button
+                type="button"
+                onClick={onDisconnect}
+                disabled={isDisconnecting}
+                style={{
+                  padding: '6px 14px',
+                  borderRadius: 8,
+                  border: '1px solid #fca5a5',
+                  backgroundColor: '#fff',
+                  color: '#b91c1c',
+                  fontSize: 13,
+                  fontWeight: 600,
+                  cursor: isDisconnecting ? 'default' : 'pointer',
+                  opacity: isDisconnecting ? 0.7 : 1,
+                }}
+              >
+                {isDisconnecting ? 'Disconnecting...' : 'Disconnect'}
+              </button>
+            </div>
+          )}
+
+          {disconnectError && (
+            <p
+              role="alert"
+              style={{
+                margin: '0 0 12px',
+                padding: '10px 12px',
+                borderRadius: 8,
+                backgroundColor: '#fef2f2',
+                border: '1px solid #fecaca',
+                color: '#b91c1c',
+                fontSize: 13,
+                lineHeight: 1.5,
+              }}
+            >
+              {disconnectError}
+            </p>
+          )}
+
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: 16,
+              flexWrap: 'wrap',
+            }}
+          >
+            <div
+              style={{
+                width: 56,
+                height: 56,
+                borderRadius: '50%',
+                background: 'linear-gradient(135deg, #0A66C2 0%, #004182 100%)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: '#fff',
+                fontWeight: 700,
+                fontSize: 18,
+                flexShrink: 0,
+                boxShadow: '0 4px 12px rgba(10, 102, 194, 0.35)',
+              }}
+              aria-hidden
+            >
+              {getInitials(summary.displayName)}
+            </div>
+
+            <div style={{ flex: 1, minWidth: 200 }}>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  marginBottom: 4,
+                }}
+              >
+                <LinkedInIcon sx={{ color: '#0A66C2', fontSize: 22 }} />
+                <h3
+                  style={{
+                    margin: 0,
+                    fontSize: 18,
+                    fontWeight: 700,
+                    color: '#1e293b',
+                    lineHeight: 1.3,
+                  }}
+                >
+                  {summary.displayName}
+                </h3>
+              </div>
+
+              <p
+                style={{
+                  margin: '0 0 4px',
+                  fontSize: 14,
+                  color: '#64748b',
+                  lineHeight: 1.4,
+                }}
+              >
+                {summary.accountTypeLabel} · {summary.providerLabel}
+              </p>
+
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: 13,
+                  color: '#94a3b8',
+                  lineHeight: 1.4,
+                }}
+              >
+                Connected via {summary.connectionSourceLabel.toLowerCase()}
+                {summary.accountIdDisplay ? ` · ID ${summary.accountIdDisplay}` : ''}
+              </p>
+            </div>
+          </div>
+
+          {warning && (
+            <p
+              role="status"
+              style={{
+                margin: '16px 0 0',
+                padding: '10px 12px',
+                borderRadius: 8,
+                backgroundColor: '#fffbeb',
+                border: '1px solid #fde68a',
+                color: '#92400e',
+                fontSize: 13,
+                lineHeight: 1.5,
+              }}
+            >
+              {warning}
+            </p>
+          )}
+
+          {showPostAs && (
+            <div style={{ marginTop: 20, paddingTop: 16, borderTop: '1px solid #e2e8f0' }}>
+              <label
+                htmlFor="linkedin-writer-post-as"
+                style={{
+                  fontSize: 13,
+                  fontWeight: 600,
+                  color: '#475569',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.04em',
+                }}
+              >
+                Post as
+              </label>
+              <select
+                id="linkedin-writer-post-as"
+                value={selectedTarget}
+                onChange={(e) =>
+                  onTargetChange?.(e.target.value as LinkedInPostTarget)
+                }
+                style={SELECT_STYLE}
+              >
+                <option value="profile">Personal profile</option>
+                <option value="organization">Company page</option>
+              </select>
+
+              {selectedTarget === 'organization' && (
+                <>
+                  <label
+                    htmlFor="linkedin-writer-company-page"
+                    style={{
+                      display: 'block',
+                      marginTop: 14,
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: '#475569',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.04em',
+                    }}
+                  >
+                    Company page
+                  </label>
+                  <select
+                    id="linkedin-writer-company-page"
+                    value={selectedOrgId}
+                    onChange={(e) => onOrgChange?.(e.target.value)}
+                    style={SELECT_STYLE}
+                    disabled={organizations.length === 0}
+                  >
+                    {organizations.length === 0 ? (
+                      <option value="">No company pages found</option>
+                    ) : (
+                      organizations.map((org) => (
+                        <option key={org.organization_id} value={org.organization_id}>
+                          {org.name || org.organization_id}
+                        </option>
+                      ))
+                    )}
+                  </select>
+                </>
+              )}
+            </div>
+          )}
+
+          {visiblePages.length > 0 && (
+            <div style={{ marginTop: 20, paddingTop: 16, borderTop: '1px solid #e2e8f0' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 6,
+                  marginBottom: 10,
+                }}
+              >
+                <BusinessIcon sx={{ color: '#64748b', fontSize: 18 }} />
+                <span
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: '#475569',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.04em',
+                  }}
+                >
+                  Company pages you manage
+                </span>
+              </div>
+              <ul
+                style={{
+                  margin: 0,
+                  padding: 0,
+                  listStyle: 'none',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 8,
+                }}
+              >
+                {visiblePages.map((page) => (
+                  <li
+                    key={page.id}
+                    style={{
+                      fontSize: 14,
+                      color: '#334155',
+                      paddingLeft: 4,
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 8,
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 6,
+                        height: 6,
+                        borderRadius: '50%',
+                        backgroundColor: '#0A66C2',
+                        flexShrink: 0,
+                      }}
+                    />
+                    {page.name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+

--- a/frontend/src/components/LinkedInWriter/components/LinkedInConnectedProfileCard.tsx
+++ b/frontend/src/components/LinkedInWriter/components/LinkedInConnectedProfileCard.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { getInitials } from '../utils/linkedInProfileSummary';
+import { linkedInPlaceholderCardStyles } from './linkedInPlaceholderStyles';
+
+interface LinkedInConnectedProfileCardProps {
+  displayName: string;
+  avatarUrl?: string | null;
+  onDisconnect?: () => void;
+  isDisconnecting?: boolean;
+  disconnectError?: string | null;
+}
+
+const AVATAR_SIZE = 48;
+
+const STATUS_DOT_SIZE = 10;
+
+export const LinkedInConnectedProfileCard: React.FC<LinkedInConnectedProfileCardProps> = ({
+  displayName,
+  avatarUrl,
+  onDisconnect,
+  isDisconnecting = false,
+  disconnectError,
+}) => {
+  const initials = getInitials(displayName);
+  const showDisconnect = Boolean(onDisconnect);
+
+  return (
+    <div style={linkedInPlaceholderCardStyles.wrapper}>
+      <div
+        style={{
+          ...linkedInPlaceholderCardStyles.inner,
+          minHeight: 80,
+          padding: '16px 24px',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            top: '-50%',
+            left: '-50%',
+            width: '200%',
+            height: '200%',
+            background:
+              'radial-gradient(circle, rgba(10, 102, 194, 0.08) 0%, transparent 70%)',
+            zIndex: 0,
+          }}
+        />
+
+        <div
+          style={{
+            position: 'relative',
+            zIndex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 16,
+            flexWrap: 'wrap',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+            <div style={{ position: 'relative', flexShrink: 0 }}>
+              {avatarUrl ? (
+                <img
+                  src={avatarUrl}
+                  alt="LinkedIn profile"
+                  style={{
+                    width: AVATAR_SIZE,
+                    height: AVATAR_SIZE,
+                    borderRadius: '50%',
+                    objectFit: 'cover',
+                    boxShadow: '0 2px 10px rgba(10, 102, 194, 0.2)',
+                  }}
+                />
+              ) : (
+                <div
+                  style={{
+                    width: AVATAR_SIZE,
+                    height: AVATAR_SIZE,
+                    borderRadius: '50%',
+                    background: 'linear-gradient(135deg, #0A66C2 0%, #004182 100%)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    color: '#fff',
+                    fontWeight: 700,
+                    fontSize: 18,
+                    boxShadow: '0 2px 10px rgba(10, 102, 194, 0.25)',
+                  }}
+                  aria-hidden
+                >
+                  {initials}
+                </div>
+              )}
+              <span
+                aria-hidden
+                style={{
+                  position: 'absolute',
+                  bottom: 2,
+                  right: 2,
+                  width: STATUS_DOT_SIZE,
+                  height: STATUS_DOT_SIZE,
+                  borderRadius: '50%',
+                  backgroundColor: '#10b981',
+                  border: '2px solid #fff',
+                  boxShadow: '0 0 0 1px rgba(16, 185, 129, 0.35)',
+                }}
+              />
+            </div>
+
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '4px 12px',
+                borderRadius: 999,
+                backgroundColor: '#ecfdf5',
+                border: '1px solid #a7f3d0',
+                color: '#047857',
+                fontSize: 13,
+                fontWeight: 600,
+              }}
+            >
+              <span
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  backgroundColor: '#10b981',
+                  flexShrink: 0,
+                }}
+                aria-hidden
+              />
+              Connected
+            </span>
+          </div>
+
+          {showDisconnect && (
+            <button
+              type="button"
+              onClick={onDisconnect}
+              disabled={isDisconnecting}
+              style={{
+                padding: '6px 14px',
+                borderRadius: 8,
+                border: '1px solid #fca5a5',
+                backgroundColor: '#fff',
+                color: '#b91c1c',
+                fontSize: 13,
+                fontWeight: 600,
+                cursor: isDisconnecting ? 'default' : 'pointer',
+                opacity: isDisconnecting ? 0.7 : 1,
+              }}
+            >
+              {isDisconnecting ? 'Disconnecting...' : 'Disconnect'}
+            </button>
+          )}
+        </div>
+
+        {disconnectError && (
+          <p
+            role="alert"
+            style={{
+              position: 'relative',
+              zIndex: 1,
+              margin: '12px 0 0',
+              padding: '10px 12px',
+              borderRadius: 8,
+              backgroundColor: '#fef2f2',
+              border: '1px solid #fecaca',
+              color: '#b91c1c',
+              fontSize: 13,
+              lineHeight: 1.5,
+            }}
+          >
+            {disconnectError}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/LinkedInWriter/components/LinkedInConnectionPlaceholder.tsx
+++ b/frontend/src/components/LinkedInWriter/components/LinkedInConnectionPlaceholder.tsx
@@ -1,0 +1,215 @@
+import React, { useState } from 'react';
+import { LinkedIn as LinkedInIcon } from '@mui/icons-material';
+import { CircularProgress } from '@mui/material';
+import { useLinkedInSocialConnection } from '../../../hooks/useLinkedInSocialConnection';
+import { LinkedInProfileSetupPanel } from './ProfileCompletion/LinkedInProfileSetupPanel';
+import { linkedInPlaceholderCardStyles } from './linkedInPlaceholderStyles';
+
+const DisconnectedState: React.FC<{
+  isConnecting: boolean;
+  connectError: string | null;
+  statusError: string | null;
+  onConnect: () => void;
+}> = ({ isConnecting, connectError, statusError, onConnect }) => {
+  const buttonLabel = isConnecting ? 'Connecting...' : 'Connect LinkedIn';
+  const displayStatusError = connectError ? null : statusError;
+
+  return (
+    <div style={linkedInPlaceholderCardStyles.wrapper}>
+      <div
+        style={{
+          ...linkedInPlaceholderCardStyles.inner,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 12,
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            top: '-50%',
+            left: '-50%',
+            width: '200%',
+            height: '200%',
+            background:
+              'radial-gradient(circle, rgba(10, 102, 194, 0.08) 0%, transparent 70%)',
+            zIndex: 0,
+          }}
+        />
+        <div
+          style={{
+            zIndex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 12,
+            width: '100%',
+          }}
+        >
+          <LinkedInIcon sx={{ color: '#0A66C2', fontSize: 40 }} />
+          {displayStatusError ? (
+            <p
+              role="alert"
+              style={{
+                margin: 0,
+                color: '#b91c1c',
+                fontSize: 14,
+                textAlign: 'center',
+                maxWidth: 480,
+                lineHeight: 1.5,
+              }}
+            >
+              {displayStatusError}
+            </p>
+          ) : (
+            <>
+              <p
+                style={{
+                  margin: 0,
+                  color: '#475569',
+                  fontSize: 14,
+                  textAlign: 'center',
+                  maxWidth: 520,
+                  lineHeight: 1.55,
+                }}
+              >
+                Connect your LinkedIn account to enable publishing and analytics.
+              </p>
+              <p
+                style={{
+                  margin: 0,
+                  color: '#64748b',
+                  fontSize: 13,
+                  textAlign: 'center',
+                  maxWidth: 520,
+                  lineHeight: 1.55,
+                }}
+              >
+                You&apos;ll sign in on LinkedIn in a popup. When asked, choose your{' '}
+                <strong>personal profile</strong> — that lets you post as yourself and on
+                company pages you manage.
+              </p>
+            </>
+          )}
+          <button
+            type="button"
+            onClick={onConnect}
+            disabled={isConnecting}
+            style={{
+              background: 'linear-gradient(135deg, #0A66C2 0%, #004182 100%)',
+              border: 'none',
+              borderRadius: 12,
+              padding: '12px 32px',
+              color: 'white',
+              fontSize: 15,
+              fontWeight: 700,
+              cursor: isConnecting ? 'default' : 'pointer',
+              opacity: isConnecting ? 0.7 : 1,
+              boxShadow: '0 4px 15px rgba(10, 102, 194, 0.35)',
+              transition: 'all 0.2s ease',
+              minWidth: 160,
+            }}
+          >
+            {buttonLabel}
+          </button>
+          {connectError && (
+            <p
+              role="alert"
+              style={{
+                margin: 0,
+                color: '#b91c1c',
+                fontSize: 13,
+                textAlign: 'center',
+                maxWidth: 520,
+                lineHeight: 1.5,
+              }}
+            >
+              {connectError}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const ConnectionLoadingState: React.FC = () => (
+  <div style={linkedInPlaceholderCardStyles.wrapper}>
+    <div
+      style={{
+        ...linkedInPlaceholderCardStyles.inner,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 12,
+      }}
+    >
+      <CircularProgress size={28} sx={{ color: '#0A66C2' }} />
+      <p style={{ margin: 0, color: '#64748b', fontSize: 14 }}>Loading LinkedIn...</p>
+    </div>
+  </div>
+);
+
+export const LinkedInConnectionPlaceholder: React.FC = () => {
+  const {
+    connected,
+    isLoading,
+    isConnecting,
+    connectError,
+    disconnectError,
+    error,
+    hasPerUserToken,
+    displayName,
+    avatarUrl,
+    connectWithOAuth,
+    disconnect,
+  } = useLinkedInSocialConnection();
+
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+
+  const handleConnect = async () => {
+    await connectWithOAuth();
+  };
+
+  const handleDisconnect = async () => {
+    if (!window.confirm('Disconnect LinkedIn? You can reconnect anytime.')) {
+      return;
+    }
+    setIsDisconnecting(true);
+    try {
+      await disconnect();
+    } finally {
+      setIsDisconnecting(false);
+    }
+  };
+
+  const showDisconnect = connected && hasPerUserToken;
+
+  if (isLoading) {
+    return <ConnectionLoadingState />;
+  }
+
+  if (connected) {
+    return (
+      <LinkedInProfileSetupPanel
+        displayName={displayName}
+        avatarUrl={avatarUrl}
+        onDisconnect={showDisconnect ? handleDisconnect : undefined}
+        isDisconnecting={isDisconnecting}
+        disconnectError={disconnectError}
+      />
+    );
+  }
+
+  return (
+    <DisconnectedState
+      isConnecting={isConnecting}
+      connectError={connectError}
+      statusError={error}
+      onConnect={handleConnect}
+    />
+  );
+};

--- a/frontend/src/components/LinkedInWriter/components/ProfileCompletion/LinkedInProfileSetupPanel.tsx
+++ b/frontend/src/components/LinkedInWriter/components/ProfileCompletion/LinkedInProfileSetupPanel.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+
+import { useLinkedInProfileCompletion } from '../../../../hooks/useLinkedInProfileCompletion';
+import { LinkedInConnectedProfileCard } from '../LinkedInConnectedProfileCard';
+import { TopicRecommendationsPanel } from '../TopicRecommendations/TopicRecommendationsPanel';
+import {
+  AnalysisErrorAlert,
+  TopicSuggestionIntro,
+} from '../TopicRecommendations/TopicSuggestionIntro';
+import { ProfileCompletionForm } from './ProfileCompletionForm';
+
+interface LinkedInProfileSetupPanelProps {
+  displayName: string;
+  avatarUrl?: string | null;
+  onDisconnect?: () => void;
+  isDisconnecting?: boolean;
+  disconnectError?: string | null;
+}
+
+export const LinkedInProfileSetupPanel: React.FC<LinkedInProfileSetupPanelProps> = ({
+  displayName,
+  avatarUrl,
+  onDisconnect,
+  isDisconnecting = false,
+  disconnectError,
+}) => {
+  const {
+    analysisState,
+    analysisError,
+    isAnalyzing,
+    questions,
+    isSubmitting,
+    submitError,
+    recommendations,
+    recommendationsMeta,
+    recommendationsError,
+    runTopicAnalysis,
+    submitCompletion,
+  } = useLinkedInProfileCompletion();
+
+  const handleRunAnalysis = () => {
+    void runTopicAnalysis();
+  };
+
+  const handleRetry = () => {
+    void runTopicAnalysis();
+  };
+
+  return (
+    <div style={{ width: '100%', maxWidth: 1200 }}>
+      <LinkedInConnectedProfileCard
+        displayName={displayName}
+        avatarUrl={avatarUrl}
+        onDisconnect={onDisconnect}
+        isDisconnecting={isDisconnecting}
+        disconnectError={disconnectError}
+      />
+
+      {analysisState === 'idle' && (
+        <TopicSuggestionIntro isAnalyzing={false} onRunAnalysis={handleRunAnalysis} />
+      )}
+
+      {analysisState === 'running' && (
+        <TopicSuggestionIntro isAnalyzing onRunAnalysis={handleRunAnalysis} />
+      )}
+
+      {analysisState === 'needs_completion' && questions.length > 0 && (
+        <ProfileCompletionForm
+          questions={questions}
+          onSubmit={submitCompletion}
+          isSubmitting={isSubmitting}
+          error={submitError}
+        />
+      )}
+
+      {analysisState === 'error' && analysisError && (
+        <AnalysisErrorAlert
+          error={analysisError}
+          onRetry={handleRetry}
+          isRetrying={isAnalyzing}
+        />
+      )}
+
+      {analysisState === 'complete' && (
+        <TopicRecommendationsPanel
+          recommendations={recommendations}
+          recommendationsMeta={recommendationsMeta}
+          recommendationsError={recommendationsError}
+          analysisError={analysisError}
+          isRefreshing={isAnalyzing}
+          onRetry={handleRetry}
+        />
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/LinkedInWriter/components/ProfileCompletion/ProfileCompletionForm.tsx
+++ b/frontend/src/components/LinkedInWriter/components/ProfileCompletion/ProfileCompletionForm.tsx
@@ -1,0 +1,234 @@
+import React, { useMemo, useState } from 'react';
+import { CircularProgress } from '@mui/material';
+
+import type { LinkedInCompletionQuestion } from '../../../../api/linkedinSocial';
+import { linkedInPlaceholderCardStyles } from '../linkedInPlaceholderStyles';
+
+export interface ProfileCompletionFormProps {
+  questions: LinkedInCompletionQuestion[];
+  onSubmit: (answers: Record<string, string | string[]>) => Promise<void>;
+  isSubmitting?: boolean;
+  error?: string | null;
+}
+
+const fieldWrapperStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+  width: '100%',
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 14,
+  fontWeight: 600,
+  color: '#334155',
+};
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '10px 12px',
+  borderRadius: 10,
+  border: '1px solid #e2e8f0',
+  backgroundColor: '#fff',
+  fontSize: 14,
+  color: '#334155',
+  fontFamily: 'inherit',
+  boxSizing: 'border-box',
+};
+
+function parseTagsValue(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function buildAnswersFromForm(
+  questions: LinkedInCompletionQuestion[],
+  values: Record<string, string>
+): Record<string, string | string[]> {
+  const answers: Record<string, string | string[]> = {};
+
+  for (const question of questions) {
+    const raw = values[question.field_key]?.trim() ?? '';
+    if (!raw) {
+      continue;
+    }
+
+    if (question.input_type === 'tags') {
+      const tags = parseTagsValue(raw);
+      if (tags.length > 0) {
+        answers[question.field_key] = tags;
+      }
+      continue;
+    }
+
+    answers[question.field_key] = raw;
+  }
+
+  return answers;
+}
+
+export const ProfileCompletionForm: React.FC<ProfileCompletionFormProps> = ({
+  questions,
+  onSubmit,
+  isSubmitting = false,
+  error = null,
+}) => {
+  const initialValues = useMemo(() => {
+    const next: Record<string, string> = {};
+    for (const question of questions) {
+      next[question.field_key] = '';
+    }
+    return next;
+  }, [questions]);
+
+  const [values, setValues] = useState<Record<string, string>>(initialValues);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  React.useEffect(() => {
+    setValues(initialValues);
+    setLocalError(null);
+  }, [initialValues]);
+
+  const handleChange = (fieldKey: string, value: string) => {
+    setValues((prev) => ({ ...prev, [fieldKey]: value }));
+    setLocalError(null);
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setLocalError(null);
+
+    const answers = buildAnswersFromForm(questions, values);
+    if (Object.keys(answers).length === 0) {
+      setLocalError('Please answer at least one question.');
+      return;
+    }
+
+    try {
+      await onSubmit(answers);
+    } catch {
+      // Parent sets submitError; keep form values for retry.
+    }
+  };
+
+  if (questions.length === 0) {
+    return null;
+  }
+
+  const displayError = localError ?? error;
+
+  return (
+    <div style={{ ...linkedInPlaceholderCardStyles.wrapper, marginTop: 16 }}>
+      <div style={linkedInPlaceholderCardStyles.inner}>
+        <form
+          onSubmit={handleSubmit}
+          style={{
+            position: 'relative',
+            zIndex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 16,
+            maxWidth: 560,
+            margin: '0 auto',
+          }}
+        >
+          <div>
+            <h3
+              style={{
+                margin: '0 0 6px',
+                fontSize: 18,
+                fontWeight: 700,
+                color: '#0f172a',
+              }}
+            >
+              Help us understand you better.
+            </h3>
+            <p style={{ margin: 0, fontSize: 14, color: '#64748b', lineHeight: 1.5 }}>
+              Please answer a few quick questions.
+            </p>
+          </div>
+
+          {questions.map((question) => (
+            <div key={question.field_key} style={fieldWrapperStyle}>
+              <label htmlFor={question.field_key} style={labelStyle}>
+                {question.label}
+                {question.required ? ' *' : ''}
+              </label>
+              {question.input_type === 'textarea' ? (
+                <textarea
+                  id={question.field_key}
+                  value={values[question.field_key] ?? ''}
+                  onChange={(event) =>
+                    handleChange(question.field_key, event.target.value)
+                  }
+                  rows={4}
+                  disabled={isSubmitting}
+                  style={{ ...inputStyle, resize: 'vertical', minHeight: 96 }}
+                />
+              ) : (
+                <input
+                  id={question.field_key}
+                  type="text"
+                  value={values[question.field_key] ?? ''}
+                  onChange={(event) =>
+                    handleChange(question.field_key, event.target.value)
+                  }
+                  disabled={isSubmitting}
+                  placeholder={
+                    question.input_type === 'tags'
+                      ? 'e.g. Python, FastAPI, Leadership'
+                      : undefined
+                  }
+                  style={inputStyle}
+                />
+              )}
+            </div>
+          ))}
+
+          {displayError && (
+            <p
+              role="alert"
+              style={{
+                margin: 0,
+                padding: '10px 12px',
+                borderRadius: 8,
+                backgroundColor: '#fef2f2',
+                border: '1px solid #fecaca',
+                color: '#b91c1c',
+                fontSize: 13,
+                lineHeight: 1.5,
+              }}
+            >
+              {displayError}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            style={{
+              alignSelf: 'flex-start',
+              background: 'linear-gradient(135deg, #0A66C2 0%, #004182 100%)',
+              border: 'none',
+              borderRadius: 12,
+              padding: '12px 28px',
+              color: 'white',
+              fontSize: 15,
+              fontWeight: 700,
+              cursor: isSubmitting ? 'default' : 'pointer',
+              opacity: isSubmitting ? 0.75 : 1,
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 10,
+            }}
+          >
+            {isSubmitting && <CircularProgress size={18} sx={{ color: '#fff' }} />}
+            {isSubmitting ? 'Saving...' : 'Save answers'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/LinkedInWriter/components/PublishLinkedInPanel.tsx
+++ b/frontend/src/components/LinkedInWriter/components/PublishLinkedInPanel.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  TextField,
+  Tooltip,
+  Typography,
+  Chip,
+} from '@mui/material';
+import { LinkedIn as LinkedInIcon } from '@mui/icons-material';
+import { useLinkedInSocialConnection } from '../../../hooks/useLinkedInSocialConnection';
+import {
+  applyLinkInFirstComment,
+  buildPublishPayload,
+} from '../utils/firstCommentUtils';
+
+interface PublishLinkedInPanelProps {
+  draft: string;
+}
+
+const PublishLinkedInPanel: React.FC<PublishLinkedInPanelProps> = ({ draft }) => {
+  const {
+    connected,
+    provider,
+    selectedAccountId,
+    selectedTarget,
+    selectedOrgId,
+    isLoading,
+  } = useLinkedInSocialConnection();
+
+  const [firstComment, setFirstComment] = useState('');
+  const [moveLinksEnabled, setMoveLinksEnabled] = useState(true);
+
+  useEffect(() => {
+    if (!moveLinksEnabled) return;
+    setFirstComment((prev) => {
+      if (prev.trim()) return prev;
+      const applied = applyLinkInFirstComment(draft, '', true);
+      return applied.firstComment;
+    });
+  }, [draft, moveLinksEnabled]);
+
+  const previewPayload = useMemo(
+    () => buildPublishPayload(draft, firstComment, moveLinksEnabled),
+    [draft, firstComment, moveLinksEnabled]
+  );
+
+  const canPublish = connected && !!previewPayload.content.trim();
+  const connectionLabel = connected
+    ? `Connected via ${provider}`
+    : 'Not connected — connect LinkedIn to publish';
+
+  return (
+    <Box
+      sx={{
+        mx: 3,
+        mb: 2,
+        p: 2,
+        border: '1px solid #e2e8f0',
+        borderRadius: 2,
+        bgcolor: '#f8fafc',
+      }}
+    >
+      <Box display="flex" alignItems="center" gap={1} mb={1.5}>
+        <LinkedInIcon sx={{ color: '#0A66C2', fontSize: 20 }} />
+        <Typography variant="subtitle2" sx={{ fontWeight: 600, color: '#1e293b' }}>
+          Publish to LinkedIn
+        </Typography>
+        <Chip
+          size="small"
+          label={isLoading ? 'Checking...' : connected ? 'Connected' : 'Not connected'}
+          color={connected ? 'success' : 'default'}
+          variant="outlined"
+        />
+      </Box>
+
+      <Typography variant="caption" sx={{ color: '#64748b', display: 'block', mb: 1.5 }}>
+        {connectionLabel}
+        {connected && selectedAccountId && (
+          <>
+            {' '}
+            · Post as {selectedTarget === 'organization' ? 'company page' : 'profile'}
+            {selectedTarget === 'organization' && selectedOrgId ? ` (${selectedOrgId})` : ''}
+          </>
+        )}
+      </Typography>
+
+      <FormControlLabel
+        control={
+          <Checkbox
+            size="small"
+            checked={moveLinksEnabled}
+            onChange={(e) => setMoveLinksEnabled(e.target.checked)}
+          />
+        }
+        label={
+          <Typography variant="body2" sx={{ color: '#334155' }}>
+            Move links from post to first comment (recommended for reach)
+          </Typography>
+        }
+        sx={{ mb: 1 }}
+      />
+
+      <TextField
+        fullWidth
+        size="small"
+        label="Link to include in first comment"
+        placeholder="https://example.com/your-article"
+        value={firstComment}
+        onChange={(e) => setFirstComment(e.target.value)}
+        helperText="Zernio posts links in the first comment to avoid LinkedIn reach penalties on link posts."
+        sx={{ mb: 1.5, bgcolor: '#fff' }}
+      />
+
+      <Tooltip title="Publishing ships in Phase 2 — payload is prepared with first_comment">
+        <span>
+          <Button
+            variant="contained"
+            disabled={!canPublish}
+            sx={{ bgcolor: '#0A66C2', '&:hover': { bgcolor: '#004182' } }}
+          >
+            Publish to LinkedIn
+          </Button>
+        </span>
+      </Tooltip>
+    </Box>
+  );
+};
+
+export default PublishLinkedInPanel;

--- a/frontend/src/components/LinkedInWriter/components/TopicRecommendations/TopicRecommendationCard.tsx
+++ b/frontend/src/components/LinkedInWriter/components/TopicRecommendations/TopicRecommendationCard.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { Tooltip } from '@mui/material';
+
+import type { LinkedInTopicRecommendation } from '../../../../api/linkedinSocial';
+import {
+  formatGrowthImpact,
+  formatRecommendationFormat,
+  growthImpactStyle,
+} from './topicRecommendationLabels';
+
+interface TopicRecommendationCardProps {
+  recommendation: LinkedInTopicRecommendation;
+  index: number;
+}
+
+const CARD_STYLE: React.CSSProperties = {
+  padding: '16px 18px',
+  borderRadius: 12,
+  backgroundColor: '#fff',
+  border: '1px solid #e2e8f0',
+  boxShadow: '0 1px 3px rgba(15, 23, 42, 0.06)',
+};
+
+const FORMAT_CHIP_STYLE: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '3px 10px',
+  borderRadius: 999,
+  fontSize: 12,
+  fontWeight: 600,
+  backgroundColor: '#eff6ff',
+  border: '1px solid #bfdbfe',
+  color: '#1d4ed8',
+};
+
+const AUDIENCE_CHIP_STYLE: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '2px 8px',
+  borderRadius: 999,
+  fontSize: 12,
+  fontWeight: 500,
+  backgroundColor: '#f8fafc',
+  border: '1px solid #e2e8f0',
+  color: '#475569',
+};
+
+const MAX_VISIBLE_AUDIENCE = 2;
+
+export const TopicRecommendationCard: React.FC<TopicRecommendationCardProps> = ({
+  recommendation,
+  index,
+}) => {
+  const visibleAudience = recommendation.target_audience.slice(0, MAX_VISIBLE_AUDIENCE);
+  const hiddenAudienceCount = Math.max(
+    0,
+    recommendation.target_audience.length - MAX_VISIBLE_AUDIENCE
+  );
+  const hiddenAudience = recommendation.target_audience.slice(MAX_VISIBLE_AUDIENCE);
+
+  return (
+    <article style={CARD_STYLE} aria-labelledby={`topic-rec-title-${recommendation.id}`}>
+      <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+        <span
+          aria-hidden
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: '50%',
+            backgroundColor: '#0A66C2',
+            color: '#fff',
+            fontSize: 13,
+            fontWeight: 700,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+          }}
+        >
+          {index + 1}
+        </span>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <h4
+            id={`topic-rec-title-${recommendation.id}`}
+            style={{
+              margin: '0 0 8px',
+              fontSize: 16,
+              fontWeight: 600,
+              color: '#1e293b',
+              lineHeight: 1.4,
+            }}
+          >
+            {recommendation.title}
+          </h4>
+
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 12 }}>
+            <span style={FORMAT_CHIP_STYLE}>
+              {formatRecommendationFormat(recommendation.recommended_format)}
+            </span>
+            <span style={growthImpactStyle(recommendation.growth_impact)}>
+              {formatGrowthImpact(recommendation.growth_impact)}
+            </span>
+          </div>
+
+          <p
+            style={{
+              margin: '0 0 4px',
+              fontSize: 12,
+              fontWeight: 600,
+              color: '#64748b',
+              textTransform: 'uppercase',
+              letterSpacing: '0.03em',
+            }}
+          >
+            Why this fits you
+          </p>
+          <p
+            style={{
+              margin: '0 0 12px',
+              fontSize: 14,
+              color: '#334155',
+              lineHeight: 1.5,
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            {recommendation.why_this_fits}
+          </p>
+
+          {recommendation.target_audience.length > 0 && (
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
+              <span style={{ fontSize: 12, color: '#64748b', fontWeight: 500 }}>For:</span>
+              {visibleAudience.map((audience) => (
+                <span key={audience} style={AUDIENCE_CHIP_STYLE}>
+                  {audience}
+                </span>
+              ))}
+              {hiddenAudienceCount > 0 && (
+                <Tooltip title={hiddenAudience.join(' · ')} arrow placement="top">
+                  <span style={{ ...AUDIENCE_CHIP_STYLE, cursor: 'default' }}>
+                    +{hiddenAudienceCount} more
+                  </span>
+                </Tooltip>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+};

--- a/frontend/src/components/LinkedInWriter/components/TopicRecommendations/TopicRecommendationsPanel.tsx
+++ b/frontend/src/components/LinkedInWriter/components/TopicRecommendations/TopicRecommendationsPanel.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+
+import type {
+  LinkedInTopicRecommendation,
+  LinkedInTopicRecommendationsMeta,
+  LinkedInProfileAnalysisError,
+} from '../../../../api/linkedinSocial';
+import { linkedInPlaceholderCardStyles } from '../linkedInPlaceholderStyles';
+import { TopicRecommendationCard } from './TopicRecommendationCard';
+import { formatRelativeUpdatedAt } from './topicRecommendationLabels';
+import { AnalysisErrorAlert } from './TopicSuggestionIntro';
+
+interface TopicRecommendationsPanelProps {
+  recommendations: LinkedInTopicRecommendation[] | null;
+  recommendationsMeta: LinkedInTopicRecommendationsMeta | null;
+  recommendationsError: string | null;
+  analysisError?: LinkedInProfileAnalysisError | null;
+  isRefreshing?: boolean;
+  onRetry?: () => void;
+}
+
+const SKELETON_CARD_STYLE: React.CSSProperties = {
+  padding: '16px 18px',
+  borderRadius: 12,
+  backgroundColor: '#fff',
+  border: '1px solid #e2e8f0',
+  minHeight: 120,
+  background:
+    'linear-gradient(90deg, #f1f5f9 25%, #e2e8f0 50%, #f1f5f9 75%)',
+  backgroundSize: '200% 100%',
+  animation: 'linkedinTopicRecShimmer 1.2s ease-in-out infinite',
+};
+
+const SKELETON_COUNT = 3;
+
+export const TopicRecommendationsPanel: React.FC<TopicRecommendationsPanelProps> = ({
+  recommendations,
+  recommendationsMeta,
+  recommendationsError,
+  analysisError = null,
+  isRefreshing = false,
+  onRetry,
+}) => {
+  const updatedLabel = formatRelativeUpdatedAt(
+    recommendationsMeta?.recommendations_updated_at
+  );
+  const showSkeleton = isRefreshing && !recommendations?.length;
+  const displayError = analysisError?.user_message ?? recommendationsError;
+  const showError = Boolean(displayError) && !showSkeleton;
+  const showEmpty =
+    !showSkeleton && !showError && (!recommendations || recommendations.length === 0);
+
+  return (
+    <div style={{ ...linkedInPlaceholderCardStyles.wrapper, marginTop: 16 }}>
+      <div
+        style={{
+          ...linkedInPlaceholderCardStyles.inner,
+          minHeight: 'unset',
+          padding: '20px 24px',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            top: '-50%',
+            left: '-50%',
+            width: '200%',
+            height: '200%',
+            background:
+              'radial-gradient(circle, rgba(10, 102, 194, 0.06) 0%, transparent 70%)',
+            zIndex: 0,
+          }}
+        />
+
+        <div style={{ position: 'relative', zIndex: 1 }}>
+          <div style={{ marginBottom: 16 }}>
+            <h3
+              style={{
+                margin: 0,
+                fontSize: 18,
+                fontWeight: 700,
+                color: '#1e293b',
+              }}
+            >
+              What to write next
+            </h3>
+            <p style={{ margin: '6px 0 0', fontSize: 14, color: '#64748b' }}>
+              Five ideas tailored to your profile
+            </p>
+            {updatedLabel && (
+              <p style={{ margin: '4px 0 0', fontSize: 12, color: '#94a3b8' }}>
+                {updatedLabel}
+              </p>
+            )}
+          </div>
+
+          {showSkeleton && (
+            <>
+              <style>{`
+                @keyframes linkedinTopicRecShimmer {
+                  0% { background-position: 200% 0; }
+                  100% { background-position: -200% 0; }
+                }
+              `}</style>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                {Array.from({ length: SKELETON_COUNT }, (_, index) => (
+                  <div key={index} style={SKELETON_CARD_STYLE} aria-hidden />
+                ))}
+              </div>
+            </>
+          )}
+
+          {showError && analysisError && (
+            <AnalysisErrorAlert
+              error={analysisError}
+              onRetry={onRetry}
+              isRetrying={isRefreshing}
+            />
+          )}
+
+          {showError && !analysisError && (
+            <div
+              role="alert"
+              style={{
+                padding: '12px 14px',
+                borderRadius: 8,
+                backgroundColor: '#fffbeb',
+                border: '1px solid #fde68a',
+                color: '#92400e',
+                fontSize: 13,
+                lineHeight: 1.5,
+                display: 'flex',
+                flexWrap: 'wrap',
+                alignItems: 'center',
+                gap: 12,
+              }}
+            >
+              <span style={{ flex: '1 1 240px' }}>{displayError}</span>
+              {onRetry && (
+                <button
+                  type="button"
+                  onClick={onRetry}
+                  disabled={isRefreshing}
+                  style={{
+                    padding: '8px 16px',
+                    borderRadius: 8,
+                    border: '1px solid #f59e0b',
+                    backgroundColor: '#fff',
+                    color: '#92400e',
+                    fontSize: 13,
+                    fontWeight: 600,
+                    cursor: isRefreshing ? 'default' : 'pointer',
+                    opacity: isRefreshing ? 0.7 : 1,
+                  }}
+                >
+                  {isRefreshing ? 'Retrying...' : 'Retry'}
+                </button>
+              )}
+            </div>
+          )}
+
+          {showEmpty && (
+            <p style={{ margin: 0, fontSize: 14, color: '#64748b', lineHeight: 1.5 }}>
+              No content suggestions are available yet. Try again in a moment.
+            </p>
+          )}
+
+          {!showSkeleton && !showError && recommendations && recommendations.length > 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              {recommendations.map((item, index) => (
+                <TopicRecommendationCard
+                  key={item.id}
+                  recommendation={item}
+                  index={index}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/LinkedInWriter/components/TopicRecommendations/TopicSuggestionIntro.tsx
+++ b/frontend/src/components/LinkedInWriter/components/TopicRecommendations/TopicSuggestionIntro.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { CircularProgress } from '@mui/material';
+
+import type { LinkedInProfileAnalysisError } from '../../../../api/linkedinSocial';
+import { linkedInPlaceholderCardStyles } from '../linkedInPlaceholderStyles';
+
+interface AnalysisErrorAlertProps {
+  error: LinkedInProfileAnalysisError;
+  onRetry?: () => void;
+  isRetrying?: boolean;
+}
+
+export const AnalysisErrorAlert: React.FC<AnalysisErrorAlertProps> = ({
+  error,
+  onRetry,
+  isRetrying = false,
+}) => (
+  <div
+    role="alert"
+    style={{
+      marginTop: 16,
+      padding: '12px 14px',
+      borderRadius: 8,
+      backgroundColor: '#fffbeb',
+      border: '1px solid #fde68a',
+      color: '#92400e',
+      fontSize: 13,
+      lineHeight: 1.5,
+      maxWidth: 1200,
+    }}
+  >
+    <p style={{ margin: '0 0 8px', fontWeight: 600 }}>{error.user_message}</p>
+    <p style={{ margin: 0, fontSize: 12, color: '#b45309' }}>
+      Failed at Phase {error.failed_phase}: {error.phase_label} ({error.error_code})
+    </p>
+    {process.env.NODE_ENV === 'development' && error.debug_message && (
+      <p
+        style={{
+          margin: '8px 0 0',
+          fontSize: 11,
+          color: '#78716c',
+          fontFamily: 'monospace',
+          wordBreak: 'break-word',
+        }}
+      >
+        {error.debug_message}
+      </p>
+    )}
+    {onRetry && (
+      <button
+        type="button"
+        onClick={onRetry}
+        disabled={isRetrying}
+        style={{
+          marginTop: 12,
+          padding: '8px 16px',
+          borderRadius: 8,
+          border: '1px solid #f59e0b',
+          backgroundColor: '#fff',
+          color: '#92400e',
+          fontSize: 13,
+          fontWeight: 600,
+          cursor: isRetrying ? 'default' : 'pointer',
+          opacity: isRetrying ? 0.7 : 1,
+        }}
+      >
+        {isRetrying ? 'Retrying...' : 'Retry'}
+      </button>
+    )}
+  </div>
+);
+
+interface TopicSuggestionIntroProps {
+  isAnalyzing: boolean;
+  onRunAnalysis: () => void;
+}
+
+export const TopicSuggestionIntro: React.FC<TopicSuggestionIntroProps> = ({
+  isAnalyzing,
+  onRunAnalysis,
+}) => (
+  <div style={{ ...linkedInPlaceholderCardStyles.wrapper, marginTop: 16 }}>
+    <div
+      style={{
+        ...linkedInPlaceholderCardStyles.inner,
+        minHeight: 'unset',
+        padding: '24px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        textAlign: 'center',
+        gap: 14,
+      }}
+    >
+      <h3
+        style={{
+          margin: 0,
+          fontSize: 18,
+          fontWeight: 700,
+          color: '#1e293b',
+        }}
+      >
+        Personalized topic ideas for your LinkedIn profile
+      </h3>
+      <p style={{ margin: 0, fontSize: 14, color: '#64748b', maxWidth: 480, lineHeight: 1.55 }}>
+        Analyze your profile to get five tailored content ideas based on your expertise and
+        audience.
+      </p>
+      {isAnalyzing ? (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            color: '#64748b',
+            fontSize: 14,
+          }}
+        >
+          <CircularProgress size={22} sx={{ color: '#0A66C2' }} />
+          Analyzing your LinkedIn profile…
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={onRunAnalysis}
+          style={{
+            background: 'linear-gradient(135deg, #0A66C2 0%, #004182 100%)',
+            border: 'none',
+            borderRadius: 12,
+            padding: '12px 28px',
+            color: 'white',
+            fontSize: 15,
+            fontWeight: 700,
+            cursor: 'pointer',
+            boxShadow: '0 4px 15px rgba(10, 102, 194, 0.35)',
+          }}
+        >
+          Topic Suggestion
+        </button>
+      )}
+    </div>
+  </div>
+);

--- a/frontend/src/components/LinkedInWriter/components/TopicRecommendations/topicRecommendationLabels.ts
+++ b/frontend/src/components/LinkedInWriter/components/TopicRecommendations/topicRecommendationLabels.ts
@@ -1,0 +1,73 @@
+import type { CSSProperties } from 'react';
+
+import type {
+  LinkedInGrowthImpact,
+  LinkedInRecommendedFormat,
+} from '../../../../api/linkedinSocial';
+
+const FORMAT_LABELS: Record<LinkedInRecommendedFormat, string> = {
+  'LinkedIn Post': 'Post',
+  'LinkedIn Article': 'Article',
+};
+
+const IMPACT_LABELS: Record<LinkedInGrowthImpact, string> = {
+  High: 'Strong reach potential',
+  Medium: 'Good reach potential',
+  Low: 'Niche reach potential',
+};
+
+const IMPACT_STYLES: Record<
+  LinkedInGrowthImpact,
+  { backgroundColor: string; border: string; color: string }
+> = {
+  High: { backgroundColor: '#ecfdf5', border: '1px solid #a7f3d0', color: '#047857' },
+  Medium: { backgroundColor: '#fffbeb', border: '1px solid #fde68a', color: '#92400e' },
+  Low: { backgroundColor: '#f1f5f9', border: '1px solid #e2e8f0', color: '#475569' },
+};
+
+export function formatRecommendationFormat(format: LinkedInRecommendedFormat): string {
+  return FORMAT_LABELS[format] ?? format;
+}
+
+export function formatGrowthImpact(impact: LinkedInGrowthImpact): string {
+  return IMPACT_LABELS[impact] ?? impact;
+}
+
+export function growthImpactStyle(impact: LinkedInGrowthImpact): CSSProperties {
+  const tokens = IMPACT_STYLES[impact] ?? IMPACT_STYLES.Low;
+  return {
+    display: 'inline-flex',
+    alignItems: 'center',
+    padding: '3px 10px',
+    borderRadius: 999,
+    fontSize: 12,
+    fontWeight: 600,
+    lineHeight: 1.4,
+    ...tokens,
+  };
+}
+
+export function formatRelativeUpdatedAt(isoTimestamp?: string | null): string | null {
+  if (!isoTimestamp) {
+    return null;
+  }
+  const updated = new Date(isoTimestamp);
+  if (Number.isNaN(updated.getTime())) {
+    console.warn('[TopicRecommendations] invalid recommendations_updated_at:', isoTimestamp);
+    return null;
+  }
+  const diffMs = Date.now() - updated.getTime();
+  const diffMinutes = Math.floor(diffMs / 60000);
+  if (diffMinutes < 1) {
+    return 'Updated just now';
+  }
+  if (diffMinutes < 60) {
+    return `Updated ${diffMinutes} minute${diffMinutes === 1 ? '' : 's'} ago`;
+  }
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) {
+    return `Updated ${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  }
+  const diffDays = Math.floor(diffHours / 24);
+  return `Updated ${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+}

--- a/frontend/src/components/LinkedInWriter/components/WelcomeMessage.tsx
+++ b/frontend/src/components/LinkedInWriter/components/WelcomeMessage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { FeatureCarousel } from './FeatureCarousel';
+import { LinkedInConnectionPlaceholder } from './LinkedInConnectionPlaceholder';
 import { InfoModals } from './InfoModals';
 import { QuickCreate } from './QuickCreate';
 import { LinkedInPreferences } from '../utils/storageUtils';
@@ -56,11 +57,8 @@ export const WelcomeMessage: React.FC<WelcomeMessageProps> = ({
       overflowY: 'auto',
       maxHeight: '100vh'
     }}>
-      {/* Enhanced Feature Carousel */}
-      <FeatureCarousel 
-        onFactCheckClick={() => setShowFactCheckModal(true)}
-        onCopilotClick={() => setShowCopilotModal(true)}
-      />
+      {/* LinkedIn connection status */}
+      <LinkedInConnectionPlaceholder />
 
       {/* Icon and Buttons Section */}
       <div style={{
@@ -289,6 +287,12 @@ export const WelcomeMessage: React.FC<WelcomeMessageProps> = ({
           userPreferences={userPreferences}
         />
       </div>
+
+      {/* Feature carousel — moved below Quick Create */}
+      <FeatureCarousel
+        onFactCheckClick={() => setShowFactCheckModal(true)}
+        onCopilotClick={() => setShowCopilotModal(true)}
+      />
 
       {/* Info Modals */}
       <InfoModals

--- a/frontend/src/components/LinkedInWriter/components/index.ts
+++ b/frontend/src/components/LinkedInWriter/components/index.ts
@@ -4,6 +4,8 @@ export { ContentEditor } from './ContentEditor';
 export { LoadingIndicator } from './LoadingIndicator';
 export { WelcomeMessage } from './WelcomeMessage';
 export { FeatureCarousel } from './FeatureCarousel';
+export { LinkedInConnectionPlaceholder } from './LinkedInConnectionPlaceholder';
+export { linkedInPlaceholderCardStyles } from './linkedInPlaceholderStyles';
 export { InfoModals } from './InfoModals';
 export { ProgressTracker } from './ProgressTracker';
 export type { ProgressStep } from './ProgressTracker';
@@ -16,8 +18,6 @@ export { CopilotRecommendationsRenderer } from './CopilotRecommendationsRenderer
 export { default as ImageGenerationSuggestions } from './ImageGenerationSuggestions';
 export { default as ImageGenerationDemo } from './ImageGenerationDemo';
 export { default as ImageGenerationTest } from './ImageGenerationTest';
-export { LinkedInSelectionImageModal } from './LinkedInSelectionImageModal';
-export { LinkedInSelectionVideoModal } from './LinkedInSelectionVideoModal';
 
 // Persona Integration Components - Now integrated into main LinkedInWriter
 

--- a/frontend/src/components/LinkedInWriter/components/linkedInPlaceholderStyles.ts
+++ b/frontend/src/components/LinkedInWriter/components/linkedInPlaceholderStyles.ts
@@ -1,0 +1,31 @@
+import type React from 'react';
+
+const CARD_WRAPPER_STYLE: React.CSSProperties = {
+  marginBottom: 20,
+  width: '100%',
+  maxWidth: 1200,
+  position: 'relative',
+  padding: '10px 0',
+};
+
+const CARD_INNER_STYLE: React.CSSProperties = {
+  background:
+    'linear-gradient(135deg, rgba(255,255,255,0.1) 0%, rgba(255,255,255,0.05) 100%)',
+  backdropFilter: 'blur(20px)',
+  border: '1px solid rgba(255,255,255,0.2)',
+  borderRadius: '20px',
+  padding: '24px 28px',
+  boxShadow: `
+    0 20px 60px rgba(0,0,0,0.15),
+    0 8px 32px rgba(10, 102, 194, 0.1),
+    inset 0 1px 0 rgba(255,255,255,0.2)
+  `,
+  position: 'relative',
+  overflow: 'hidden',
+  minHeight: 180,
+};
+
+export const linkedInPlaceholderCardStyles = {
+  wrapper: CARD_WRAPPER_STYLE,
+  inner: CARD_INNER_STYLE,
+};

--- a/frontend/src/components/LinkedInWriter/utils/firstCommentUtils.ts
+++ b/frontend/src/components/LinkedInWriter/utils/firstCommentUtils.ts
@@ -1,0 +1,60 @@
+const URL_REGEX = /https?:\/\/[^\s<>"{}|\\^`[\]]+/i;
+
+export const LINK_IN_FIRST_COMMENT_SUFFIX = 'Link in first comment 👇';
+
+export function extractFirstUrl(text: string): string | null {
+  const match = text.match(URL_REGEX);
+  return match ? match[0] : null;
+}
+
+export function removeFirstUrl(text: string, url: string): string {
+  return text.replace(url, '').replace(/\s{2,}/g, ' ').trim();
+}
+
+export interface ApplyLinkInFirstCommentResult {
+  content: string;
+  firstComment: string;
+  changed: boolean;
+}
+
+/**
+ * When draft contains a URL and firstComment is empty, move the URL to firstComment
+ * and append a short cue line to the post body.
+ */
+export function applyLinkInFirstComment(
+  draft: string,
+  firstComment: string,
+  enabled = true
+): ApplyLinkInFirstCommentResult {
+  if (!enabled || firstComment.trim()) {
+    return { content: draft, firstComment, changed: false };
+  }
+
+  const url = extractFirstUrl(draft);
+  if (!url) {
+    return { content: draft, firstComment, changed: false };
+  }
+
+  let content = removeFirstUrl(draft, url);
+  if (!content.includes(LINK_IN_FIRST_COMMENT_SUFFIX)) {
+    content = content ? `${content}\n\n${LINK_IN_FIRST_COMMENT_SUFFIX}` : LINK_IN_FIRST_COMMENT_SUFFIX;
+  }
+
+  return {
+    content,
+    firstComment: url,
+    changed: true,
+  };
+}
+
+export function buildPublishPayload(
+  draft: string,
+  firstComment: string,
+  moveLinksEnabled: boolean
+): { content: string; first_comment: string } {
+  const applied = applyLinkInFirstComment(draft, firstComment, moveLinksEnabled);
+  return {
+    content: applied.content,
+    first_comment: applied.firstComment,
+  };
+}

--- a/frontend/src/components/LinkedInWriter/utils/linkedInProfileSummary.ts
+++ b/frontend/src/components/LinkedInWriter/utils/linkedInProfileSummary.ts
@@ -1,0 +1,203 @@
+import type {
+
+  LinkedInAccount,
+
+  LinkedInConnectionStatus,
+
+  LinkedInOrganization,
+
+} from '../../../api/linkedinSocial';
+
+
+
+export interface LinkedInCompanyPage {
+
+  name: string;
+
+  id: string;
+
+}
+
+
+
+export interface LinkedInProfileSummary {
+
+  displayName: string;
+
+  accountTypeLabel: string;
+
+  providerLabel: string;
+
+  connectionSourceLabel: string;
+
+  accountIdDisplay: string | null;
+
+  companyPages: LinkedInCompanyPage[];
+
+}
+
+
+
+const MAX_COMPANY_PAGES = 5;
+
+
+
+function truncateId(id: string, maxLen = 12): string {
+
+  if (id.length <= maxLen) return id;
+
+  return `${id.slice(0, maxLen)}…`;
+
+}
+
+
+
+function formatProviderLabel(provider: string): string {
+
+  if (provider === 'zernio') return 'Zernio';
+
+  if (provider === 'native') return 'LinkedIn';
+
+  return provider.charAt(0).toUpperCase() + provider.slice(1);
+
+}
+
+
+
+function isInternalUserId(value: string | null | undefined): boolean {
+  return Boolean(value?.trim().startsWith('user_'));
+}
+
+
+
+function findPersonalAccount(accounts: LinkedInAccount[]): LinkedInAccount | undefined {
+
+  return (
+
+    accounts.find((a) => a.account_type === 'personal') ||
+
+    accounts.find((a) => a.account_type !== 'organization') ||
+
+    accounts[0]
+
+  );
+
+}
+
+
+
+export function buildLinkedInProfileSummary(params: {
+
+  status: LinkedInConnectionStatus | null;
+
+  accounts: LinkedInAccount[];
+
+  organizations: LinkedInOrganization[];
+
+  provider: string;
+
+}): LinkedInProfileSummary {
+
+  const { status, accounts, organizations, provider } = params;
+
+
+
+  const personalAccount = findPersonalAccount(accounts);
+
+  const statusPersonal = status?.accounts?.find(
+
+    (a) => a.account_type === 'personal' || a.account_type !== 'organization'
+
+  );
+
+
+
+  const statusAccountName = status?.account_name?.trim();
+  const displayName =
+    personalAccount?.username?.trim() ||
+    (statusAccountName && !isInternalUserId(statusAccountName)
+      ? statusAccountName
+      : undefined) ||
+    'LinkedIn account';
+
+
+
+  const accountId =
+
+    personalAccount?.account_id || statusPersonal?.account_id || accounts[0]?.account_id;
+
+
+
+  const accountTypeLabel =
+
+    personalAccount?.account_type === 'organization'
+
+      ? 'Company page'
+
+      : 'Personal profile';
+
+
+
+  const companyPages: LinkedInCompanyPage[] = organizations
+
+    .slice(0, MAX_COMPANY_PAGES)
+
+    .map((org) => ({
+
+      name: org.name?.trim() || org.organization_id,
+
+      id: org.organization_id,
+
+    }));
+
+
+
+  const orgAccount = accounts.find((a) => a.account_type === 'organization');
+
+  if (companyPages.length === 0 && orgAccount?.username) {
+
+    companyPages.push({
+
+      name: orgAccount.username,
+
+      id: orgAccount.account_id,
+
+    });
+
+  }
+
+
+
+  return {
+
+    displayName,
+
+    accountTypeLabel,
+
+    providerLabel: formatProviderLabel(provider),
+
+    connectionSourceLabel: 'Your account',
+
+    accountIdDisplay: accountId ? truncateId(accountId) : null,
+
+    companyPages,
+
+  };
+
+}
+
+
+
+export function getInitials(name: string): string {
+
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+
+  if (parts.length === 0) return 'LI';
+
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+
+  return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
+
+}
+
+

--- a/frontend/src/components/OnboardingWizard/IntegrationsStep.tsx
+++ b/frontend/src/components/OnboardingWizard/IntegrationsStep.tsx
@@ -74,13 +74,11 @@ interface IntegrationPlatform {
   benefits: string[];
   oauthUrl?: string;
   isEnabled: boolean;
-  tooltip?: string;
 }
 
 const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateHeaderContent, onValidationChange, onDataChange }) => {
   const { user } = useUser();
   const [email, setEmail] = useState<string>('');
-  const [oauthError, setOauthError] = useState<string | null>(null);
   
   // Use custom hooks
   const { gscSites, connectedPlatforms, setConnectedPlatforms, handleGSCConnect } = useGSCConnection();
@@ -114,63 +112,13 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
   // Bing OAuth hook
   const { connected: bingConnected, sites: bingSites, connect: connectBing, refreshStatus: refreshBingStatus } = useBingOAuth();
 
-  // Hardcoded value-prop copy for each platform.
-  // oneLiner = short value prop shown under the name.
-  // tooltip   = longer "what this unlocks" text behind a hover ⓘ.
-  const INTEGRATION_COPY: Record<string, { oneLiner: string; tooltip: string }> = {
-    wix: {
-      oneLiner: 'Publish posts directly to your Wix site.',
-      tooltip: 'Auto-publish blog posts to your Wix site, sync media, and use Wix SEO settings to optimize each post before it goes live.',
-    },
-    wordpress: {
-      oneLiner: 'Publish posts directly to your WordPress site.',
-      tooltip: 'Secure OAuth login to WordPress.com or self-hosted sites. Push drafts, manage media, and apply SEO meta from ALwrity in one click.',
-    },
-    gsc: {
-      oneLiner: 'See what people search before they find you.',
-      tooltip: 'Powers AI Visibility, Search Console insights, and the SEO agent. We use cached GSC data to find low-CTR pages, striking-distance queries, and cannibalization.',
-    },
-    bing: {
-      oneLiner: 'Add Bing search data to your SEO picture.',
-      tooltip: 'Complements GSC with Bing search performance, index coverage, and crawl stats. Cached for fast, quota-safe weekly recommendations.',
-    },
-    facebook: {
-      oneLiner: 'Schedule and publish Facebook posts.',
-      tooltip: 'Connect a Facebook Page to schedule posts, recycle top performers, and pull engagement metrics back into your dashboard.',
-    },
-    twitter: {
-      oneLiner: 'Schedule and publish tweets.',
-      tooltip: 'Connect an X account to schedule threads, monitor trends, and track engagement on every post you publish from ALwrity.',
-    },
-    linkedin: {
-      oneLiner: 'Publish to your personal profile or company page.',
-      tooltip: 'Great for B2B. Schedule posts, run AI-drafted articles, and pull network analytics. Uses your Step 4 persona to keep tone on-brand.',
-    },
-    instagram: {
-      oneLiner: 'Schedule and publish Instagram posts.',
-      tooltip: 'Connect an Instagram Business account to schedule feed posts, manage captions with your persona, and pull reach and engagement metrics.',
-    },
-    youtube: {
-      oneLiner: 'Optimize videos and pull channel analytics.',
-      tooltip: 'Pull view, watch-time, and CTR data for your YouTube channel. Video SEO and thumbnail suggestions are on the roadmap.',
-    },
-    tiktok: {
-      oneLiner: 'Pull TikTok performance and trends.',
-      tooltip: 'Pull video performance and trend data once TikTok connectors ship. Roadmap: trend-aware short-form repurposing from your best posts.',
-    },
-    pinterest: {
-      oneLiner: 'Schedule pins and pull Pinterest analytics.',
-      tooltip: 'Connect a Pinterest Business account to schedule pins and boards, and pull impression and click metrics into your dashboard.',
-    },
-  };
-
   // Initialize integrations data
   const [integrations] = useState<IntegrationPlatform[]>([
     // Website Platforms
     {
       id: 'wix',
       name: 'Wix',
-      description: INTEGRATION_COPY.wix.oneLiner,
+      description: 'Connect your Wix website for automated content publishing and analytics',
       icon: <WixIcon />,
       category: 'website',
       status: 'available',
@@ -182,7 +130,7 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
     {
       id: 'wordpress',
       name: 'WordPress',
-      description: INTEGRATION_COPY.wordpress.oneLiner,
+      description: 'Connect your WordPress.com sites with secure OAuth authentication',
       icon: <WordPressIcon />,
       category: 'website',
       status: 'available',
@@ -194,7 +142,7 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
     {
       id: 'gsc',
       name: 'Google Search Console',
-      description: INTEGRATION_COPY.gsc.oneLiner,
+      description: 'Connect GSC for comprehensive SEO analytics and content optimization',
       icon: <GoogleIcon />,
       category: 'analytics',
       status: 'available',
@@ -206,7 +154,7 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
     {
       id: 'bing',
       name: 'Bing Webmaster Tools',
-      description: INTEGRATION_COPY.bing.oneLiner,
+      description: 'Connect Bing Webmaster for comprehensive SEO insights and search performance data',
       icon: <AnalyticsIcon />,
       category: 'analytics',
       status: 'available',
@@ -219,7 +167,7 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
     {
       id: 'facebook',
       name: 'Facebook',
-      description: INTEGRATION_COPY.facebook.oneLiner,
+      description: 'Connect your Facebook page for AI-powered content creation and posting',
       icon: <FacebookIcon />,
       category: 'social',
       status: 'coming_soon',
@@ -230,7 +178,7 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
     {
       id: 'twitter',
       name: 'Twitter',
-      description: INTEGRATION_COPY.twitter.oneLiner,
+      description: 'Connect your Twitter account for automated tweeting and analytics',
       icon: <TwitterIcon />,
       category: 'social',
       status: 'coming_soon',
@@ -241,18 +189,18 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
     {
       id: 'linkedin',
       name: 'LinkedIn',
-      description: INTEGRATION_COPY.linkedin.oneLiner,
+      description: 'Connect your LinkedIn profile for professional content publishing',
       icon: <LinkedInIcon />,
       category: 'social',
-      status: 'coming_soon',
+      status: 'available',
       features: ['Professional posting', 'Network insights', 'Content optimization'],
       benefits: ['LinkedIn article publishing', 'Professional network analytics', 'B2B content insights'],
-      isEnabled: false
+      isEnabled: true
     },
     {
       id: 'instagram',
       name: 'Instagram',
-      description: INTEGRATION_COPY.instagram.oneLiner,
+      description: 'Connect your Instagram account for visual content management',
       icon: <InstagramIcon />,
       category: 'social',
       status: 'coming_soon',
@@ -263,7 +211,7 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
     {
       id: 'youtube',
       name: 'YouTube',
-      description: INTEGRATION_COPY.youtube.oneLiner,
+      description: 'Connect your YouTube channel for video content optimization',
       icon: <YouTubeIcon />,
       category: 'social',
       status: 'coming_soon',
@@ -274,7 +222,7 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
     {
       id: 'tiktok',
       name: 'TikTok',
-      description: INTEGRATION_COPY.tiktok.oneLiner,
+      description: 'Connect your TikTok account for short-form content optimization',
       icon: <TikTokIcon />,
       category: 'social',
       status: 'coming_soon',
@@ -285,7 +233,7 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
     {
       id: 'pinterest',
       name: 'Pinterest',
-      description: INTEGRATION_COPY.pinterest.oneLiner,
+      description: 'Connect your Pinterest account for visual content strategy',
       icon: <PinterestIcon />,
       category: 'social',
       status: 'coming_soon',
@@ -298,7 +246,7 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
   useEffect(() => {
     updateHeaderContent({
       title: 'Connect Your Platforms',
-      description: 'Plug in the sites and channels you publish to. Everything is optional — connect what you have now, and add the rest later in Settings.'
+      description: 'Connect your websites and social media accounts to enable AI-powered content publishing and analytics'
     });
   }, [updateHeaderContent]);
 
@@ -323,7 +271,6 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
         await refreshBingStatus();
       } catch (e) {
         console.error('Failed to refresh Bing status:', e);
-        setOauthError('Could not verify Bing connection status.');
       }
     })();
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -356,8 +303,9 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
       // Remove query parameters from URL
       window.history.replaceState({}, document.title, window.location.pathname);
     } else if (error) {
+      // WordPress OAuth failed
       console.error('WordPress OAuth error:', error);
-      setOauthError('WordPress connection failed. Please try again.');
+      // Remove query parameters from URL
       window.history.replaceState({}, document.title, window.location.pathname);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -380,11 +328,11 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
     if (platformId === 'gsc') {
       await handleGSCConnect();
     } else if (platformId === 'bing') {
+      // Use the Bing OAuth hook for connection
       try {
         await connectBing();
       } catch (error) {
         console.error('Bing connection failed:', error);
-        setOauthError('Bing connection failed. Please try again.');
       }
     } else {
       await handleConnect(platformId);
@@ -396,72 +344,12 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
   const analyticsPlatforms = integrations.filter(p => p.category === 'analytics');
   const socialPlatforms = integrations.filter(p => p.category === 'social');
 
-  // Attach hardcoded tooltip text to each platform for the card UI.
-  const withTooltip = (list: IntegrationPlatform[]) =>
-    list.map(p => ({ ...p, tooltip: INTEGRATION_COPY[p.id]?.tooltip || p.tooltip }));
-
 
   // Primary Site Selection State
   const [primarySite, setPrimarySite] = useState<string>('');
-
+  
   // Get sites from hooks for the memo
   const { sites: wixSites, connected: wixConnected } = useWixConnection();
-
-  // Live status per platform, derived from the existing OAuth hooks (no new API calls).
-  // Source of truth per platform:
-  //   - gsc:    connectedPlatforms includes 'gsc' (set by useGSCConnection after getStatus)
-  //   - bing:   bingConnected (from useBingOAuth)
-  //   - wix:    wixConnected  (from useWixConnection)
-  //   - wp:     wordpressConnected (from useWordPressOAuth)
-  // needs_reauth = local state thinks connected but underlying hook says not connected
-  //                (e.g. cached flag survived but token was revoked server-side).
-  const liveStatus: Record<string, IntegrationPlatform['status']> = {
-    gsc: connectedPlatforms.includes('gsc') ? 'connected' : 'available',
-    bing: bingConnected ? 'connected' : 'available',
-    wix: wixConnected ? 'connected' : 'available',
-    wordpress: wordpressConnected ? 'connected' : 'available',
-    facebook: 'coming_soon',
-    twitter: 'coming_soon',
-    linkedin: 'coming_soon',
-    instagram: 'coming_soon',
-    youtube: 'coming_soon',
-    tiktok: 'coming_soon',
-    pinterest: 'coming_soon',
-  };
-
-  // Platforms that are actually connectable today (not coming_soon).
-  const CONNECTABLE_IDS = ['gsc', 'bing', 'wix', 'wordpress'] as const;
-  const connectedCount = CONNECTABLE_IDS.filter(id => liveStatus[id] === 'connected').length;
-  const allConnectableEmpty = connectedCount === 0;
-
-  // Per-platform readiness row data: icon, display name, and a 1-line hint
-  // shown in the readiness panel for both connected and not-connected states.
-  const READINESS_ROWS: Record<string, { name: string; icon: React.ReactNode; connectedHint: string; disconnectedHint: string }> = {
-    gsc: {
-      name: 'Google Search Console',
-      icon: <GoogleIcon sx={{ fontSize: 18 }} />,
-      connectedHint: 'Powers SEO agent and AI Visibility.',
-      disconnectedHint: 'Connect for search analytics and SEO suggestions.',
-    },
-    bing: {
-      name: 'Bing Webmaster Tools',
-      icon: <AnalyticsIcon sx={{ fontSize: 18 }} />,
-      connectedHint: 'Adds Bing data to your SEO picture.',
-      disconnectedHint: 'Connect to add Bing search data.',
-    },
-    wix: {
-      name: 'Wix',
-      icon: <WixIcon sx={{ fontSize: 18 }} />,
-      connectedHint: 'Ready to publish posts to your Wix site.',
-      disconnectedHint: 'Connect to publish directly to Wix.',
-    },
-    wordpress: {
-      name: 'WordPress',
-      icon: <WordPressIcon sx={{ fontSize: 18 }} />,
-      connectedHint: 'Ready to publish posts to your WordPress site.',
-      disconnectedHint: 'Connect to publish directly to WordPress.',
-    },
-  };
   
   const availableSites = React.useMemo(() => {
     const sites: { url: string; source: string; name: string }[] = [];
@@ -598,39 +486,13 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
       {/* Email Address Section */}
       <EmailSection email={email} onEmailChange={setEmail} />
 
-      {/* OAuth Error Alert */}
-      {oauthError && (
-        <Fade in timeout={500}>
-          <Alert severity="error" sx={{ mb: 2, borderRadius: 2 }} onClose={() => setOauthError(null)}>
-            {oauthError}
-          </Alert>
-        </Fade>
-      )}
-
       {/* Website Platforms */}
       <Fade in timeout={800}>
         <div>
-          <Box sx={{ mb: 1.5, display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-            <Typography variant="caption" sx={{ color: '#64748b', fontWeight: 600 }}>
-              All integrations are optional. Connect what you have now — you can add the rest anytime in Settings.
-            </Typography>
-            <Chip
-              size="small"
-              icon={<CheckCircleIcon sx={{ fontSize: 16 }} />}
-              label={`${connectedCount} of ${CONNECTABLE_IDS.length} connectable platforms connected`}
-              sx={{
-                ml: 'auto',
-                bgcolor: allConnectableEmpty ? '#f1f5f9' : '#ecfdf5',
-                color: allConnectableEmpty ? '#475569' : '#065f46',
-                fontWeight: 700,
-                '& .MuiChip-icon': { color: 'inherit' }
-              }}
-            />
-          </Box>
           <PlatformSection
             title="Website Platforms"
-            description="Publish blog posts and pages directly to your site."
-            platforms={withTooltip(websitePlatforms)}
+            description="Connect your website for automated content publishing and SEO optimization"
+            platforms={websitePlatforms}
             connectedPlatforms={connectedPlatforms}
             gscSites={null}
             isLoading={isLoading}
@@ -639,7 +501,6 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
               setConnectedPlatforms(connectedPlatforms.filter(p => p !== platformId));
             }}
             setConnectedPlatforms={setConnectedPlatforms}
-            liveStatus={liveStatus}
           />
         </div>
       </Fade>
@@ -761,13 +622,12 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
         <div>
           <PlatformSection
             title="Analytics & SEO"
-            description="Plug in search data so the SEO and Content agents have real signals to work with."
-            platforms={withTooltip(analyticsPlatforms)}
+            description="Connect analytics platforms for data-driven content optimization"
+            platforms={analyticsPlatforms}
             connectedPlatforms={connectedPlatforms}
             gscSites={gscSites}
                   isLoading={isLoading}
             onConnect={handlePlatformConnect}
-                  liveStatus={liveStatus}
                 />
         </div>
       </Fade>
@@ -811,123 +671,17 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
         </Fade>
       )}
 
-      {/* Data-Readiness Panel — honest state of the 4 connectable platforms */}
-      <Fade in timeout={1100}>
-        <Paper
-          elevation={1}
-          sx={{
-            mt: 3,
-            p: { xs: 2, md: 2.5 },
-            borderRadius: 2,
-            border: '1px solid',
-            borderColor: connectedCount > 0 ? '#bbf7d0' : '#e2e8f0',
-            background: connectedCount > 0
-              ? 'linear-gradient(135deg, #f0fdf4 0%, #ffffff 100%)'
-              : 'linear-gradient(135deg, #f8fafc 0%, #ffffff 100%)',
-          }}
-        >
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5 }}>
-            <Box
-              sx={{
-                width: 36,
-                height: 36,
-                borderRadius: '50%',
-                bgcolor: connectedCount > 0 ? '#dcfce7' : '#f1f5f9',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              {connectedCount > 0 ? (
-                <CheckCircleIcon sx={{ color: '#16a34a' }} />
-              ) : (
-                <LightbulbIcon sx={{ color: '#94a3b8' }} />
-              )}
-            </Box>
-            <Box sx={{ flex: 1 }}>
-              <Typography variant="subtitle1" sx={{ fontWeight: 700, color: '#0f172a' }}>
-                {connectedCount > 0
-                  ? `${connectedCount} of ${CONNECTABLE_IDS.length} connectable platforms connected`
-                  : 'No platforms connected yet'}
-              </Typography>
-              <Typography variant="caption" sx={{ color: '#64748b' }}>
-                {connectedCount > 0
-                  ? 'You can finish onboarding now, or connect more to unlock features.'
-                  : 'Finish onboarding to add platforms later in Settings → Integrations.'}
-              </Typography>
-            </Box>
-          </Box>
-
-          <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 1 }}>
-            {CONNECTABLE_IDS.map(id => {
-              const row = READINESS_ROWS[id];
-              const isConnected = liveStatus[id] === 'connected';
-              return (
-                <Box
-                  key={id}
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1.25,
-                    p: 1.25,
-                    borderRadius: 1.5,
-                    border: '1px solid',
-                    borderColor: isConnected ? '#86efac' : '#e2e8f0',
-                    bgcolor: isConnected ? '#f0fdf4' : '#ffffff',
-                    transition: 'all 0.2s',
-                  }}
-                >
-                  <Box
-                    sx={{
-                      width: 28,
-                      height: 28,
-                      borderRadius: '50%',
-                      bgcolor: isConnected ? '#dcfce7' : '#f1f5f9',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      color: isConnected ? '#16a34a' : '#94a3b8',
-                      flexShrink: 0,
-                    }}
-                  >
-                    {row.icon}
-                  </Box>
-                  <Box sx={{ flex: 1, minWidth: 0 }}>
-                    <Typography variant="body2" sx={{ fontWeight: 600, color: '#0f172a' }}>
-                      {row.name}
-                    </Typography>
-                    <Typography variant="caption" sx={{ color: '#64748b', display: 'block' }}>
-                      {isConnected ? row.connectedHint : row.disconnectedHint}
-                    </Typography>
-                  </Box>
-                  <Box
-                    sx={{
-                      width: 8,
-                      height: 8,
-                      borderRadius: '50%',
-                      bgcolor: isConnected ? '#22c55e' : '#cbd5e1',
-                      flexShrink: 0,
-                    }}
-                  />
-                </Box>
-              );
-            })}
-          </Box>
-        </Paper>
-      </Fade>
-
       {/* Social Media Platforms */}
       <Fade in timeout={1200}>
         <div>
           <PlatformSection
             title="Social Media Platforms"
-            description="Schedule posts and pull engagement back into your dashboard."
-            platforms={withTooltip(socialPlatforms)}
+            description="Connect your social media accounts for automated posting and engagement analytics"
+            platforms={socialPlatforms}
             connectedPlatforms={connectedPlatforms}
             gscSites={null}
             isLoading={isLoading}
             onConnect={handlePlatformConnect}
-            liveStatus={liveStatus}
           />
         </div>
       </Fade>

--- a/frontend/src/components/OnboardingWizard/common/LinkedInPlatformCard.tsx
+++ b/frontend/src/components/OnboardingWizard/common/LinkedInPlatformCard.tsx
@@ -1,0 +1,491 @@
+/**
+
+ * LinkedIn Platform Card — Growth Engine social connection (Zernio OAuth).
+
+ */
+
+
+
+import React, { useEffect, useState } from 'react';
+
+import {
+
+  Box,
+
+  Card,
+
+  Typography,
+
+  Chip,
+
+  CircularProgress,
+
+  Tooltip,
+
+  FormControl,
+
+  InputLabel,
+
+  Select,
+
+  MenuItem,
+
+  Button,
+
+} from '@mui/material';
+
+import {
+
+  LinkedIn as LinkedInIcon,
+
+  CheckCircle as CheckCircleIcon,
+
+  Link as LinkIcon,
+
+} from '@mui/icons-material';
+
+import { useLinkedInSocialConnection } from '../../../hooks/useLinkedInSocialConnection';
+
+
+
+interface LinkedInPlatformCardProps {
+
+  connectedPlatforms: string[];
+
+  setConnectedPlatforms: (platforms: string[]) => void;
+
+  onConnect?: (platform: string) => void;
+
+  onDisconnect?: (platform: string) => void;
+
+}
+
+
+
+const LinkedInPlatformCard: React.FC<LinkedInPlatformCardProps> = ({
+
+  connectedPlatforms,
+
+  setConnectedPlatforms,
+
+  onConnect,
+
+  onDisconnect,
+
+}) => {
+
+  const {
+
+    connected,
+
+    provider,
+
+    hasPerUserToken,
+
+    accountName,
+
+    accounts,
+
+    organizations,
+
+    selectedAccountId,
+
+    selectedTarget,
+
+    selectedOrgId,
+
+    isLoading,
+
+    isConnecting,
+
+    connectError,
+
+    connectWithOAuth,
+
+    disconnect,
+
+    handleAccountChange,
+
+    handleTargetChange,
+
+    handleOrgChange,
+
+  } = useLinkedInSocialConnection();
+
+
+
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+
+
+
+  useEffect(() => {
+
+    if (connected) {
+
+      if (!connectedPlatforms.includes('linkedin')) {
+
+        setConnectedPlatforms([...connectedPlatforms, 'linkedin']);
+
+      }
+
+    } else if (connectedPlatforms.includes('linkedin')) {
+
+      setConnectedPlatforms(connectedPlatforms.filter((p) => p !== 'linkedin'));
+
+    }
+
+  }, [connected, connectedPlatforms, setConnectedPlatforms]);
+
+
+
+  const showDisconnect = connected && hasPerUserToken;
+
+
+
+  const handleLinkedInConnect = async () => {
+
+    if (onConnect) {
+
+      onConnect('linkedin');
+
+    }
+
+    await connectWithOAuth();
+
+  };
+
+
+
+  const handleLinkedInDisconnect = async () => {
+
+    setIsDisconnecting(true);
+
+    try {
+
+      const success = await disconnect();
+
+      if (success) {
+
+        setConnectedPlatforms(connectedPlatforms.filter((p) => p !== 'linkedin'));
+
+        onDisconnect?.('linkedin');
+
+      }
+
+    } finally {
+
+      setIsDisconnecting(false);
+
+    }
+
+  };
+
+
+
+  return (
+
+    <Card
+
+      variant="outlined"
+
+      sx={{
+
+        height: '100%',
+
+        display: 'flex',
+
+        flexDirection: 'column',
+
+        p: 2,
+
+        borderColor: connected ? '#4ade80' : '#e2e8f0',
+
+        backgroundColor: connected ? '#f0fdf4' : '#ffffff',
+
+        transition: 'all 0.2s ease',
+
+        '&:hover': {
+
+          borderColor: connected ? '#22c55e' : '#cbd5e1',
+
+          boxShadow: '0 2px 8px rgba(0, 0, 0, 0.05)',
+
+        },
+
+      }}
+
+    >
+
+      <Box display="flex" justifyContent="space-between" alignItems="flex-start" mb={1}>
+
+        <Box display="flex" alignItems="center" gap={1.5}>
+
+          <Box
+
+            sx={{
+
+              color: '#0A66C2',
+
+              bgcolor: '#ffffff',
+
+              p: 0.5,
+
+              borderRadius: 1,
+
+              border: '1px solid #e2e8f0',
+
+              display: 'flex',
+
+            }}
+
+          >
+
+            <LinkedInIcon fontSize="small" />
+
+          </Box>
+
+          <Box>
+
+            <Typography variant="subtitle2" sx={{ fontWeight: 600, color: '#1e293b', lineHeight: 1.2 }}>
+
+              LinkedIn
+
+            </Typography>
+
+            <Typography variant="caption" sx={{ color: '#64748b', display: 'block' }}>
+
+              Professional publishing
+
+            </Typography>
+
+          </Box>
+
+        </Box>
+
+        {isLoading ? (
+
+          <CircularProgress size={16} sx={{ color: '#64748b' }} />
+
+        ) : connected ? (
+
+          <Tooltip title={`Connected via ${provider}`}>
+
+            <CheckCircleIcon sx={{ color: '#22c55e', fontSize: 20 }} />
+
+          </Tooltip>
+
+        ) : (
+
+          <Chip label="Not connected" size="small" sx={{ height: 24, fontSize: '0.75rem' }} />
+
+        )}
+
+      </Box>
+
+
+
+      {connected ? (
+
+        <Box mt={1} display="flex" flexDirection="column" gap={1.5}>
+
+          {accountName && (
+
+            <Typography variant="caption" sx={{ color: '#334155' }}>
+
+              {accountName}
+
+            </Typography>
+
+          )}
+
+
+
+          {accounts.length > 1 && (
+
+            <FormControl size="small" fullWidth>
+
+              <InputLabel id="linkedin-account-label">Account</InputLabel>
+
+              <Select
+
+                labelId="linkedin-account-label"
+
+                label="Account"
+
+                value={selectedAccountId}
+
+                onChange={(e) => handleAccountChange(e.target.value)}
+
+              >
+
+                {accounts.map((account) => (
+
+                  <MenuItem key={account.account_id} value={account.account_id}>
+
+                    {account.username || account.account_id}
+
+                    {account.account_type ? ` (${account.account_type})` : ''}
+
+                  </MenuItem>
+
+                ))}
+
+              </Select>
+
+            </FormControl>
+
+          )}
+
+
+
+          <FormControl size="small" fullWidth>
+
+            <InputLabel id="linkedin-target-label">Post as</InputLabel>
+
+            <Select
+
+              labelId="linkedin-target-label"
+
+              label="Post as"
+
+              value={selectedTarget}
+
+              onChange={(e) => handleTargetChange(e.target.value as 'profile' | 'organization')}
+
+            >
+
+              <MenuItem value="profile">Personal profile</MenuItem>
+
+              <MenuItem value="organization">Company page</MenuItem>
+
+            </Select>
+
+          </FormControl>
+
+
+
+          {selectedTarget === 'organization' && (
+
+            <FormControl size="small" fullWidth>
+
+              <InputLabel id="linkedin-org-label">Company page</InputLabel>
+
+              <Select
+
+                labelId="linkedin-org-label"
+
+                label="Company page"
+
+                value={selectedOrgId}
+
+                onChange={(e) => handleOrgChange(e.target.value)}
+
+              >
+
+                {organizations.length === 0 ? (
+
+                  <MenuItem value="" disabled>
+
+                    No organizations found
+
+                  </MenuItem>
+
+                ) : (
+
+                  organizations.map((org) => (
+
+                    <MenuItem key={org.organization_id} value={org.organization_id}>
+
+                      {org.name || org.organization_id}
+
+                    </MenuItem>
+
+                  ))
+
+                )}
+
+              </Select>
+
+            </FormControl>
+
+          )}
+
+
+
+          {showDisconnect && (
+
+            <Button
+
+              size="small"
+
+              color="error"
+
+              variant="outlined"
+
+              disabled={isDisconnecting}
+
+              onClick={handleLinkedInDisconnect}
+
+            >
+
+              {isDisconnecting ? 'Disconnecting...' : 'Disconnect'}
+
+            </Button>
+
+          )}
+
+        </Box>
+
+      ) : (
+
+        <Box mt={1} display="flex" flexDirection="column" gap={1}>
+
+          <Typography variant="caption" sx={{ color: '#64748b', lineHeight: 1.45 }}>
+
+            Sign in with LinkedIn in a popup. Choose your personal profile when asked to post as yourself and on company pages you manage.
+
+          </Typography>
+
+          <Button
+
+            size="small"
+
+            variant="contained"
+
+            startIcon={isConnecting ? <CircularProgress size={14} color="inherit" /> : <LinkIcon />}
+
+            disabled={isConnecting}
+
+            onClick={handleLinkedInConnect}
+
+            sx={{ bgcolor: '#0A66C2', '&:hover': { bgcolor: '#004182' }, alignSelf: 'flex-start' }}
+
+          >
+
+            Connect LinkedIn
+
+          </Button>
+
+          {connectError && (
+
+            <Typography variant="caption" sx={{ color: '#b91c1c', lineHeight: 1.45 }} role="alert">
+
+              {connectError}
+
+            </Typography>
+
+          )}
+
+        </Box>
+
+      )}
+
+    </Card>
+
+  );
+
+};
+
+
+
+export default LinkedInPlatformCard;

--- a/frontend/src/components/OnboardingWizard/common/PlatformSection.tsx
+++ b/frontend/src/components/OnboardingWizard/common/PlatformSection.tsx
@@ -7,8 +7,7 @@ import {
   CardContent,
   Stack,
   Chip,
-  Button,
-  Tooltip
+  Button
 } from '@mui/material';
 import {
   CheckCircle as CheckIcon,
@@ -21,6 +20,7 @@ import PlatformCard from './PlatformCard';
 import GSCPlatformCard from './GSCPlatformCard';
 import WordPressOAuthPlatformCard from './WordPressOAuthPlatformCard';
 import WixPlatformCard from './WixPlatformCard';
+import LinkedInPlatformCard from './LinkedInPlatformCard';
 import { type GSCSite } from '../../../api/gsc';
 
 interface Platform {
@@ -29,12 +29,11 @@ interface Platform {
   description: string;
   icon: React.ReactNode;
   category: 'website' | 'social' | 'analytics';
-  status: 'available' | 'connected' | 'coming_soon' | 'disabled' | 'needs_reauth';
+  status: 'available' | 'connected' | 'coming_soon' | 'disabled';
   features: string[];
   benefits: string[];
   oauthUrl?: string;
   isEnabled: boolean;
-  tooltip?: string;
 }
 
 interface PlatformSectionProps {
@@ -48,9 +47,6 @@ interface PlatformSectionProps {
   onDisconnect?: (platformId: string) => void;
   setConnectedPlatforms?: (platforms: string[]) => void;
   fadeTimeout?: number;
-  // Optional per-platform status overrides from the parent. Keys are platform.id.
-  // When provided, these override the default connected/available inference from connectedPlatforms.
-  liveStatus?: Record<string, Platform['status']>;
 }
 
 const PlatformSection: React.FC<PlatformSectionProps> = ({
@@ -63,15 +59,13 @@ const PlatformSection: React.FC<PlatformSectionProps> = ({
   onConnect,
   onDisconnect,
   setConnectedPlatforms,
-  fadeTimeout = 800,
-  liveStatus
+  fadeTimeout = 800
 }) => {
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'connected': return 'success';
       case 'available': return 'primary';
       case 'coming_soon': return 'warning';
-      case 'needs_reauth': return 'warning';
       case 'disabled': return 'default';
       default: return 'default';
     }
@@ -82,7 +76,6 @@ const PlatformSection: React.FC<PlatformSectionProps> = ({
       case 'connected': return <CheckIcon />;
       case 'available': return <LaunchIcon />;
       case 'coming_soon': return <ScheduleIcon />;
-      case 'needs_reauth': return <ErrorIcon />;
       case 'disabled': return <ErrorIcon />;
       default: return <InfoIcon />;
     }
@@ -93,22 +86,15 @@ const PlatformSection: React.FC<PlatformSectionProps> = ({
       case 'connected': return 'Connected';
       case 'available': return 'Connect';
       case 'coming_soon': return 'Coming Soon';
-      case 'needs_reauth': return 'Reconnect';
       case 'disabled': return 'Disabled';
       default: return 'Unknown';
     }
   };
 
-  const platformsWithStatus = platforms.map(platform => {
-    // Live status from parent (e.g. from useIntegrationStatus) takes precedence.
-    if (liveStatus && liveStatus[platform.id]) {
-      return { ...platform, status: liveStatus[platform.id] };
-    }
-    return {
-      ...platform,
-      status: connectedPlatforms.includes(platform.id) ? 'connected' : platform.status
-    };
-  });
+  const platformsWithStatus = platforms.map(platform => ({
+    ...platform,
+    status: connectedPlatforms.includes(platform.id) ? 'connected' : platform.status
+  }));
 
   return (
     <Box sx={{ mb: 4 }}>
@@ -150,6 +136,13 @@ const PlatformSection: React.FC<PlatformSectionProps> = ({
                 connectedPlatforms={connectedPlatforms}
                 setConnectedPlatforms={setConnectedPlatforms || (() => {})}
               />
+            ) : platform.id === 'linkedin' ? (
+              <LinkedInPlatformCard
+                onConnect={onConnect}
+                onDisconnect={onDisconnect}
+                connectedPlatforms={connectedPlatforms}
+                setConnectedPlatforms={setConnectedPlatforms || (() => {})}
+              />
             ) : platform.category === 'social' ? (
               <Card 
                 sx={{
@@ -170,16 +163,9 @@ const PlatformSection: React.FC<PlatformSectionProps> = ({
                       {platform.icon}
                     </Box>
                     <Box sx={{ flex: 1 }}>
-                      <Stack direction="row" spacing={0.5} alignItems="center">
-                        <Typography variant="subtitle1" sx={{ fontWeight: 600, color: '#1e293b' }}>
-                          {platform.name}
-                        </Typography>
-                        {platform.tooltip && (
-                          <Tooltip title={platform.tooltip} arrow placement="top">
-                            <InfoIcon sx={{ fontSize: 16, color: '#94a3b8', cursor: 'help' }} />
-                          </Tooltip>
-                        )}
-                      </Stack>
+                      <Typography variant="subtitle1" sx={{ fontWeight: 600, color: '#1e293b' }}>
+                        {platform.name}
+                      </Typography>
                       <Typography variant="body2" sx={{ color: '#64748b', fontSize: '0.875rem' }}>
                         {platform.description}
                       </Typography>

--- a/frontend/src/components/OnboardingWizard/common/usePlatformConnections.ts
+++ b/frontend/src/components/OnboardingWizard/common/usePlatformConnections.ts
@@ -1,7 +1,22 @@
 import { useState, useEffect } from 'react';
 import { createClient, OAuthStrategy } from '@wix/sdk';
 import { WIX_CLIENT_ID, getWixRedirectOrigin, getWixTrustedOrigins } from '../../../config/wixConfig';
+import { getApiBaseUrl } from '../../../utils/apiUrl';
 import { markConnectionHandled, isAlreadyHandled, clearConnectionHandled } from '../../../utils/wixConnectionDedup';
+import { getLinkedInConnectErrorMessage } from '../../../api/linkedinSocial';
+import { connectWithLinkedInOAuth } from '../../../utils/linkedInOAuthConnect';
+
+const getTrustedOAuthOrigins = (): string[] => {
+  const origins = getWixTrustedOrigins();
+  try {
+    const apiUrl = getApiBaseUrl();
+    const parsed = new URL(apiUrl);
+    origins.push(`${parsed.protocol}//${parsed.host}`);
+  } catch {
+    // ignore invalid API URL
+  }
+  return [...new Set(origins)];
+};
 
 export const usePlatformConnections = () => {
   const [connectedPlatforms, setConnectedPlatforms] = useState<string[]>([]);
@@ -11,7 +26,7 @@ export const usePlatformConnections = () => {
 
   useEffect(() => {
     const handler = (event: MessageEvent) => {
-      const trusted = getWixTrustedOrigins();
+      const trusted = getTrustedOAuthOrigins();
       if (!trusted.includes(event.origin)) return;
       if (!event.data || typeof event.data !== 'object') return;
 
@@ -27,6 +42,18 @@ export const usePlatformConnections = () => {
       }
       if (event.data.type === 'WIX_OAUTH_ERROR') {
         setToastMessage('Wix connection failed. Please try again.');
+        setShowToast(true);
+      }
+      if (event.data.type === 'LINKEDIN_OAUTH_SUCCESS') {
+        setConnectedPlatforms(prev => {
+          if (prev.includes('linkedin')) return prev;
+          return [...prev, 'linkedin'];
+        });
+        setToastMessage('LinkedIn account connected successfully!');
+        setShowToast(true);
+      }
+      if (event.data.type === 'LINKEDIN_OAUTH_ERROR') {
+        setToastMessage('LinkedIn connection failed. Please try again.');
         setShowToast(true);
       }
     };
@@ -112,6 +139,17 @@ export const usePlatformConnections = () => {
     }
   };
 
+  const handleLinkedInConnect = async () => {
+    try {
+      await connectWithLinkedInOAuth();
+    } catch (error) {
+      const message = getLinkedInConnectErrorMessage(error);
+      setToastMessage(message);
+      setShowToast(true);
+      throw error;
+    }
+  };
+
   const handleConnect = async (platformId: string) => {
     setIsLoading(true);
     try {
@@ -119,11 +157,14 @@ export const usePlatformConnections = () => {
         await handleWixConnect();
         return;
       }
-      
-      // For other platforms, you can add their connection logic here
-      
+      if (platformId === 'linkedin') {
+        await handleLinkedInConnect();
+        return;
+      }
     } catch (error) {
       console.error('Connection error:', error);
+      setToastMessage('Connection failed. Please try again.');
+      setShowToast(true);
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/hooks/useLinkedInProfileCompletion.ts
+++ b/frontend/src/hooks/useLinkedInProfileCompletion.ts
@@ -1,0 +1,220 @@
+import { useCallback, useRef, useState } from 'react';
+
+import {
+  completeLinkedInProfile,
+  getLinkedInSocialErrorMessage,
+  logProfileAnalysisError,
+  mapProfileHttpErrorToAnalysisError,
+  runLinkedInTopicAnalysis,
+  type LinkedInAIProfileIntelligence,
+  type LinkedInCompletionQuestion,
+  type LinkedInProfileAcquireResponse,
+  type LinkedInProfileAnalysisError,
+  type LinkedInProfileIntelligenceMeta,
+  type LinkedInProfileValidation,
+  type LinkedInTopicRecommendation,
+  type LinkedInTopicRecommendationsMeta,
+} from '../api/linkedinSocial';
+import {
+  getBackendCooldownSecondsRemaining,
+  isBackendCooldownActive,
+} from '../api/client';
+
+const LOG_PREFIX = '[LinkedInProfileCompletion]';
+const REC_LOG_PREFIX = '[TopicRecommendations]';
+const TOPIC_LOG_PREFIX = '[TopicSuggestion]';
+
+export type TopicAnalysisState =
+  | 'idle'
+  | 'running'
+  | 'needs_completion'
+  | 'complete'
+  | 'error';
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+
+async function waitForBackendCooldown(): Promise<void> {
+  while (isBackendCooldownActive()) {
+    const seconds = getBackendCooldownSecondsRemaining();
+    await sleep(Math.max(seconds, 1) * 1000);
+  }
+}
+
+function resolveAnalysisState(
+  data: LinkedInProfileAcquireResponse
+): TopicAnalysisState {
+  if (data.analysis_error) {
+    return 'error';
+  }
+  if (!data.profile_validation?.is_profile_complete) {
+    return 'needs_completion';
+  }
+  if (data.recommendations_error || !data.recommendations?.length) {
+    return 'error';
+  }
+  return 'complete';
+}
+
+function pickDisplayError(
+  data: LinkedInProfileAcquireResponse
+): LinkedInProfileAnalysisError | null {
+  if (data.analysis_error) {
+    return data.analysis_error;
+  }
+  if (data.recommendations_error) {
+    return {
+      failed_phase: 6,
+      phase_label: 'Topic Recommendations',
+      error_code: 'recommendations_failed',
+      user_message: data.recommendations_error,
+      debug_message: `last_completed_phase=${data.last_completed_phase ?? 'unknown'}`,
+    };
+  }
+  return null;
+}
+
+export function useLinkedInProfileCompletion() {
+  const [analysisState, setAnalysisState] = useState<TopicAnalysisState>('idle');
+  const [analysisError, setAnalysisError] = useState<LinkedInProfileAnalysisError | null>(
+    null
+  );
+  const [profileValidation, setProfileValidation] =
+    useState<LinkedInProfileValidation | null>(null);
+  const [questions, setQuestions] = useState<LinkedInCompletionQuestion[]>([]);
+  const [aiProfileIntelligence, setAiProfileIntelligence] =
+    useState<LinkedInAIProfileIntelligence | null>(null);
+  const [aiProfileIntelligenceMeta, setAiProfileIntelligenceMeta] =
+    useState<LinkedInProfileIntelligenceMeta | null>(null);
+  const [recommendations, setRecommendations] = useState<LinkedInTopicRecommendation[] | null>(
+    null
+  );
+  const [recommendationsMeta, setRecommendationsMeta] =
+    useState<LinkedInTopicRecommendationsMeta | null>(null);
+  const [recommendationsError, setRecommendationsError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const analysisAttemptRef = useRef(0);
+
+  const applyProfileResponse = useCallback((data: LinkedInProfileAcquireResponse) => {
+    setProfileValidation(data.profile_validation ?? null);
+    setQuestions(data.profile_completion?.questions ?? []);
+    setAiProfileIntelligence(data.ai_profile_intelligence ?? null);
+    setAiProfileIntelligenceMeta(data.ai_profile_intelligence_meta ?? null);
+    setRecommendations(data.recommendations ?? null);
+    setRecommendationsMeta(data.recommendations_meta ?? null);
+    setRecommendationsError(data.recommendations_error ?? null);
+
+    const displayError = pickDisplayError(data);
+    setAnalysisError(displayError);
+
+    if (displayError) {
+      logProfileAnalysisError('pipeline returned error', displayError);
+    }
+
+    const nextState = resolveAnalysisState(data);
+    setAnalysisState(nextState);
+
+    console.info(`${TOPIC_LOG_PREFIX} pipeline response applied`, {
+      analysisState: nextState,
+      lastCompletedPhase: data.last_completed_phase ?? null,
+      isProfileComplete: data.profile_validation?.is_profile_complete ?? false,
+      recommendationCount: data.recommendations?.length ?? 0,
+      hasAnalysisError: Boolean(data.analysis_error),
+      hasRecommendationsError: Boolean(data.recommendations_error),
+    });
+  }, []);
+
+  const runTopicAnalysis = useCallback(async () => {
+    const attemptId = ++analysisAttemptRef.current;
+    console.info(`${TOPIC_LOG_PREFIX} user triggered analysis`);
+    setAnalysisState('running');
+    setAnalysisError(null);
+    setRecommendationsError(null);
+
+    try {
+      await waitForBackendCooldown();
+      const data = await runLinkedInTopicAnalysis();
+      if (analysisAttemptRef.current !== attemptId) {
+        return;
+      }
+      applyProfileResponse(data);
+    } catch (err) {
+      if (analysisAttemptRef.current !== attemptId) {
+        return;
+      }
+      const mapped = mapProfileHttpErrorToAnalysisError(err);
+      logProfileAnalysisError('HTTP request failed', mapped);
+      setAnalysisError(mapped);
+      setAnalysisState('error');
+      setRecommendations(null);
+      setRecommendationsMeta(null);
+      setRecommendationsError(mapped.user_message);
+    }
+  }, [applyProfileResponse]);
+
+  const submitCompletion = useCallback(
+    async (answers: Record<string, string | string[]>) => {
+      setIsSubmitting(true);
+      setSubmitError(null);
+      console.info(`${LOG_PREFIX} submit start`, { answerKeys: Object.keys(answers) });
+
+      try {
+        await waitForBackendCooldown();
+        const result = await completeLinkedInProfile(answers);
+        setProfileValidation(result.profile_validation);
+        setQuestions(result.profile_completion?.questions ?? []);
+
+        if (result.profile_validation.is_profile_complete) {
+          console.info(
+            `${LOG_PREFIX} profile now complete — continuing topic analysis (Phases 5–6)`
+          );
+          await runTopicAnalysis();
+        } else {
+          setAnalysisState('needs_completion');
+          setRecommendations(null);
+          setRecommendationsMeta(null);
+          setRecommendationsError(null);
+          setAnalysisError(null);
+        }
+
+        console.info(`${LOG_PREFIX} submit complete`, {
+          isProfileComplete: result.profile_validation.is_profile_complete,
+        });
+      } catch (err) {
+        const message = getLinkedInSocialErrorMessage(err);
+        console.error(`${LOG_PREFIX} submit failed:`, message, err);
+        setSubmitError(message);
+        throw err;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [runTopicAnalysis]
+  );
+
+  const isProfileComplete = profileValidation?.is_profile_complete ?? false;
+  const isAnalyzing = analysisState === 'running';
+  const hasStartedAnalysis = analysisState !== 'idle';
+
+  return {
+    analysisState,
+    analysisError,
+    isAnalyzing,
+    hasStartedAnalysis,
+    profileValidation,
+    questions,
+    aiProfileIntelligence,
+    aiProfileIntelligenceMeta,
+    recommendations,
+    recommendationsMeta,
+    recommendationsError,
+    isProfileComplete,
+    isSubmitting,
+    submitError,
+    runTopicAnalysis,
+    submitCompletion,
+  };
+}

--- a/frontend/src/hooks/useLinkedInSocialConnection.ts
+++ b/frontend/src/hooks/useLinkedInSocialConnection.ts
@@ -1,0 +1,584 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+
+import {
+
+  getLinkedInConnectionStatus,
+
+  listLinkedInAccounts,
+
+  listLinkedInOrganizations,
+
+  disconnectLinkedIn,
+
+  getLinkedInSocialErrorMessage,
+
+  type LinkedInAccount,
+
+  type LinkedInConnectionStatus,
+
+  type LinkedInOrganization,
+
+} from '../api/linkedinSocial';
+
+import {
+
+  buildLinkedInProfileSummary,
+
+  type LinkedInProfileSummary,
+
+} from '../components/LinkedInWriter/utils/linkedInProfileSummary';
+
+import { connectWithLinkedInOAuth } from '../utils/linkedInOAuthConnect';
+
+
+
+export type LinkedInPostTarget = 'profile' | 'organization';
+
+
+
+const STORAGE_ACCOUNT = 'linkedin_social_selected_account';
+
+const STORAGE_TARGET = 'linkedin_social_selected_target';
+
+const STORAGE_ORG = 'linkedin_social_selected_org';
+
+
+
+function statusAccountsToLinkedInAccounts(
+
+  status: LinkedInConnectionStatus
+
+): LinkedInAccount[] {
+
+  return (status.accounts || []).map((a) => ({
+
+    account_id: a.account_id,
+
+    account_type: a.account_type ?? null,
+
+    username: null,
+
+    platform: 'linkedin',
+
+  }));
+
+}
+
+
+
+export const useLinkedInSocialConnection = () => {
+
+  const [status, setStatus] = useState<LinkedInConnectionStatus | null>(null);
+
+  const [accounts, setAccounts] = useState<LinkedInAccount[]>([]);
+
+  const [organizations, setOrganizations] = useState<LinkedInOrganization[]>([]);
+
+  const [selectedAccountId, setSelectedAccountId] = useState<string>('');
+
+  const [selectedTarget, setSelectedTarget] = useState<LinkedInPostTarget>('profile');
+
+  const [selectedOrgId, setSelectedOrgId] = useState<string>('');
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [isConnecting, setIsConnecting] = useState(false);
+
+  const [error, setError] = useState<string | null>(null);
+
+  const [connectError, setConnectError] = useState<string | null>(null);
+
+  const [disconnectError, setDisconnectError] = useState<string | null>(null);
+
+  const [profileLoadWarning, setProfileLoadWarning] = useState<string | null>(null);
+
+
+
+  const loadOrganizations = useCallback(async (accountId: string): Promise<boolean> => {
+
+    if (!accountId) {
+
+      setOrganizations([]);
+
+      return true;
+
+    }
+
+    try {
+
+      const orgResponse = await listLinkedInOrganizations(accountId);
+
+      setOrganizations(orgResponse.organizations || []);
+
+      return true;
+
+    } catch (err) {
+
+      console.warn('[LinkedInConnect] organizations load failed:', accountId, err);
+
+      setOrganizations([]);
+
+      return false;
+
+    }
+
+  }, []);
+
+
+
+  const checkStatus = useCallback(async () => {
+
+    setIsLoading(true);
+
+    setError(null);
+
+    setProfileLoadWarning(null);
+
+
+
+    let connectionStatus: LinkedInConnectionStatus;
+
+    try {
+
+      connectionStatus = await getLinkedInConnectionStatus();
+
+      setStatus(connectionStatus);
+
+      console.info('[LinkedInConnect] status loaded', {
+
+        connected: connectionStatus.connected,
+
+        provider: connectionStatus.provider,
+
+      });
+
+    } catch (e) {
+
+      console.error('[LinkedInConnect] status fetch failed:', e);
+
+      setError('Could not verify LinkedIn connection. Please refresh and try again.');
+
+      setStatus({
+
+        connected: false,
+
+        provider: 'zernio',
+
+        has_per_user_token: false,
+
+        accounts: [],
+
+      });
+
+      setAccounts([]);
+
+      setOrganizations([]);
+
+      setIsLoading(false);
+
+      return;
+
+    }
+
+
+
+    if (!connectionStatus.connected) {
+
+      setAccounts([]);
+
+      setOrganizations([]);
+
+      setIsLoading(false);
+
+      return;
+
+    }
+
+
+
+    let accountList: LinkedInAccount[] = [];
+
+    let profileWarning: string | null = null;
+
+
+
+    try {
+
+      const accountsResponse = await listLinkedInAccounts();
+
+      accountList = accountsResponse.accounts || [];
+
+      setAccounts(accountList);
+
+    } catch (accountsErr) {
+
+      console.warn('[LinkedInConnect] profile details partial load (accounts):', accountsErr);
+
+      accountList = statusAccountsToLinkedInAccounts(connectionStatus);
+
+      setAccounts(accountList);
+
+      profileWarning =
+
+        'Some profile details could not be loaded. Showing basic connection info.';
+
+    }
+
+
+
+    const storedAccount = localStorage.getItem(STORAGE_ACCOUNT) || '';
+
+    const storedTarget =
+
+      (localStorage.getItem(STORAGE_TARGET) as LinkedInPostTarget) || 'profile';
+
+    const storedOrg = localStorage.getItem(STORAGE_ORG) || '';
+
+
+
+    const defaultAccount =
+
+      accountList.find((a) => a.account_id === storedAccount)?.account_id ||
+
+      accountList.find((a) => a.account_type === 'personal')?.account_id ||
+
+      accountList[0]?.account_id ||
+
+      connectionStatus.accounts?.[0]?.account_id ||
+
+      '';
+
+
+
+    setSelectedAccountId(defaultAccount);
+
+    setSelectedTarget(storedTarget);
+
+    setSelectedOrgId(storedOrg);
+
+
+
+    if (defaultAccount) {
+
+      if (connectionStatus.provider !== 'unipile') {
+        const orgsOk = await loadOrganizations(defaultAccount);
+
+        if (!orgsOk) {
+
+          const orgsFromStatus = connectionStatus.organizations || [];
+
+          if (orgsFromStatus.length > 0) {
+
+            setOrganizations(
+
+              orgsFromStatus.map((o) => ({
+
+                organization_id: o.organization_id,
+
+                name: o.name,
+
+                urn: o.urn,
+
+              }))
+
+            );
+
+          }
+
+          profileWarning =
+
+            profileWarning ||
+
+            'Company pages could not be loaded. Personal profile is still connected.';
+
+        }
+      } else {
+        setOrganizations([]);
+      }
+
+    } else if (connectionStatus.organizations?.length) {
+
+      setOrganizations(
+
+        connectionStatus.organizations.map((o) => ({
+
+          organization_id: o.organization_id,
+
+          name: o.name,
+
+          urn: o.urn,
+
+        }))
+
+      );
+
+    }
+
+
+
+    if (profileWarning) {
+
+      setProfileLoadWarning(profileWarning);
+
+      console.warn('[LinkedInConnect] profile load warning:', profileWarning);
+
+    }
+
+
+
+    setIsLoading(false);
+
+  }, [loadOrganizations]);
+
+
+
+  useEffect(() => {
+
+    checkStatus();
+
+  }, [checkStatus]);
+
+
+
+  useEffect(() => {
+
+    const onOAuthSuccess = () => {
+
+      checkStatus();
+
+    };
+
+    window.addEventListener('linkedin-oauth-success', onOAuthSuccess);
+
+    return () => window.removeEventListener('linkedin-oauth-success', onOAuthSuccess);
+
+  }, [checkStatus]);
+
+
+
+  const handleAccountChange = useCallback(
+
+    async (accountId: string) => {
+
+      setSelectedAccountId(accountId);
+
+      localStorage.setItem(STORAGE_ACCOUNT, accountId);
+
+      await loadOrganizations(accountId);
+
+    },
+
+    [loadOrganizations]
+
+  );
+
+
+
+  const handleTargetChange = useCallback((target: LinkedInPostTarget) => {
+
+    setSelectedTarget(target);
+
+    localStorage.setItem(STORAGE_TARGET, target);
+
+  }, []);
+
+
+
+  const handleOrgChange = useCallback((orgId: string) => {
+
+    setSelectedOrgId(orgId);
+
+    localStorage.setItem(STORAGE_ORG, orgId);
+
+  }, []);
+
+
+
+  const clearSelectionStorage = useCallback(() => {
+
+    localStorage.removeItem(STORAGE_ACCOUNT);
+
+    localStorage.removeItem(STORAGE_TARGET);
+
+    localStorage.removeItem(STORAGE_ORG);
+
+    setSelectedAccountId('');
+
+    setSelectedTarget('profile');
+
+    setSelectedOrgId('');
+
+  }, []);
+
+
+
+  const disconnect = useCallback(async (): Promise<boolean> => {
+    setDisconnectError(null);
+    console.info('[LinkedInConnect] starting disconnect');
+
+    try {
+      const result = await disconnectLinkedIn();
+      clearSelectionStorage();
+      await checkStatus();
+      console.info('[LinkedInConnect] disconnect succeeded', {
+        success: result.success,
+      });
+      return result.success;
+    } catch (err) {
+      const msg = getLinkedInSocialErrorMessage(err);
+      console.error('[LinkedInConnect] disconnect failed:', msg, err);
+      setDisconnectError(msg);
+      return false;
+    }
+  }, [checkStatus, clearSelectionStorage]);
+
+
+
+  const connectWithOAuth = useCallback(async (): Promise<boolean> => {
+
+    setIsConnecting(true);
+
+    setConnectError(null);
+
+    setDisconnectError(null);
+
+    console.info('[LinkedInConnect] starting OAuth connect');
+
+    try {
+
+      await connectWithLinkedInOAuth({
+        verifyConnected: async () => {
+          const connectionStatus = await getLinkedInConnectionStatus();
+          return connectionStatus.connected;
+        },
+      });
+
+      console.info('[LinkedInConnect] OAuth connect succeeded');
+
+      await checkStatus();
+
+      return true;
+
+    } catch (err) {
+
+      const msg = getLinkedInSocialErrorMessage(err);
+
+      console.error('[LinkedInConnect] connect failed:', msg, err);
+
+      setConnectError(msg);
+
+      return false;
+
+    } finally {
+
+      setIsConnecting(false);
+
+    }
+
+  }, [checkStatus]);
+
+
+
+  const connected = status?.connected ?? false;
+
+  const provider = status?.provider ?? 'zernio';
+
+  const hasPerUserToken = status?.has_per_user_token ?? false;
+
+
+
+  const primaryProfile: LinkedInProfileSummary | null = useMemo(() => {
+
+    if (!connected) return null;
+
+    return buildLinkedInProfileSummary({
+
+      status,
+
+      accounts,
+
+      organizations,
+
+      provider,
+
+    });
+
+  }, [connected, status, accounts, organizations, provider]);
+
+
+
+  const avatarUrl = useMemo(() => {
+    const personalAccount =
+      accounts.find((a) => a.account_type === 'personal') ||
+      accounts.find((a) => a.account_type !== 'organization') ||
+      accounts[0];
+    return personalAccount?.avatar_url ?? null;
+  }, [accounts]);
+
+
+
+  const displayName = useMemo(
+    () =>
+      primaryProfile?.displayName ??
+      status?.account_name ??
+      'LinkedIn account',
+    [primaryProfile, status?.account_name]
+  );
+
+
+
+  return {
+
+    connected,
+
+    provider,
+
+    hasPerUserToken,
+
+    accountName: status?.account_name,
+
+    avatarUrl,
+
+    displayName,
+
+    accounts,
+
+    organizations,
+
+    selectedAccountId,
+
+    selectedTarget,
+
+    selectedOrgId,
+
+    isLoading,
+
+    isConnecting,
+
+    error,
+
+    connectError,
+
+    disconnectError,
+
+    profileLoadWarning,
+
+    primaryProfile,
+
+    checkStatus,
+
+    connectWithOAuth,
+
+    handleAccountChange,
+
+    handleTargetChange,
+
+    handleOrgChange,
+
+    disconnect,
+
+  };
+
+};
+
+

--- a/frontend/src/utils/linkedInOAuthConnect.ts
+++ b/frontend/src/utils/linkedInOAuthConnect.ts
@@ -90,6 +90,14 @@ export function connectWithLinkedInOAuth(
       if (settled) return;
       settled = true;
       cleanup();
+      try {
+        if (popup && !popup.closed) {
+          popup.close();
+          console.info('[LinkedInConnect] OAuth popup closed by opener');
+        }
+      } catch (err) {
+        console.warn('[LinkedInConnect] could not close OAuth popup:', err);
+      }
       console.info('[LinkedInConnect] OAuth connect resolved', { source });
       window.dispatchEvent(new CustomEvent('linkedin-oauth-success'));
       resolve();

--- a/frontend/src/utils/linkedInOAuthConnect.ts
+++ b/frontend/src/utils/linkedInOAuthConnect.ts
@@ -1,0 +1,199 @@
+/**
+ * Shared LinkedIn OAuth popup flow (Zernio / Unipile connect).
+ * Used by LinkedIn Writer and onboarding integrations.
+ */
+
+import { getLinkedInAuthUrl } from '../api/linkedinSocial';
+import { getWixTrustedOrigins } from '../config/wixConfig';
+import { getApiBaseUrl } from './apiUrl';
+
+const POPUP_NAME = 'linkedin_oauth';
+const POPUP_FEATURES = 'width=600,height=700,scrollbars=yes';
+const POPUP_POLL_MS = 500;
+const STATUS_POLL_MS = 2000;
+/** Allow webhook / sync to finish after popup closes before treating connect as failed. */
+const POPUP_CLOSE_GRACE_MS = 2000;
+
+export interface LinkedInOAuthConnectOptions {
+  /** When postMessage is missed, confirm connection via GET /connection/status. */
+  verifyConnected?: () => Promise<boolean>;
+}
+
+function appendOriginFromUrl(origins: string[], url: string | undefined): void {
+  if (!url?.trim()) return;
+  try {
+    const parsed = new URL(url.trim());
+    origins.push(`${parsed.protocol}//${parsed.host}`);
+  } catch {
+    // ignore invalid URL
+  }
+}
+
+export function getTrustedLinkedInOAuthOrigins(): string[] {
+  const origins = getWixTrustedOrigins();
+  appendOriginFromUrl(origins, getApiBaseUrl());
+  appendOriginFromUrl(origins, process.env.REACT_APP_API_URL);
+  appendOriginFromUrl(origins, process.env.REACT_APP_NGROK_ORIGIN);
+  appendOriginFromUrl(origins, process.env.REACT_APP_NGROK_URL);
+  return [...new Set(origins)];
+}
+
+function isTrustedOAuthMessageOrigin(origin: string, trusted: string[]): boolean {
+  if (trusted.includes(origin)) {
+    return true;
+  }
+  if (process.env.NODE_ENV === 'production') {
+    return false;
+  }
+  try {
+    const host = new URL(origin).hostname.toLowerCase();
+    return host.endsWith('.ngrok-free.app') || host.endsWith('.ngrok-free.dev');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Opens Zernio/Unipile OAuth in a popup (or full-page redirect if blocked).
+ * Resolves when the callback posts LINKEDIN_OAUTH_SUCCESS, or when verifyConnected
+ * confirms the account is linked (Unipile notify_url / sync fallback).
+ */
+export function connectWithLinkedInOAuth(
+  options: LinkedInOAuthConnectOptions = {}
+): Promise<void> {
+  return new Promise(async (resolve, reject) => {
+    let authResponse;
+    try {
+      authResponse = await getLinkedInAuthUrl();
+      console.info('[LinkedInConnect] auth URL fetched', {
+        provider: authResponse.provider,
+      });
+    } catch (err) {
+      console.error('[LinkedInConnect] auth URL fetch failed:', err);
+      reject(err);
+      return;
+    }
+
+    const trusted = getTrustedLinkedInOAuthOrigins();
+    let pollTimer: ReturnType<typeof setInterval> | undefined;
+    let statusPollTimer: ReturnType<typeof setInterval> | undefined;
+    let settled = false;
+    let popupClosedAt: number | null = null;
+
+    const cleanup = () => {
+      window.removeEventListener('message', onMessage);
+      if (pollTimer) clearInterval(pollTimer);
+      if (statusPollTimer) clearInterval(statusPollTimer);
+    };
+
+    const finishSuccess = (source: string) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      console.info('[LinkedInConnect] OAuth connect resolved', { source });
+      window.dispatchEvent(new CustomEvent('linkedin-oauth-success'));
+      resolve();
+    };
+
+    const tryVerifyConnected = async (context: string): Promise<boolean> => {
+      if (!options.verifyConnected || settled) {
+        return false;
+      }
+      try {
+        const connected = await options.verifyConnected();
+        if (connected) {
+          finishSuccess(`connection-status:${context}`);
+          return true;
+        }
+      } catch (err) {
+        console.warn('[LinkedInConnect] connection status verify failed:', context, err);
+      }
+      return false;
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      if (!isTrustedOAuthMessageOrigin(event.origin, trusted)) {
+        console.warn('[LinkedInConnect] ignored postMessage from untrusted origin', {
+          origin: event.origin,
+          trustedOrigins: trusted,
+        });
+        return;
+      }
+      if (!event.data || typeof event.data !== 'object') return;
+
+      if (event.data.type === 'LINKEDIN_OAUTH_SUCCESS') {
+        finishSuccess('postMessage');
+        return;
+      }
+      if (event.data.type === 'LINKEDIN_OAUTH_ERROR') {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        const message =
+          typeof event.data.error === 'string' && event.data.error.trim()
+            ? event.data.error
+            : 'LinkedIn connection failed. Please try again.';
+        console.error('[LinkedInConnect] OAuth popup error message received:', message);
+        reject(new Error(message));
+      }
+    };
+
+    window.addEventListener('message', onMessage);
+
+    const popup = window.open(
+      authResponse.authorization_url,
+      POPUP_NAME,
+      POPUP_FEATURES
+    );
+
+    if (!popup) {
+      console.info('[LinkedInConnect] popup blocked, redirecting full page');
+      cleanup();
+      window.location.href = authResponse.authorization_url;
+      return;
+    }
+
+    console.info('[LinkedInConnect] OAuth popup opened');
+
+    if (options.verifyConnected) {
+      statusPollTimer = setInterval(() => {
+        if (settled || popup.closed) return;
+        void tryVerifyConnected('poll');
+      }, STATUS_POLL_MS);
+    }
+
+    pollTimer = setInterval(() => {
+      if (settled) return;
+
+      if (!popup.closed) {
+        popupClosedAt = null;
+        return;
+      }
+
+      if (popupClosedAt === null) {
+        popupClosedAt = Date.now();
+        console.info('[LinkedInConnect] OAuth popup closed; verifying connection');
+        return;
+      }
+
+      if (Date.now() - popupClosedAt < POPUP_CLOSE_GRACE_MS) {
+        return;
+      }
+
+      void (async () => {
+        if (settled) return;
+        if (await tryVerifyConnected('popup-closed')) {
+          return;
+        }
+        console.warn('[LinkedInConnect] OAuth popup closed before completion');
+        settled = true;
+        cleanup();
+        reject(
+          new Error(
+            'LinkedIn connection was closed before completing. Please try again.'
+          )
+        );
+      })();
+    }, POPUP_POLL_MS);
+  });
+}


### PR DESCRIPTION
## 📝 Description

This PR delivers end-to-end LinkedIn integration for the LinkedIn Writer using the **Unipile API** for account connection and profile acquisition, plus a **six-phase LinkedIn Analysis Context pipeline** that transforms a connected profile into personalized content topic recommendations.

### Why this PR replaces #729

PR #729 was opened from a branch **41 commits behind** `ALwrity/main`. It included **104 changed files**, many unrelated to LinkedIn (content strategy, OAuth monitoring, GSC, etc.) that upstream had already fixed.

This PR is a **clean re-apply** of LinkedIn-only work onto **current `main`**:

| | PR #729 (old) | This PR (new) |
|--|---------------|---------------|
| Base | Stale fork `main` | Current `ALwrity/main` |
| Files | 104 | **75** |
| Unrelated diffs | Included | **Removed** |
| Manual E2E | Passed on old base | **Passed on fresh base** |

Original work is preserved on backup branch `backup/pr729-full-work-2026-06-20`.

### Unipile connection

- Hosted OAuth connect/disconnect flow with per-user credential storage
- Two-step profile acquisition from Unipile (`/users/me` → `/users/{identifier}` with `linkedin_sections`)
- Connection status API and frontend popup flow with post-connect verification
- **OAuth popup auto-closes** after successful connect (opener + callback page fix)

### Analysis Context pipeline (Phases 1–6)

| Phase | Purpose | Key output |
|-------|---------|------------|
| **1** | Profile acquisition | Normalized LinkedIn profile from Unipile; persisted in `linkedin_analysis_context` |
| **2** | Profile context normalization | Canonical `profile_context` snapshot with content-hash cache |
| **3** | Completeness validation | `is_profile_complete`, score, missing fields |
| **4** | Adaptive profile completion | Dynamic completion questions; user answers merged into context |
| **5** | AI Profile Intelligence | Gemini structured JSON → professional identity, expertise, audience, writing opportunities |
| **6** | Topic recommendations | Gemini structured JSON → exactly 5 personalized LinkedIn content ideas |

All phases are orchestrated through **`GET /api/linkedin-social/profile`**, with cache-first behavior, hash-based invalidation, structured `analysis_error` on phase failure, and a full **Topic Suggestion** UX in the LinkedIn Writer.

### Reliability improvements

- **Gemini structured-output schema fix** — `$ref`/`$defs` resolution and `enum` preservation so LLM output matches allowed values (`recommended_format`, `growth_impact`)
- **LLM output normalization** — enum casing/whitespace fixes and safe defaults before Pydantic validation
- **Validation retry** — one automatic LLM retry on schema failure (Phases 5 & 6)
- **OAuth callback hardening** — callback page always attempts `window.close()`; opener closes popup when connection confirmed via status poll

---

## Architecture Overview

```
Unipile OAuth Connect
        │
        ▼
Phase 1: Profile fetch + normalize (Unipile API)
        │
        ▼
Phase 2: Profile context build + cache
        │
        ▼
Phase 3: Completeness validation
        │
        ▼
Phase 4: Adaptive completion (if incomplete)
        │
        ▼
Phase 5: AI Profile Intelligence (Gemini)
        │
        ▼
Phase 6: Topic Recommendations (Gemini) → 5 content ideas
        │
        ▼
LinkedIn Writer UI — TopicRecommendationsPanel
```

### Data flow

- **Input:** Connected Unipile account + optional user completion answers
- **Storage:** Per-user `linkedin_analysis_context` row (SQLite per workspace)
- **Output:** `profile`, `profile_context`, `profile_validation`, `ai_profile_intelligence`, `recommendations` (5 items)

Downstream phases invalidate automatically when upstream content hashes or timestamps change.

---

## Backend Changes

### Unipile connection

| Module | Responsibility |
|--------|----------------|
| `backend/services/integrations/linkedin_oauth.py` | OAuth URL, callback, encrypted credential storage, Unipile account sync |
| `backend/services/integrations/linkedin/unipile_provider.py` | Connect/disconnect, account listing, own-profile fetch |
| `backend/services/integrations/linkedin/unipile_client.py` | Low-level Unipile HTTP client |
| `backend/api/unipile_webhook_routes.py` | Unipile `notify_url` webhook handler |

### Analysis pipeline services

| Phase | Key modules |
|-------|-------------|
| 1 | `profile_service.py`, `profile_repository.py` |
| 2 | `profile_context_builder.py`, `profile_context_service.py` |
| 3 | `profile_validation_service.py` |
| 4 | `profile_completion_service.py`, `profile_completion_questions.py` |
| 5 | `profile_intelligence_service.py`, `profile_intelligence_validator.py`, `profile_intelligence_llm.py` |
| 6 | `topic_recommendation_service.py`, `topic_recommendation_validator.py`, `topic_recommendation_llm.py`, `prompts/linkedin/topic_recommendation_prompt.py` |

### API

- **`backend/api/linkedin_social_routes.py`** — orchestrates Phases 1–6 on `GET /profile`
- **`backend/models/linkedin_social_models.py`** — response models including `ProfileAnalysisErrorResponse`, `TopicRecommendationResponse`
- Query params: `refresh`, `refresh_intelligence`, `refresh_recommendations`
- **`backend/alwrity_utils/router_manager.py`** — registers `linkedin_social` and `unipile_webhook` routers (preserves existing `linkedin_video`)

### LLM & OAuth reliability

- **`backend/services/llm_providers/gemini_provider.py`** — `_dict_to_types_schema` resolves `$ref`/`$defs`, passes `enum`, `required`, and array bounds to Gemini
- **`backend/services/integrations/oauth_callback_utils.py`** — callback HTML posts success message and closes popup reliably

---

## Frontend Changes

| Module | Responsibility |
|--------|----------------|
| `frontend/src/api/linkedinSocial.ts` | Pipeline API client, Phase 1–6 types, `runLinkedInTopicAnalysis()` |
| `frontend/src/utils/linkedInOAuthConnect.ts` | Unipile OAuth popup flow, connection verification, popup close on success |
| `frontend/src/hooks/useLinkedInSocialConnection.ts` | Connect/disconnect state |
| `frontend/src/hooks/useLinkedInProfileCompletion.ts` | Analysis state machine + Topic Suggestion trigger |
| `frontend/src/components/LinkedInWriter/components/LinkedInConnectionPlaceholder.tsx` | Connect entry + profile setup panel when connected |
| `frontend/src/components/LinkedInWriter/components/ProfileCompletion/LinkedInProfileSetupPanel.tsx` | Phase 4 completion form |
| `frontend/src/components/LinkedInWriter/components/TopicRecommendations/` | Recommendations panel, cards, error/retry UI |
| `frontend/src/components/OnboardingWizard/common/LinkedInPlatformCard.tsx` | LinkedIn connect in onboarding |

---

## Intentionally excluded (vs old PR #729)

These were in #729 but **not** in this PR — upstream already has them or they belong in a follow-up PR:

| Category | Examples |
|----------|----------|
| Stale unrelated fixes | Content strategy streaming/caching, OAuth token monitoring, GSC analyzer, scheduler dashboard |
| Analytics UI (follow-up PR) | `LinkedInAnalyticsDashboard`, date-range picker components |
| Local dev artifacts | `ngrok.exe` |
| `main.py` onboarding guard | Not needed when using `python start_alwrity_backend.py` (`app.py` handles feature modes) |

Backend analytics service modules (`personal_analytics.py`, etc.) remain for API route imports; analytics **UI** is deferred.

---

## Commit History (this branch)

| Commit | Summary |
|--------|---------|
| `77aa8e6f` | Restore Unipile Phases 1–6 on fresh upstream main (75 LinkedIn files) |
| `0ab6b326` | Fix OAuth popup auto-close after successful Unipile connect |

> Note: Intermediate revert commits for an abandoned `main.py` fix may appear in history; net code change is the two commits above.

---

## 🔄 Type of Change

- [x] 🐛 Bug fix (OAuth popup close)
- [x] ✨ New feature (Unipile connect + Phases 1–6)
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI changes
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvements
- [ ] 🧪 Test additions/updates

---

## 🎯 Related Issues

Supersedes #729

Closes #(issue number)  
Fixes #(issue number)  
Related to #(issue number)

---

## 🧪 Testing

- [ ] Backend tests pass (reviewer to run)
- [ ] Frontend tests pass
- [x] Manual testing completed on fresh `upstream/main` base
- [ ] Cross-browser testing (if applicable)
- [ ] Mobile testing (if applicable)

### Manual test plan (verified locally)

1. [x] Connect LinkedIn via Unipile OAuth popup → `GET /connection/status` returns connected
2. [x] OAuth popup closes automatically after connect
3. [x] Open LinkedIn Writer → connected profile / setup panel renders
4. [x] Click **Topic Suggestion** → Phases 1–6 complete → 5 recommendation cards display
5. [ ] Incomplete profile → completion questions → submit answers → pipeline resumes
6. [ ] Induce LLM/validation failure → structured error with phase label and **Retry** button
7. [ ] `refresh_recommendations=true` → new topic set generated
8. [x] Disconnect → reconnect → pipeline runs cleanly from Phase 1

### Recommended local startup (matches team README)

```powershell
# Backend — use app.py entry point (not uvicorn main:app)
cd backend
python start_alwrity_backend.py

# Frontend
cd frontend
npm start
```

For LinkedIn-only dev: `ALWRITY_ENABLED_FEATURES=linkedin` in `backend/.env`

### Backend test commands

```bash
cd backend
python -m pytest tests/services/integrations/linkedin/test_topic_recommendation_validator.py -v
python -m pytest tests/services/integrations/linkedin/test_topic_recommendation_service.py -v
python -m pytest tests/services/llm_providers/test_gemini_schema_conversion.py -v
python -m pytest tests/api/test_linkedin_profile_route.py -v
```

---

## 📸 Screenshots (if applicable)

### Before

<!-- LinkedIn Writer without connected profile / no topic recommendations -->

### After

<!-- Connected profile card + 5 topic recommendation cards after Topic Suggestion -->

---

## 🏷️ Component/Feature

- [ ] Blog Writer
- [ ] SEO Dashboard
- [ ] Content Planning
- [ ] Facebook Writer
- [x] LinkedIn Writer
- [x] Onboarding (LinkedIn platform card only)
- [ ] Authentication
- [x] API
- [x] Database
- [ ] GSC Integration
- [ ] Subscription System
- [ ] Monitoring/Billing
- [ ] Documentation
- [ ] Other: _______________

---

## 📋 Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

### ALwrity-Specific Checklist

- [x] API endpoints follow RESTful conventions
- [x] AI service integrations handle rate limits and errors gracefully
- [x] Content generation includes proper validation and sanitization
- [x] Database migrations are included if schema changes are made
- [ ] Environment variables are documented in env_template.txt
- [x] Security considerations have been addressed
- [x] Performance impact has been considered
- [x] User experience is consistent with existing features
- [x] No unrelated upstream fixes re-introduced from stale branch

---

## 🔍 Code Quality

- [x] Code is properly formatted
- [ ] No console.log statements left in production code
- [x] Error handling is implemented where needed
- [x] Performance considerations have been addressed
- [x] Security considerations have been addressed

---

## 📚 Documentation

- [ ] README updated (if needed)
- [ ] API documentation updated (if needed)
- [x] Code comments added for complex logic
- [ ] Changelog updated (if applicable)

### Related docs in this repo

- `docs/linkedin/PR_729_BRANCH_RECOVERY_PLAN.md` — branch recovery plan (how this PR was built)
- `docs/linkedin/linkedin-profile-recommendation-editing/PHASE_7_IMPLEMENTATION_PLAN.md` — next phase (out of scope here)
- `docs/linkedin/unipile/` — Unipile connection migration and RCA docs

---

## 🚀 Deployment Notes

### Required environment variables

| Variable | Purpose |
|----------|---------|
| `UNIPILE_API_KEY` | Unipile API authentication |
| `UNIPILE_DSN` | Unipile API base URL |
| `GEMINI_API_KEY` | Phases 5 & 6 LLM calls |
| `LINKEDIN_TOKEN_ENCRYPTION_KEY` | Encrypted per-user credential storage |
| `NGROK_URL` / public backend URL | OAuth callback + Unipile `notify_url` (development) |
| `FRONTEND_URL` or `OAUTH_CALLBACK_ALLOWED_ORIGINS` | OAuth callback postMessage target (optional; popup close works without) |

### Operational notes

- Phases 5–6 use Gemini structured JSON; allow extended timeout on `GET /profile` (frontend client configured for long-running requests)
- Per-user analysis data stored in `linkedin_analysis_context` (SQLite per workspace)
- Start backend with `python start_alwrity_backend.py` (uses `app.py` with feature-mode routing)
- Restart backend after deploy before running Topic Suggestion E2E

---

## 🔗 Additional Context

### Phase 6 recommendation shape

Each recommendation includes:

- `id` — server-assigned UUID
- `title` — concise content idea headline
- `why_this_fits` — 1–2 sentences explaining fit to this user
- `recommended_format` — `"LinkedIn Post"` or `"LinkedIn Article"`
- `target_audience` — array of professional audience labels
- `growth_impact` — `"High"`, `"Medium"`, or `"Low"`

### Structured pipeline errors

When a phase fails, the API returns `analysis_error`:

```json
{
  "failed_phase": 6,
  "phase_label": "Topic Recommendations",
  "error_code": "schema_validation",
  "user_message": "We couldn't load content suggestions right now. Please try again.",
  "debug_message": "..."
}
```

### Modular architecture principles

- API routes validate and delegate only — no business logic in routes
- Services own orchestration and gates
- Repositories own persistence
- LLM adapters are thin and injectable for tests
- Validators are pure (no LLM, no DB)

### Follow-up work (not in this PR)

- **Analytics dashboard UI** — second PR from backup branch
- **Phase 7 — Profile Optimization Recommendations** — after this PR merges

---

## 👥 Reviewers

@AJaySi @rajbhati 

---

**Thank you for contributing to ALwrity!** 🎉
