### PR TITLE
refactor(oauth): make LinkedIn OAuth follow the common OAuth framework

### DIFF
--- a/backend/services/integrations/bing_oauth.py
+++ b/backend/services/integrations/bing_oauth.py
@@ -12,13 +12,24 @@ from datetime import datetime, timedelta
 from loguru import logger
 import json
 from urllib.parse import quote
+from cryptography.fernet import Fernet, InvalidToken
 from ..analytics_cache_service import analytics_cache
 
 from services.database import get_user_db_path
+from .oauth_provider_base import OAuthProviderBase, resolve_encryption_key
 
-class BingOAuthService:
+class BingOAuthService(OAuthProviderBase):
     """Manages Bing Webmaster Tools OAuth2 authentication flow."""
-    
+
+    # SQL fragments consumed by OAuthProviderBase._migrate_plaintext_tokens_if_needed
+    _select_plaintext_tokens_sql = (
+        "SELECT id, access_token, refresh_token FROM bing_oauth_tokens WHERE user_id = ?"
+    )
+    _update_token_sql = (
+        "UPDATE bing_oauth_tokens SET access_token = ?, refresh_token = ?, updated_at = datetime('now') "
+        "WHERE id = ? AND user_id = ?"
+    )
+
     def __init__(self):
         # Bing Webmaster OAuth2 credentials
         self.client_id = os.getenv('BING_CLIENT_ID', '')
@@ -27,12 +38,15 @@ class BingOAuthService:
         self.base_url = "https://www.bing.com"
         self.api_base_url = "https://www.bing.com/webmaster/api.svc/json"
 
+        # Token encryption (matches the Wix/WordPress pattern; closes
+        # a security gap where Bing tokens were stored in plaintext).
+        self.token_encryption_key = resolve_encryption_key("bing")
+        self._fernet = self._initialize_fernet()
+        self._migration_done: set = set()
+
         if not self.client_id or not self.client_secret or self.client_id == 'your_bing_client_id_here':
             logger.warning("Bing Webmaster OAuth client credentials not configured. Please set BING_CLIENT_ID and BING_CLIENT_SECRET environment variables with valid Bing Webmaster application credentials.")
             logger.warning("To get credentials: 1. Go to https://www.bing.com/webmasters/ 2. Sign in to Bing Webmaster Tools 3. Go to Settings > API Access 4. Create OAuth client")
-    
-    def _get_db_path(self, user_id: str) -> str:
-        return get_user_db_path(user_id)
 
     def _init_db(self, user_id: str):
         """Initialize database tables for OAuth tokens."""
@@ -213,11 +227,13 @@ class BingOAuthService:
             
             with sqlite3.connect(db_path) as conn:
                 cursor = conn.cursor()
+                encrypted_access = self._encrypt_token(access_token)
+                encrypted_refresh = self._encrypt_token(refresh_token)
                 cursor.execute('''
-                    INSERT INTO bing_oauth_tokens 
+                    INSERT INTO bing_oauth_tokens
                     (user_id, access_token, refresh_token, token_type, expires_at, scope)
                     VALUES (?, ?, ?, ?, ?, ?)
-                ''', (user_id, access_token, refresh_token, token_type, expires_at, 'webmaster.manage'))
+                ''', (user_id, encrypted_access, encrypted_refresh, token_type, expires_at, 'webmaster.manage'))
                 conn.commit()
                 logger.info(f"Bing OAuth: Token inserted into database for user {user_id}")
             
@@ -307,8 +323,9 @@ class BingOAuthService:
             db_path = self._get_db_path(user_id)
             if not os.path.exists(db_path):
                 return []
-                
+
             with sqlite3.connect(db_path) as conn:
+                self._migrate_plaintext_tokens_if_needed(conn, user_id)
                 cursor = conn.cursor()
                 cursor.execute('''
                     SELECT id, access_token, refresh_token, token_type, expires_at, scope, created_at
@@ -316,13 +333,32 @@ class BingOAuthService:
                     WHERE user_id = ? AND is_active = TRUE AND expires_at > datetime('now')
                     ORDER BY created_at DESC
                 ''', (user_id,))
-                
+
                 tokens = []
                 for row in cursor.fetchall():
+                    access_token_val = row[1]
+                    refresh_token_val = row[2]
+                    try:
+                        decrypted_access = (
+                            self._decrypt_token(access_token_val)
+                            if self._is_likely_encrypted_blob(access_token_val)
+                            else access_token_val
+                        )
+                    except InvalidToken:
+                        logger.error(f"Failed to decrypt Bing access token for user {user_id}, token_id={row[0]}")
+                        continue
+                    try:
+                        decrypted_refresh = (
+                            self._decrypt_token(refresh_token_val)
+                            if self._is_likely_encrypted_blob(refresh_token_val)
+                            else refresh_token_val
+                        )
+                    except InvalidToken:
+                        decrypted_refresh = None
                     tokens.append({
                         "id": row[0],
-                        "access_token": row[1],
-                        "refresh_token": row[2],
+                        "access_token": decrypted_access,
+                        "refresh_token": decrypted_refresh,
                         "token_type": row[3],
                         "expires_at": row[4],
                         "scope": row[5],
@@ -339,10 +375,11 @@ class BingOAuthService:
             # Ensure DB tables exist for this user before querying
             self._init_db(user_id)
             db_path = self._get_db_path(user_id)
-            
+
             with sqlite3.connect(db_path) as conn:
+                self._migrate_plaintext_tokens_if_needed(conn, user_id)
                 cursor = conn.cursor()
-                
+
                 # Get all tokens (active and expired)
                 cursor.execute('''
                     SELECT id, access_token, refresh_token, token_type, expires_at, scope, created_at, is_active
@@ -350,16 +387,34 @@ class BingOAuthService:
                     WHERE user_id = ?
                     ORDER BY created_at DESC
                 ''', (user_id,))
-                
+
                 all_tokens = []
                 active_tokens = []
                 expired_tokens = []
-                
+
                 for row in cursor.fetchall():
+                    access_token_val = row[1]
+                    refresh_token_val = row[2]
+                    try:
+                        decrypted_access = (
+                            self._decrypt_token(access_token_val)
+                            if self._is_likely_encrypted_blob(access_token_val)
+                            else access_token_val
+                        )
+                    except InvalidToken:
+                        decrypted_access = None
+                    try:
+                        decrypted_refresh = (
+                            self._decrypt_token(refresh_token_val)
+                            if self._is_likely_encrypted_blob(refresh_token_val)
+                            else refresh_token_val
+                        )
+                    except InvalidToken:
+                        decrypted_refresh = None
                     token_data = {
                         "id": row[0],
-                        "access_token": row[1],
-                        "refresh_token": row[2],
+                        "access_token": decrypted_access,
+                        "refresh_token": decrypted_refresh,
                         "token_type": row[3],
                         "expires_at": row[4],
                         "scope": row[5],
@@ -367,7 +422,7 @@ class BingOAuthService:
                         "is_active": bool(row[7])
                     }
                     all_tokens.append(token_data)
-                    
+
                     # Determine expiry using robust parsing and is_active flag
                     is_active_flag = bool(row[7])
                     not_expired = False
@@ -482,11 +537,12 @@ class BingOAuthService:
             db_path = self._get_db_path(user_id)
             with sqlite3.connect(db_path) as conn:
                 cursor = conn.cursor()
+                encrypted_access = self._encrypt_token(access_token)
                 cursor.execute('''
-                    UPDATE bing_oauth_tokens 
+                    UPDATE bing_oauth_tokens
                     SET access_token = ?, expires_at = ?, is_active = TRUE, updated_at = datetime('now')
                     WHERE user_id = ? AND refresh_token = ?
-                ''', (access_token, expires_at, user_id, refresh_token))
+                ''', (encrypted_access, expires_at, user_id, refresh_token))
                 conn.commit()
             
             logger.info(f"Bing access token refreshed for user {user_id}")
@@ -696,12 +752,13 @@ class BingOAuthService:
                         expires_at_value = datetime.now() + timedelta(seconds=int(refreshed_token["expires_in"]))
                     except Exception:
                         expires_at_value = None
+                encrypted_access = self._encrypt_token(refreshed_token["access_token"])
                 cursor.execute('''
-                    UPDATE bing_oauth_tokens 
+                    UPDATE bing_oauth_tokens
                     SET access_token = ?, expires_at = ?, is_active = TRUE, updated_at = datetime('now')
                     WHERE id = ?
                 ''', (
-                    refreshed_token["access_token"],
+                    encrypted_access,
                     expires_at_value,
                     token_id
                 ))

--- a/backend/services/integrations/linkedin_oauth.py
+++ b/backend/services/integrations/linkedin_oauth.py
@@ -18,10 +18,9 @@ from typing import Any, Dict, List, Mapping, Optional, Tuple
 from urllib.parse import quote, unquote, urlencode, urlparse
 
 import requests
-from cryptography.fernet import Fernet, InvalidToken
 from loguru import logger
 
-from services.database import get_user_db_path
+from services.integrations.oauth_provider_base import OAuthProviderBase, resolve_encryption_key
 from services.integrations.linkedin.types import (
     LinkedInCredentials,
     LinkedInNotConnectedError,
@@ -54,8 +53,15 @@ def _is_placeholder_backend_url(url: str) -> bool:
     return any(token in normalized for token in _PLACEHOLDER_BACKEND_URL_TOKENS)
 
 
-class LinkedInOAuthService:
-    """Manages LinkedIn Growth Engine credentials (Zernio, Unipile, or native OAuth)."""
+class LinkedInOAuthService(OAuthProviderBase):
+    """Manages LinkedIn Growth Engine credentials (Zernio, Unipile, or native OAuth).
+
+    Inherits Fernet token encryption and per-user DB path resolution from
+    OAuthProviderBase (commits e383d08c / 1ca38b01 / 386f7813). Overrides
+    only the migration method: LinkedIn stores a Zernio API key alongside
+    the LinkedIn access/refresh tokens, so the standard 2-column
+    migration doesn't fit and we use a 3-column variant here.
+    """
 
     _TOKEN_SELECT_COLUMNS = """
         id, user_id, provider_mode, zernio_api_key, zernio_account_id,
@@ -66,54 +72,14 @@ class LinkedInOAuthService:
 
     def __init__(self, db_path: Optional[str] = None):
         self.db_path = db_path
-        self.token_encryption_key = (
-            os.getenv("LINKEDIN_TOKEN_ENCRYPTION_KEY")
-            or os.getenv("OAUTH_TOKEN_ENCRYPTION_KEY")
-        )
+        self.token_encryption_key = resolve_encryption_key("linkedin")
+        # Fail-fast at construction: if the key is missing or invalid,
+        # OAuthProviderBase._initialize_fernet raises ValueError with a
+        # message naming the provider-specific env var. This matches the
+        # cs4 normalization applied to Bing/Wix/WordPress/YouTube in
+        # 386f7813.
         self._fernet = self._initialize_fernet()
         self._migration_done: set[str] = set()
-
-    def _initialize_fernet(self) -> Optional[Fernet]:
-        if not self.token_encryption_key:
-            logger.warning(
-                "LinkedIn token encryption key not configured; "
-                "per-user credential storage will be unavailable."
-            )
-            return None
-        try:
-            return Fernet(self.token_encryption_key.encode("utf-8"))
-        except Exception:
-            logger.error("LinkedIn token encryption key is invalid.")
-            return None
-
-    def _encrypt_token(self, token: Optional[str]) -> Optional[str]:
-        if not token:
-            return None
-        if not self._fernet:
-            raise ValueError(
-                "Token encryption unavailable: set LINKEDIN_TOKEN_ENCRYPTION_KEY "
-                "or OAUTH_TOKEN_ENCRYPTION_KEY"
-            )
-        return self._fernet.encrypt(token.encode("utf-8")).decode("utf-8")
-
-    def _decrypt_token(self, token_blob: Optional[str]) -> Optional[str]:
-        if not token_blob:
-            return None
-        if not self._fernet:
-            raise ValueError("Token decryption unavailable: missing encryption key")
-        try:
-            return self._fernet.decrypt(token_blob.encode("utf-8")).decode("utf-8")
-        except InvalidToken:
-            logger.error("LinkedIn token decryption failed (invalid token blob)")
-            return None
-
-    def _is_likely_encrypted_blob(self, value: Optional[str]) -> bool:
-        return bool(value and value.startswith("gAAAAA"))
-
-    def _get_db_path(self, user_id: str) -> str:
-        if self.db_path:
-            return self.db_path
-        return get_user_db_path(user_id)
 
     def _init_db(self, user_id: str) -> None:
         db_path = self._get_db_path(user_id)
@@ -226,7 +192,19 @@ class LinkedInOAuthService:
     def _migrate_plaintext_tokens_if_needed(
         self, conn: sqlite3.Connection, user_id: str
     ) -> None:
-        if not self._fernet or user_id in self._migration_done:
+        """Override of OAuthProviderBase._migrate_plaintext_tokens_if_needed.
+
+        LinkedIn stores three encrypted columns per row (Zernio API key,
+        LinkedIn access token, LinkedIn refresh token), while the base
+        class's migration handles two columns. We keep the 2-column
+        behaviour for access/refresh by calling the base, then do an
+        additional pass for the Zernio API key.
+
+        The per-user gate is honoured via self._migration_done; the base
+        class would skip this user on subsequent calls, so we manage the
+        gate ourselves to keep both passes in lockstep.
+        """
+        if user_id in self._migration_done:
             return
         cursor = conn.cursor()
         cursor.execute(
@@ -511,6 +489,7 @@ class LinkedInOAuthService:
             created_at,
             _updated_at,
             zernio_profile_id,
+            *_rest,  # unipile_account_id, unipile_org_account_id (optional)
         ) = row
         not_expired, expires_dt = self._parse_expires_at(expires_at)
         has_refresh = bool(linkedin_refresh_token)

--- a/backend/services/integrations/oauth_provider_base.py
+++ b/backend/services/integrations/oauth_provider_base.py
@@ -1,0 +1,195 @@
+"""
+OAuth Provider Base Class
+
+Shared Fernet token encryption + plaintext migration for the four
+ALwrity OAuth providers (Bing, Wix, WordPress, YouTube).
+
+All four providers store their OAuth tokens in a per-user SQLite
+database (see services.database.get_user_db_path) and exchange
+them with remote APIs. Before this base class existed, each
+provider maintained its own copy of the Fernet init / encrypt /
+decrypt / migration logic. Bing (the only one that was storing
+plaintext) caught up with the others in commit e383d08c, but
+the actual code was still duplicated across all four files.
+
+This module extracts the shared surface:
+
+- _initialize_fernet: read BING_TOKEN_ENCRYPTION_KEY /
+  WIX_TOKEN_ENCRYPTION_KEY / WORDPRESS_TOKEN_ENCRYPTION_KEY /
+  YOUTUBE_TOKEN_ENCRYPTION_KEY (each provider class supplies
+  its key attribute name) with a shared fallback to
+  OAUTH_TOKEN_ENCRYPTION_KEY. Returns Optional[Fernet] (matches
+  the Wix/WordPress/Bing convention). YouTube overrides this to
+  raise on missing key (see oauth_provider_base / YouTube).
+- _encrypt_token / _decrypt_token: word-for-word identical
+  across providers. Raise ValueError if Fernet is unavailable
+  so the caller knows the failure mode.
+- _is_likely_encrypted_blob: Fernet ciphertext starts with
+  'gAAAAA'. Used to skip decryption for already-plaintext
+  rows during the one-time migration.
+- _migrate_plaintext_tokens_if_needed: re-encrypts any plaintext
+  rows the first time the user reads their tokens, gated by
+  the per-instance _migration_done set so the migration runs
+  at most once per user per process.
+- _get_db_path: thin wrapper over services.database.get_user_db_path
+  that honours an optional ctor-injected db_path (for tests).
+
+Subclasses (WixOAuthService, WordPressOAuthService,
+BingOAuthService, YouTubeOAuthService) keep their own:
+
+- __init__: provider-specific client_id, client_secret, scope,
+  redirect_uri, base_url
+- _init_db: provider-specific SQLite schema (CREATE TABLE
+  per provider, with different columns)
+- _get_db_path override: only if a provider needs a different
+  path resolution
+- generate_authorization_url / handle_oauth_callback:
+  provider-specific OAuth flow
+- The full Google OAuth library integration in YouTubeOAuthService
+  (uses google-auth-oauthlib instead of manual token storage)
+"""
+
+import os
+import sqlite3
+from typing import Optional
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from loguru import logger
+
+from services.database import get_user_db_path
+
+
+# Per-provider env var names, in the order they should be tried
+# (provider-specific first, shared fallback last). Subclasses
+# override the appropriate name.
+PROVIDER_ENV_VARS = {
+    "bing": "BING_TOKEN_ENCRYPTION_KEY",
+    "wix": "WIX_TOKEN_ENCRYPTION_KEY",
+    "wordpress": "WORDPRESS_TOKEN_ENCRYPTION_KEY",
+    "youtube": "YOUTUBE_TOKEN_ENCRYPTION_KEY",
+    "linkedin": "LINKEDIN_TOKEN_ENCRYPTION_KEY",
+}
+
+
+class OAuthProviderBase:
+    """Shared Fernet encryption + plaintext migration for OAuth tokens.
+
+    Subclasses must define:
+        self.token_encryption_key: str | None  (set in __init__)
+    """
+
+    def _initialize_fernet(self) -> Fernet:
+        """Initialize Fernet, raising on missing or invalid key.
+
+        OAuth tokens must be encrypted at rest. The user's 'no
+        fallbacks' mandate means a missing or invalid key fails
+        fast at service construction, not lazily on the first
+        token operation (where the failure mode is a confusing
+        'Fernet is None' deep in the call stack).
+
+        Subclasses inherit this behavior by default. The previous
+        'warn and return None' behavior in Wix/WordPress/Bing
+        is a step-3 change: this commit normalizes all 4
+        providers to fail-fast at construction.
+
+        To override (e.g. to fail-soft in a test fixture), set
+        self._fernet manually after __init__.
+        """
+        if not self.token_encryption_key:
+            # List all provider-specific env vars so the operator
+            # sees the full picture. The class name (type(self).__name__)
+            # identifies which one is the canonical match for this
+            # provider.
+            env_vars = " / ".join(sorted(PROVIDER_ENV_VARS.values()))
+            raise ValueError(
+                f"{type(self).__name__} token encryption key is not configured. "
+                f"Set the appropriate env var ({env_vars}) or the shared "
+                f"OAUTH_TOKEN_ENCRYPTION_KEY fallback. "
+                f"Generate a key: python -c \"from cryptography.fernet import Fernet; "
+                f"print(Fernet.generate_key().decode())\""
+            )
+        try:
+            return Fernet(self.token_encryption_key.encode("utf-8"))
+        except Exception as e:
+            raise ValueError(
+                f"{type(self).__name__} token encryption key is invalid: {e}"
+            )
+
+    def _encrypt_token(self, token: Optional[str]) -> Optional[str]:
+        if not token:
+            return None
+        # _fernet is guaranteed by _initialize_fernet raising at
+        # construction. The AttributeError that would result from
+        # None is a programmer error (someone set _fernet=None
+        # directly), not a runtime condition.
+        return self._fernet.encrypt(token.encode("utf-8")).decode("utf-8")
+
+    def _decrypt_token(self, token_blob: Optional[str]) -> Optional[str]:
+        if not token_blob:
+            return None
+        return self._fernet.decrypt(token_blob.encode("utf-8")).decode("utf-8")
+
+    def _is_likely_encrypted_blob(self, value: Optional[str]) -> bool:
+        return bool(value and value.startswith("gAAAAA"))
+
+    def _migrate_plaintext_tokens_if_needed(
+        self, conn: sqlite3.Connection, user_id: str
+    ) -> None:
+        """One-time migration: re-encrypt plaintext rows during rollout.
+
+        Subclasses must define:
+            self._migration_done: set  (per-user-per-process gate)
+            self._select_plaintext_tokens_sql: str  (SELECT id, access_token, refresh_token ...)
+            self._update_token_sql: str  (UPDATE ... SET access_token = ?, refresh_token = ?, updated_at = ...)
+
+        See WixOAuthService for the canonical pattern.
+        """
+        if user_id in self._migration_done:
+            return
+        cursor = conn.cursor()
+        cursor.execute(self._select_plaintext_tokens_sql, (user_id,))
+        rows = cursor.fetchall()
+        migrated = 0
+        for row in rows:
+            token_id = row[0]
+            access_token = row[1]
+            refresh_token = row[2]
+            needs_access = access_token and not self._is_likely_encrypted_blob(access_token)
+            needs_refresh = refresh_token and not self._is_likely_encrypted_blob(refresh_token)
+            if not (needs_access or needs_refresh):
+                continue
+            enc_access = self._encrypt_token(access_token) if needs_access else access_token
+            enc_refresh = self._encrypt_token(refresh_token) if needs_refresh else refresh_token
+            cursor.execute(
+                self._update_token_sql,
+                (enc_access, enc_refresh, token_id, user_id),
+            )
+            migrated += 1
+        if migrated:
+            conn.commit()
+            logger.info(
+                f"{type(self).__name__} OAuth token migration completed for user {user_id}; rows migrated={migrated}"
+            )
+        self._migration_done.add(user_id)
+
+    def _get_db_path(self, user_id: str) -> str:
+        if getattr(self, "db_path", None):
+            return self.db_path
+        return get_user_db_path(user_id)
+
+
+def resolve_encryption_key(provider_name: str) -> Optional[str]:
+    """Resolve the Fernet key for a provider, honouring the
+    provider-specific env var first, then the shared
+    OAUTH_TOKEN_ENCRYPTION_KEY fallback.
+
+    Used by subclass __init__ methods to set
+    self.token_encryption_key.
+    """
+    provider_var = PROVIDER_ENV_VARS.get(provider_name.lower())
+    if provider_var:
+        specific = os.getenv(provider_var)
+        if specific:
+            return specific
+    return os.getenv("OAUTH_TOKEN_ENCRYPTION_KEY")

--- a/backend/services/integrations/wix_oauth.py
+++ b/backend/services/integrations/wix_oauth.py
@@ -11,78 +11,26 @@ from loguru import logger
 from cryptography.fernet import Fernet, InvalidToken
 
 from services.database import get_user_db_path
+from .oauth_provider_base import OAuthProviderBase, resolve_encryption_key
 
-class WixOAuthService:
+class WixOAuthService(OAuthProviderBase):
     """Manages Wix OAuth2 authentication flow and token storage."""
-    
+
+    # SQL fragments consumed by OAuthProviderBase._migrate_plaintext_tokens_if_needed
+    _select_plaintext_tokens_sql = (
+        "SELECT id, access_token, refresh_token FROM wix_oauth_tokens WHERE user_id = ?"
+    )
+    _update_token_sql = (
+        "UPDATE wix_oauth_tokens SET access_token = ?, refresh_token = ?, updated_at = datetime('now') "
+        "WHERE id = ? AND user_id = ?"
+    )
+
     def __init__(self, db_path: Optional[str] = None):
         self.db_path = db_path
-        self.token_encryption_key = (
-            os.getenv("WIX_TOKEN_ENCRYPTION_KEY")
-            or os.getenv("OAUTH_TOKEN_ENCRYPTION_KEY")
-        )
+        self.token_encryption_key = resolve_encryption_key("wix")
         self._fernet = self._initialize_fernet()
         self._migration_done: set = set()
 
-    def _initialize_fernet(self) -> Optional[Fernet]:
-        if not self.token_encryption_key:
-            logger.error("Wix token encryption key is not configured.")
-            return None
-        try:
-            return Fernet(self.token_encryption_key.encode("utf-8"))
-        except Exception:
-            logger.error("Wix token encryption key is invalid.")
-            return None
-
-    def _encrypt_token(self, token: Optional[str]) -> Optional[str]:
-        if not token:
-            return None
-        if not self._fernet:
-            raise ValueError("Token encryption is unavailable: missing/invalid managed key")
-        return self._fernet.encrypt(token.encode("utf-8")).decode("utf-8")
-
-    def _decrypt_token(self, token_blob: Optional[str]) -> Optional[str]:
-        if not token_blob:
-            return None
-        if not self._fernet:
-            raise ValueError("Token decryption is unavailable: missing/invalid managed key")
-        return self._fernet.decrypt(token_blob.encode("utf-8")).decode("utf-8")
-
-    def _is_likely_encrypted_blob(self, value: Optional[str]) -> bool:
-        return bool(value and value.startswith("gAAAAA"))
-
-    def _migrate_plaintext_tokens_if_needed(self, conn: sqlite3.Connection, user_id: str) -> None:
-        if not self._fernet or user_id in self._migration_done:
-            return
-        cursor = conn.cursor()
-        cursor.execute(
-            "SELECT id, access_token, refresh_token FROM wix_oauth_tokens WHERE user_id = ?",
-            (user_id,),
-        )
-        rows = cursor.fetchall()
-        migrated = 0
-        for token_id, access_token, refresh_token in rows:
-            needs_access = access_token and not self._is_likely_encrypted_blob(access_token)
-            needs_refresh = refresh_token and not self._is_likely_encrypted_blob(refresh_token)
-            if not (needs_access or needs_refresh):
-                continue
-            enc_access = self._encrypt_token(access_token) if needs_access else access_token
-            enc_refresh = self._encrypt_token(refresh_token) if needs_refresh else refresh_token
-            cursor.execute(
-                "UPDATE wix_oauth_tokens SET access_token = ?, refresh_token = ?, updated_at = datetime('now') WHERE id = ? AND user_id = ?",
-                (enc_access, enc_refresh, token_id, user_id),
-            )
-            migrated += 1
-        if migrated:
-            conn.commit()
-            logger.info(f"Wix OAuth token migration completed for user {user_id}; rows migrated={migrated}")
-        self._migration_done.add(user_id)
-    
-    def _get_db_path(self, user_id: str) -> str:
-        if self.db_path:
-            return self.db_path
-        return get_user_db_path(user_id)
-    
     def _init_db(self, user_id: str):
         """Initialize database tables for OAuth tokens."""
         db_path = self._get_db_path(user_id)

--- a/backend/services/integrations/wordpress_oauth.py
+++ b/backend/services/integrations/wordpress_oauth.py
@@ -13,104 +13,46 @@ from loguru import logger
 from cryptography.fernet import Fernet, InvalidToken
 
 from services.database import get_user_db_path
+from .oauth_provider_base import OAuthProviderBase, resolve_encryption_key
 
-class WordPressOAuthService:
+class WordPressOAuthService(OAuthProviderBase):
     """Manages WordPress.com OAuth2 authentication flow."""
-    
+
+    # SQL fragments consumed by OAuthProviderBase._migrate_plaintext_tokens_if_needed
+    _select_plaintext_tokens_sql = (
+        "SELECT id, access_token, refresh_token FROM wordpress_oauth_tokens WHERE user_id = ?"
+    )
+    _update_token_sql = (
+        "UPDATE wordpress_oauth_tokens SET access_token = ?, refresh_token = ?, updated_at = datetime('now') "
+        "WHERE id = ? AND user_id = ?"
+    )
+
     def __init__(self, db_path: str = None):
         # db_path is deprecated in favor of dynamic user_id based paths
         self.db_path = db_path
         # WordPress.com OAuth2 credentials
         self.client_id = os.getenv('WORDPRESS_CLIENT_ID', '')
         self.client_secret = os.getenv('WORDPRESS_CLIENT_SECRET', '')
-        
+
         # Determine redirect URI dynamically
         default_redirect = 'https://alwrity-ai.vercel.app/wp/callback'
         frontend_url = os.getenv('FRONTEND_URL')
-        
+
         if frontend_url:
             self.redirect_uri = f"{frontend_url.rstrip('/')}/wp/callback"
         else:
             self.redirect_uri = os.getenv('WORDPRESS_REDIRECT_URI', default_redirect)
-            
+
         self.base_url = "https://public-api.wordpress.com"
-        self.token_encryption_key = (
-            os.getenv("WORDPRESS_TOKEN_ENCRYPTION_KEY")
-            or os.getenv("OAUTH_TOKEN_ENCRYPTION_KEY")
-        )
+        self.token_encryption_key = resolve_encryption_key("wordpress")
         self._fernet = self._initialize_fernet()
+        self._migration_done: set = set()
 
         # Validate configuration
         if not self.client_id or not self.client_secret or self.client_id == 'your_wordpress_com_client_id_here':
             logger.error("WordPress OAuth client credentials not configured. Please set WORDPRESS_CLIENT_ID and WORDPRESS_CLIENT_SECRET environment variables with valid WordPress.com application credentials.")
             logger.error("To get credentials: 1. Go to https://developer.wordpress.com/apps/ 2. Create a new application 3. Set redirect URI to: https://your-domain.com/wp/callback")
-    
-    def _initialize_fernet(self) -> Optional[Fernet]:
-        """Initialize token encryption using managed key from env/secret manager."""
-        if not self.token_encryption_key:
-            logger.error("WordPress token encryption key is not configured.")
-            return None
-        try:
-            return Fernet(self.token_encryption_key.encode("utf-8"))
-        except Exception:
-            logger.error("WordPress token encryption key is invalid.")
-            return None
 
-    def _encrypt_token(self, token: Optional[str]) -> Optional[str]:
-        if not token:
-            return None
-        if not self._fernet:
-            raise ValueError("Token encryption is unavailable: missing/invalid managed key")
-        return self._fernet.encrypt(token.encode("utf-8")).decode("utf-8")
-
-    def _decrypt_token(self, token_blob: Optional[str]) -> Optional[str]:
-        if not token_blob:
-            return None
-        if not self._fernet:
-            raise ValueError("Token decryption is unavailable: missing/invalid managed key")
-        return self._fernet.decrypt(token_blob.encode("utf-8")).decode("utf-8")
-
-    def _is_likely_encrypted_blob(self, value: Optional[str]) -> bool:
-        return bool(value and value.startswith("gAAAAA"))
-
-    def _migrate_plaintext_tokens_if_needed(self, conn: sqlite3.Connection, user_id: str) -> None:
-        """One-time migration path: re-encrypt plaintext rows during rollout."""
-        if not self._fernet:
-            return
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT id, access_token, refresh_token
-            FROM wordpress_oauth_tokens
-            WHERE user_id = ?
-            """,
-            (user_id,),
-        )
-        rows = cursor.fetchall()
-        migrated = 0
-        for token_id, access_token, refresh_token in rows:
-            needs_access_migration = access_token and not self._is_likely_encrypted_blob(access_token)
-            needs_refresh_migration = refresh_token and not self._is_likely_encrypted_blob(refresh_token)
-            if not (needs_access_migration or needs_refresh_migration):
-                continue
-            encrypted_access = self._encrypt_token(access_token) if needs_access_migration else access_token
-            encrypted_refresh = self._encrypt_token(refresh_token) if needs_refresh_migration else refresh_token
-            cursor.execute(
-                """
-                UPDATE wordpress_oauth_tokens
-                SET access_token = ?, refresh_token = ?, updated_at = datetime('now')
-                WHERE id = ? AND user_id = ?
-                """,
-                (encrypted_access, encrypted_refresh, token_id, user_id),
-            )
-            migrated += 1
-        if migrated:
-            conn.commit()
-            logger.info(f"WordPress OAuth token migration completed for user {user_id}; rows migrated={migrated}")
-
-    def _get_db_path(self, user_id: str) -> str:
-        return get_user_db_path(user_id)
-    
     def _init_db(self, user_id: str):
         """Initialize database tables for OAuth tokens."""
         db_path = self._get_db_path(user_id)

--- a/backend/services/oauth_token_monitoring_service.py
+++ b/backend/services/oauth_token_monitoring_service.py
@@ -77,6 +77,30 @@ def _check_youtube(user_id: str) -> bool:
         return False
 
 
+def _check_linkedin(user_id: str) -> bool:
+    # Imported lazily for the same reason as YouTube: LinkedInOAuthService
+    # inherits from OAuthProviderBase and fails fast at construction if
+    # LINKEDIN_TOKEN_ENCRYPTION_KEY (or OAUTH_TOKEN_ENCRYPTION_KEY) is
+    # missing. Lazy import keeps the dispatch module loadable in
+    # environments where the key isn't configured yet.
+    from services.integrations.linkedin_oauth import LinkedInOAuthService
+    try:
+        linkedin_service = LinkedInOAuthService()
+        token_status = linkedin_service.get_user_token_status(user_id)
+        if token_status.get('has_active_tokens'):
+            return True
+        expired = token_status.get('expired_tokens', [])
+        return bool(expired) and any(t.get('linkedin_refresh_token') for t in expired)
+    except Exception as exc:
+        # Constructor may raise (missing key) or the status call may
+        # hit a database error. Either way, treat as "not connected"
+        # so we don't poison the whole detection.
+        logger.debug(
+            f"[OAuth Monitoring] LinkedIn check skipped for user {user_id}: {exc}"
+        )
+        return False
+
+
 # Stable ordering preserved from the previous inline implementation.
 _PLATFORM_CHECKS: List[Tuple[str, Callable[[str], bool]]] = [
     ('gsc', _check_gsc),
@@ -84,6 +108,7 @@ _PLATFORM_CHECKS: List[Tuple[str, Callable[[str], bool]]] = [
     ('wordpress', _check_wordpress),
     ('wix', _check_wix),
     ('youtube', _check_youtube),
+    ('linkedin', _check_linkedin),
 ]
 
 
@@ -114,19 +139,20 @@ def _safe_check(platform: str, checker: Callable[[str], bool], user_id: str) -> 
 def get_connected_platforms(user_id: str) -> List[str]:
     """
     Detect which platforms are connected for a user by checking token storage.
-    
+
     Checks:
     - GSC: gsc_credentials table
     - Bing: bing_oauth_tokens table
     - WordPress: wordpress_oauth_tokens table
     - Wix: wix_oauth_tokens table
     - YouTube: youtube_oauth_tokens table
-    
+    - LinkedIn: linkedin_oauth_tokens table (Zernio / native / Unipile)
+
     Args:
         user_id: User ID (Clerk string)
-        
+
     Returns:
-        List of connected platform identifiers: ['gsc', 'bing', 'wordpress', 'wix', 'youtube']
+        List of connected platform identifiers: ['gsc', 'bing', 'wordpress', 'wix', 'youtube', 'linkedin']
     """
     connected: List[str] = []
 
@@ -158,7 +184,7 @@ def create_oauth_monitoring_tasks(
         db: Database session
         platforms: Optional list of platforms to create tasks for.
                    If None, auto-detects connected platforms.
-                   Valid values: 'gsc', 'bing', 'wordpress', 'wix'
+                   Valid values: 'gsc', 'bing', 'wordpress', 'wix', 'youtube', 'linkedin'
         
     Returns:
         List of created OAuthTokenMonitoringTask instances

--- a/backend/services/youtube/youtube_oauth_service.py
+++ b/backend/services/youtube/youtube_oauth_service.py
@@ -21,16 +21,35 @@ from cryptography.fernet import Fernet
 from loguru import logger
 
 from services.database import get_user_db_path
+from services.integrations.oauth_provider_base import OAuthProviderBase, resolve_encryption_key
 
 
-class YouTubeOAuthService:
-    """Manages YouTube OAuth2 authentication flow and token storage."""
+class YouTubeOAuthService(OAuthProviderBase):
+    """Manages YouTube OAuth2 authentication flow and token storage.
+
+    Inherits Fernet token encryption + plaintext migration from
+    OAuthProviderBase. YouTube keeps one override because the
+    call-site contract differs from the base:
+    - _decrypt_token: YouTube swallows decryption errors and returns
+      None so the caller's `if not access_token` check can handle
+      a corrupted row; the base class propagates. Kept here to
+      preserve the existing call-site contract.
+    """
 
     SCOPES = [
         "https://www.googleapis.com/auth/youtube.upload",
         "https://www.googleapis.com/auth/youtube.readonly",
         "https://www.googleapis.com/auth/youtube.force-ssl",
     ]
+
+    # SQL fragments consumed by OAuthProviderBase._migrate_plaintext_tokens_if_needed
+    _select_plaintext_tokens_sql = (
+        "SELECT id, access_token, refresh_token FROM youtube_oauth_tokens WHERE user_id = ?"
+    )
+    _update_token_sql = (
+        "UPDATE youtube_oauth_tokens SET access_token = ?, refresh_token = ?, updated_at = datetime('now') "
+        "WHERE id = ? AND user_id = ?"
+    )
 
     def __init__(self, db_path: Optional[str] = None):
         self.db_path = db_path
@@ -45,9 +64,7 @@ class YouTubeOAuthService:
         self.redirect_uri = os.getenv("YOUTUBE_REDIRECT_URI", default_redirect)
 
         # Token encryption
-        self.token_encryption_key = os.getenv(
-            "YOUTUBE_TOKEN_ENCRYPTION_KEY"
-        ) or os.getenv("OAUTH_TOKEN_ENCRYPTION_KEY")
+        self.token_encryption_key = resolve_encryption_key("youtube")
         self._fernet: Fernet = self._initialize_fernet()
         self._migration_done: set = set()
 
@@ -61,24 +78,16 @@ class YouTubeOAuthService:
                 "YouTube upload will not work until these are configured."
             )
 
-    def _initialize_fernet(self) -> Fernet:
-        if not self.token_encryption_key:
-            raise ValueError(
-                "YOUTUBE_TOKEN_ENCRYPTION_KEY (or OAUTH_TOKEN_ENCRYPTION_KEY) is not set. "
-                "OAuth tokens must be encrypted at rest. "
-                "Generate a key: python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\""
-            )
-        try:
-            return Fernet(self.token_encryption_key.encode("utf-8"))
-        except Exception as e:
-            raise ValueError(f"Invalid YOUTUBE_TOKEN_ENCRYPTION_KEY: {e}")
-
-    def _encrypt_token(self, token: Optional[str]) -> Optional[str]:
-        if not token:
-            return None
-        return self._fernet.encrypt(token.encode("utf-8")).decode("utf-8")
+    # _initialize_fernet is inherited from OAuthProviderBase. YouTube
+    # used to override it to raise on missing key; the base class
+    # now does the same thing with a unified error message that
+    # names the correct env var per provider, so the override is
+    # redundant. (Step 3 of the cs4 plan.)
 
     def _decrypt_token(self, token_blob: Optional[str]) -> Optional[str]:
+        # YouTube-specific: swallow decryption errors and return None
+        # so the caller's `if not access_token` check can handle a
+        # corrupted row. The base class propagates the exception.
         if not token_blob:
             return None
         try:
@@ -86,9 +95,6 @@ class YouTubeOAuthService:
         except Exception as e:
             logger.error(f"YouTube OAuth: token decryption failed: {e}")
             return None
-
-    def _is_likely_encrypted_blob(self, value: Optional[str]) -> bool:
-        return bool(value and value.startswith("gAAAAA"))
 
     def _build_client_config(self) -> Optional[Dict[str, Any]]:
         if not self.client_id or not self.client_secret:
@@ -105,9 +111,6 @@ class YouTubeOAuthService:
                 "javascript_origins": [],
             }
         }
-
-    def _get_db_path(self, user_id: str) -> str:
-        return get_user_db_path(user_id)
 
     def _init_db(self, user_id: str):
         db_path = self._get_db_path(user_id)
@@ -142,33 +145,6 @@ class YouTubeOAuthService:
             """)
             conn.commit()
             logger.debug(f"YouTube OAuth tables initialized for user {user_id}")
-
-    def _migrate_plaintext_tokens_if_needed(self, conn: sqlite3.Connection, user_id: str) -> None:
-        if not self._fernet or user_id in self._migration_done:
-            return
-        cursor = conn.cursor()
-        cursor.execute(
-            "SELECT id, access_token, refresh_token FROM youtube_oauth_tokens WHERE user_id = ?",
-            (user_id,),
-        )
-        rows = cursor.fetchall()
-        migrated = 0
-        for token_id, access_token, refresh_token in rows:
-            needs_access = access_token and not self._is_likely_encrypted_blob(access_token)
-            needs_refresh = refresh_token and not self._is_likely_encrypted_blob(refresh_token)
-            if not (needs_access or needs_refresh):
-                continue
-            enc_access = self._encrypt_token(access_token) if needs_access else access_token
-            enc_refresh = self._encrypt_token(refresh_token) if needs_refresh else refresh_token
-            cursor.execute(
-                "UPDATE youtube_oauth_tokens SET access_token = ?, refresh_token = ?, updated_at = datetime('now') WHERE id = ? AND user_id = ?",
-                (enc_access, enc_refresh, token_id, user_id),
-            )
-            migrated += 1
-        if migrated:
-            conn.commit()
-            logger.info(f"YouTube OAuth token migration completed for user {user_id}; rows={migrated}")
-        self._migration_done.add(user_id)
 
     def generate_authorization_url(self, user_id: str) -> Optional[str]:
         """Generate Google OAuth authorization URL for YouTube scopes."""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,8 +1,15 @@
 """Pytest configuration for backend tests."""
 
+import os
 import sys
+import sqlite3
+import tempfile
 import types
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Iterator
+
+import pytest
 
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
@@ -28,5 +35,293 @@ if "services.llm_providers.main_image_generation" not in sys.modules:
     async def _enhance_image_prompt(prompt, user_id=None):
         return prompt
 
-    _llm_img.enhance_image_prompt = _enhance_image_prompt
-    sys.modules["services.llm_providers.main_image_generation"] = _llm_img
+# =========================================================================
+# Schema helpers (subset of real services' tables — enough for the
+# services under test to query what they need).
+# =========================================================================
+
+def _init_wordpress_oauth_tokens(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS wordpress_oauth_tokens (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            access_token TEXT NOT NULL,
+            refresh_token TEXT,
+            token_type TEXT DEFAULT 'bearer',
+            expires_at TIMESTAMP,
+            scope TEXT,
+            blog_id TEXT,
+            blog_url TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            is_active BOOLEAN DEFAULT TRUE
+        )
+        """
+    )
+
+
+def _init_wordpress_sites(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS wordpress_sites (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            site_url TEXT NOT NULL,
+            site_name TEXT,
+            username TEXT,
+            app_password TEXT,
+            is_active BOOLEAN DEFAULT TRUE,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+
+def _init_wordpress_posts(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS wordpress_posts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            site_id INTEGER,
+            wp_post_id INTEGER,
+            title TEXT,
+            status TEXT,
+            published_at TIMESTAMP,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+
+def _init_wix_oauth_tokens(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS wix_oauth_tokens (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            access_token TEXT NOT NULL,
+            refresh_token TEXT,
+            token_type TEXT DEFAULT 'bearer',
+            expires_at TIMESTAMP,
+            expires_in INTEGER,
+            scope TEXT,
+            site_id TEXT,
+            member_id TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            is_active BOOLEAN DEFAULT TRUE
+        )
+        """
+    )
+
+
+def _init_bing_oauth_tokens(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS bing_oauth_tokens (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            access_token TEXT NOT NULL,
+            refresh_token TEXT,
+            token_type TEXT DEFAULT 'bearer',
+            expires_at TIMESTAMP,
+            scope TEXT,
+            site_url TEXT,
+            is_active BOOLEAN DEFAULT TRUE,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+
+def _init_youtube_oauth_tokens(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS youtube_oauth_tokens (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            channel_id TEXT,
+            channel_name TEXT,
+            expires_at TIMESTAMP,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            is_active BOOLEAN DEFAULT TRUE
+        )
+        """
+    )
+
+
+def _init_linkedin_oauth_tokens(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS linkedin_oauth_tokens (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            provider_mode TEXT NOT NULL,
+            zernio_api_key TEXT,
+            zernio_account_id TEXT,
+            zernio_org_account_id TEXT,
+            linkedin_access_token TEXT,
+            linkedin_refresh_token TEXT,
+            expires_at TIMESTAMP,
+            account_name TEXT,
+            profile_urn TEXT,
+            is_active BOOLEAN DEFAULT TRUE,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            zernio_profile_id TEXT,
+            unipile_account_id TEXT,
+            unipile_org_account_id TEXT
+        )
+        """
+    )
+
+
+_ALL_SCHEMAS = (
+    _init_wordpress_oauth_tokens,
+    _init_wordpress_sites,
+    _init_wordpress_posts,
+    _init_wix_oauth_tokens,
+    _init_bing_oauth_tokens,
+    _init_youtube_oauth_tokens,
+    _init_linkedin_oauth_tokens,
+)
+
+
+# Module-level dict tracking the most recently entered temp DB. The
+# ``__exit__`` of ``_PatchedUserDB`` uses this to clear the path only
+# when the outer context unwinds (a nested context shouldn't clobber
+# the outer one).
+_ACTIVE_DB_PATH: dict = {"path": ""}
+
+
+# =========================================================================
+# Shared fixtures
+# =========================================================================
+
+@contextmanager
+def temp_user_db(user_id: str = "user_test") -> Iterator[str]:
+    """Context manager that yields a temp DB path pre-loaded with all
+    OAuth schemas. Cleanup is best-effort.
+
+    Used by tests that need a writable per-user SQLite without touching
+    the real filesystem.
+    """
+    tmpdir = tempfile.mkdtemp(prefix=f"oauth_test_{user_id}_")
+    db_path = os.path.join(tmpdir, f"alwrity_{user_id}.db")
+    with sqlite3.connect(db_path) as conn:
+        for init in _ALL_SCHEMAS:
+            init(conn)
+        conn.commit()
+    try:
+        yield db_path
+    finally:
+        try:
+            os.remove(db_path)
+            os.rmdir(tmpdir)
+        except OSError:
+            pass
+
+
+@pytest.fixture
+def oauth_db():
+    """Pytest fixture returning the ``temp_user_db`` context manager."""
+    return temp_user_db
+
+
+@pytest.fixture
+def patch_user_db_path(monkeypatch):
+    """Factory fixture that patches ``get_user_db_path`` in every module
+    that re-imports it from ``services.database``.
+
+    Returns a function ``patcher(user_id)`` that returns a context
+    manager. Entering the context manager:
+
+    1. Creates a temp DB pre-loaded with all OAuth schemas.
+    2. Patches ``get_user_db_path`` in every OAuth service module to
+       return that temp DB path.
+
+    The patches are auto-undone at test teardown by ``monkeypatch``.
+
+    Example::
+
+        def test_xxx(patch_user_db_path):
+            with patch_user_db_path('user_a') as ctx:
+                # ctx.db_path is the temp path
+                # ctx.user_id is 'user_a'
+                # any call to get_user_db_path() returns ctx.db_path
+                with sqlite3.connect(ctx.db_path) as conn:
+                    conn.execute("INSERT INTO ...")
+                result = get_connected_platforms(ctx.user_id)
+    """
+    patches = []
+
+    def _patcher(user_id: str):
+        ctx = temp_user_db(user_id)
+        # Pre-allocate the path so the caller can see it inside __enter__.
+        return _PatchedUserDB(ctx, monkeypatch, user_id)
+
+    return _patcher
+
+
+class _PatchedUserDB:
+    def __init__(self, ctx, monkeypatch, user_id: str):
+        self._ctx = ctx
+        self._monkeypatch = monkeypatch
+        self._user_id = user_id
+        self.db_path: str = ""
+        self.user_id: str = user_id
+
+    def __enter__(self):
+        # Create the temp DB first
+        self.db_path = self._ctx.__enter__()
+        _ACTIVE_DB_PATH["path"] = self.db_path
+
+        # Import the modules so monkeypatch has live references to patch
+        from services import database as database_module
+        from services import oauth_token_monitoring_service as otm_mod
+        import services.integrations.wordpress_oauth as wp_mod
+        import services.integrations.wordpress_publisher as wp_pub_mod
+        import services.integrations.bing_oauth as bing_mod
+        import services.integrations.wix_oauth as wix_mod
+        import services.youtube.youtube_oauth_service as yt_mod
+        import services.gsc_service as gsc_mod
+        import services.integrations.wordpress_service as wp_service_mod
+        # _get_db_path was moved to the OAuth provider base class in the
+        # cs4 refactor; the patch must target the base module too.
+        import services.integrations.oauth_provider_base as oauth_base_mod
+
+        modules = [
+            database_module,
+            otm_mod,  # Important: the dispatch module that calls get_user_db_path at module scope
+            wp_mod,
+            wp_pub_mod,  # WordPressPublisher uses get_user_db_path at module scope
+            bing_mod,
+            wix_mod,
+            yt_mod,
+            gsc_mod,
+            wp_service_mod,
+            oauth_base_mod,
+        ]
+        for mod in modules:
+            self._monkeypatch.setattr(
+                mod,
+                "get_user_db_path",
+                lambda _uid, p=self.db_path: p,
+            )
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        result = self._ctx.__exit__(exc_type, exc, tb)
+        # Only clear if the path we set is still current. A nested
+        # scenario would otherwise clobber the outer context.
+        if _ACTIVE_DB_PATH.get("path") == self.db_path:
+            _ACTIVE_DB_PATH["path"] = ""
+        return result
+
+
+_llm_img.enhance_image_prompt = _enhance_image_prompt
+sys.modules["services.llm_providers.main_image_generation"] = _llm_img

--- a/backend/tests/test_linkedin_oauth.py
+++ b/backend/tests/test_linkedin_oauth.py
@@ -1,0 +1,321 @@
+"""
+Tests for services.integrations.linkedin_oauth.LinkedInOAuthService.
+
+The LinkedIn service is special:
+- It inherits from OAuthProviderBase (cs4 P1 refactor).
+- It must fail-fast at construction if LINKEDIN_TOKEN_ENCRYPTION_KEY is
+  missing (cs4 P2 normalization).
+- It stores three encrypted columns (Zernio API key, LinkedIn access
+  token, LinkedIn refresh token) — not the standard 2-column pattern,
+  so the migration method is overridden to handle the extra column.
+
+These tests pin down:
+1. Inherit from OAuthProviderBase
+2. Use resolve_encryption_key("linkedin") for env lookup
+3. Fail-fast (raise ValueError) at construction if the key is missing
+4. Fail-fast (raise ValueError) at construction if the key is invalid
+5. Succeed at construction if LINKEDIN_TOKEN_ENCRYPTION_KEY is set
+6. Succeed at construction if OAUTH_TOKEN_ENCRYPTION_KEY fallback is set
+7. Migration handles the 3-column case (Zernio + access + refresh)
+"""
+
+import os
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_linkedin_service(monkeypatch, key="test-key-from-env"):
+    """Construct a LinkedInOAuthService with the env var set, returning
+    the service and a temp DB context.
+
+    Uses patch_user_db_path fixture's underlying temp DB mechanism by
+    patching get_user_db_path in the linkedin_oauth module.
+    """
+    monkeypatch.setenv("LINKEDIN_TOKEN_ENCRYPTION_KEY", key)
+    monkeypatch.delenv("OAUTH_TOKEN_ENCRYPTION_KEY", raising=False)
+    from services.integrations.linkedin_oauth import LinkedInOAuthService
+    from cryptography.fernet import Fernet
+    # Round-trip the key through Fernet.generate_key + encode so the
+    # constructor accepts it. The key must be a valid Fernet key.
+    valid_key = Fernet.generate_key().decode("utf-8")
+    monkeypatch.setenv("LINKEDIN_TOKEN_ENCRYPTION_KEY", valid_key)
+    return LinkedInOAuthService()
+
+
+class TestLinkedInOAuthServiceInheritance:
+    """LinkedInOAuthService must inherit from OAuthProviderBase so the
+    shared Fernet logic is reused, not re-implemented.
+    """
+
+    def test_inherits_from_oauth_provider_base(self):
+        from services.integrations.linkedin_oauth import LinkedInOAuthService
+        from services.integrations.oauth_provider_base import OAuthProviderBase
+        assert issubclass(LinkedInOAuthService, OAuthProviderBase)
+
+    def test_does_not_re_implement_initialize_fernet(self):
+        """The base class provides _initialize_fernet. If LinkedIn
+        overrides it, that breaks the fail-fast normalization."""
+        from services.integrations.linkedin_oauth import LinkedInOAuthService
+        from services.integrations.oauth_provider_base import OAuthProviderBase
+        assert (
+            LinkedInOAuthService._initialize_fernet
+            is OAuthProviderBase._initialize_fernet
+        )
+
+    def test_does_not_re_implement_encrypt_token(self):
+        from services.integrations.linkedin_oauth import LinkedInOAuthService
+        from services.integrations.oauth_provider_base import OAuthProviderBase
+        assert (
+            LinkedInOAuthService._encrypt_token
+            is OAuthProviderBase._encrypt_token
+        )
+
+    def test_does_not_re_implement_decrypt_token(self):
+        from services.integrations.linkedin_oauth import LinkedInOAuthService
+        from services.integrations.oauth_provider_base import OAuthProviderBase
+        assert (
+            LinkedInOAuthService._decrypt_token
+            is OAuthProviderBase._decrypt_token
+        )
+
+    def test_does_not_re_implement_is_likely_encrypted_blob(self):
+        from services.integrations.linkedin_oauth import LinkedInOAuthService
+        from services.integrations.oauth_provider_base import OAuthProviderBase
+        assert (
+            LinkedInOAuthService._is_likely_encrypted_blob
+            is OAuthProviderBase._is_likely_encrypted_blob
+        )
+
+    def test_does_not_re_implement_get_db_path(self):
+        from services.integrations.linkedin_oauth import LinkedInOAuthService
+        from services.integrations.oauth_provider_base import OAuthProviderBase
+        assert (
+            LinkedInOAuthService._get_db_path
+            is OAuthProviderBase._get_db_path
+        )
+
+    def test_does_override_migrate_plaintext_tokens(self):
+        """LinkedIn's 3-column migration (Zernio + access + refresh) is
+        a deliberate override of the base's 2-column migration."""
+        from services.integrations.linkedin_oauth import LinkedInOAuthService
+        from services.integrations.oauth_provider_base import OAuthProviderBase
+        assert (
+            LinkedInOAuthService._migrate_plaintext_tokens_if_needed
+            is not OAuthProviderBase._migrate_plaintext_tokens_if_needed
+        )
+
+
+class TestLinkedInOAuthServiceFailFast:
+    """The user's mandate: no fallbacks, no mocks, fail-fast.
+
+    LinkedInOAuthService must raise ValueError at construction if
+    LINKEDIN_TOKEN_ENCRYPTION_KEY is missing AND
+    OAUTH_TOKEN_ENCRYPTION_KEY fallback is also missing. Same for an
+    invalid key. Matches the cs4 P2 normalization applied to
+    Bing/Wix/WordPress/YouTube in commit 386f7813.
+    """
+
+    def test_raises_when_no_key_configured(self, monkeypatch):
+        monkeypatch.delenv("LINKEDIN_TOKEN_ENCRYPTION_KEY", raising=False)
+        monkeypatch.delenv("OAUTH_TOKEN_ENCRYPTION_KEY", raising=False)
+        from services.integrations.linkedin_oauth import LinkedInOAuthService
+        with pytest.raises(ValueError) as exc:
+            LinkedInOAuthService()
+        # Error message must name the provider-specific env var so the
+        # operator knows what to set.
+        assert "LINKEDIN_TOKEN_ENCRYPTION_KEY" in str(exc.value)
+
+    def test_raises_when_key_is_invalid(self, monkeypatch):
+        monkeypatch.setenv("LINKEDIN_TOKEN_ENCRYPTION_KEY", "not-a-valid-fernet-key")
+        monkeypatch.delenv("OAUTH_TOKEN_ENCRYPTION_KEY", raising=False)
+        from services.integrations.linkedin_oauth import LinkedInOAuthService
+        with pytest.raises(ValueError) as exc:
+            LinkedInOAuthService()
+        assert "invalid" in str(exc.value).lower()
+
+    def test_succeeds_with_provider_specific_key(self, monkeypatch):
+        from cryptography.fernet import Fernet
+        valid = Fernet.generate_key().decode("utf-8")
+        monkeypatch.setenv("LINKEDIN_TOKEN_ENCRYPTION_KEY", valid)
+        monkeypatch.delenv("OAUTH_TOKEN_ENCRYPTION_KEY", raising=False)
+        from services.integrations.linkedin_oauth import LinkedInOAuthService
+        svc = LinkedInOAuthService()
+        assert svc._fernet is not None
+
+    def test_succeeds_with_shared_oauth_key_fallback(self, monkeypatch):
+        from cryptography.fernet import Fernet
+        valid = Fernet.generate_key().decode("utf-8")
+        monkeypatch.delenv("LINKEDIN_TOKEN_ENCRYPTION_KEY", raising=False)
+        monkeypatch.setenv("OAUTH_TOKEN_ENCRYPTION_KEY", valid)
+        from services.integrations.linkedin_oauth import LinkedInOAuthService
+        svc = LinkedInOAuthService()
+        assert svc._fernet is not None
+
+
+class TestLinkedInOAuthServiceMigration:
+    """The 3-column migration must encrypt Zernio API key + LinkedIn
+    access/refresh tokens in a single pass.
+    """
+
+    def test_migration_handles_three_columns(self, patch_user_db_path, monkeypatch):
+        """Plaintext rows for all 3 columns get re-encrypted in one pass."""
+        from cryptography.fernet import Fernet
+        valid = Fernet.generate_key().decode("utf-8")
+        monkeypatch.setenv("LINKEDIN_TOKEN_ENCRYPTION_KEY", valid)
+        monkeypatch.delenv("OAUTH_TOKEN_ENCRYPTION_KEY", raising=False)
+
+        from services.integrations.linkedin_oauth import LinkedInOAuthService
+
+        with patch_user_db_path("user_linkedin_migration") as ctx:
+            with sqlite3.connect(ctx.db_path) as conn:
+                conn.execute(
+                    """
+                    INSERT INTO linkedin_oauth_tokens (
+                        user_id, provider_mode,
+                        zernio_api_key, linkedin_access_token, linkedin_refresh_token
+                    ) VALUES (?, 'zernio', ?, ?, ?)
+                    """,
+                    (ctx.user_id, "zernio-plaintext", "access-plaintext", "refresh-plaintext"),
+                )
+                conn.commit()
+
+            svc = LinkedInOAuthService()
+            # Initialise the DB (idempotent for the per-user migration)
+            svc._init_db(ctx.user_id)
+            with sqlite3.connect(ctx.db_path) as conn:
+                svc._migrate_plaintext_tokens_if_needed(conn, ctx.user_id)
+                conn.commit()
+                row = conn.execute(
+                    """
+                    SELECT zernio_api_key, linkedin_access_token, linkedin_refresh_token
+                    FROM linkedin_oauth_tokens WHERE user_id = ?
+                    """,
+                    (ctx.user_id,),
+                ).fetchone()
+
+        zernio, access, refresh = row
+        # All three should now be Fernet-encrypted blobs (start with gAAAAA).
+        assert zernio.startswith("gAAAAA"), f"zernio not encrypted: {zernio[:20]}"
+        assert access.startswith("gAAAAA"), f"access not encrypted: {access[:20]}"
+        assert refresh.startswith("gAAAAA"), f"refresh not encrypted: {refresh[:20]}"
+
+    def test_migration_skips_already_encrypted_rows(self, patch_user_db_path, monkeypatch):
+        """Rows that are already encrypted are not re-encrypted (idempotent)."""
+        from cryptography.fernet import Fernet
+        valid = Fernet.generate_key().decode("utf-8")
+        monkeypatch.setenv("LINKEDIN_TOKEN_ENCRYPTION_KEY", valid)
+        monkeypatch.delenv("OAUTH_TOKEN_ENCRYPTION_KEY", raising=False)
+
+        from services.integrations.linkedin_oauth import LinkedInOAuthService
+
+        # Pre-encrypt the tokens with the same key the service will use.
+        fernet = Fernet(valid.encode("utf-8"))
+        encrypted_zernio = fernet.encrypt(b"already-encrypted").decode("utf-8")
+        encrypted_access = fernet.encrypt(b"already-encrypted").decode("utf-8")
+        encrypted_refresh = fernet.encrypt(b"already-encrypted").decode("utf-8")
+
+        with patch_user_db_path("user_linkedin_idempotent") as ctx:
+            with sqlite3.connect(ctx.db_path) as conn:
+                conn.execute(
+                    """
+                    INSERT INTO linkedin_oauth_tokens (
+                        user_id, provider_mode,
+                        zernio_api_key, linkedin_access_token, linkedin_refresh_token
+                    ) VALUES (?, 'zernio', ?, ?, ?)
+                    """,
+                    (ctx.user_id, encrypted_zernio, encrypted_access, encrypted_refresh),
+                )
+                conn.commit()
+
+            svc = LinkedInOAuthService()
+            svc._init_db(ctx.user_id)
+            with sqlite3.connect(ctx.db_path) as conn:
+                svc._migrate_plaintext_tokens_if_needed(conn, ctx.user_id)
+                row = conn.execute(
+                    """
+                    SELECT zernio_api_key, linkedin_access_token, linkedin_refresh_token
+                    FROM linkedin_oauth_tokens WHERE user_id = ?
+                    """,
+                    (ctx.user_id,),
+                ).fetchone()
+
+        # Values must be unchanged (still decryptable to the same plaintext).
+        zernio, access, refresh = row
+        assert fernet.decrypt(zernio.encode("utf-8")) == b"already-encrypted"
+        assert fernet.decrypt(access.encode("utf-8")) == b"already-encrypted"
+        assert fernet.decrypt(refresh.encode("utf-8")) == b"already-encrypted"
+
+    def test_migration_runs_only_once_per_user(self, patch_user_db_path, monkeypatch):
+        """The per-user-per-process gate prevents repeated migration work."""
+        from cryptography.fernet import Fernet
+        valid = Fernet.generate_key().decode("utf-8")
+        monkeypatch.setenv("LINKEDIN_TOKEN_ENCRYPTION_KEY", valid)
+        monkeypatch.delenv("OAUTH_TOKEN_ENCRYPTION_KEY", raising=False)
+
+        from services.integrations.linkedin_oauth import LinkedInOAuthService
+
+        with patch_user_db_path("user_linkedin_once") as ctx:
+            with sqlite3.connect(ctx.db_path) as conn:
+                conn.execute(
+                    """
+                    INSERT INTO linkedin_oauth_tokens (
+                        user_id, provider_mode, linkedin_access_token
+                    ) VALUES (?, 'native', ?)
+                    """,
+                    (ctx.user_id, "plaintext-token"),
+                )
+                conn.commit()
+
+            svc = LinkedInOAuthService()
+            svc._init_db(ctx.user_id)
+            with sqlite3.connect(ctx.db_path) as conn:
+                # First pass: encrypts the token
+                svc._migrate_plaintext_tokens_if_needed(conn, ctx.user_id)
+                first_row = conn.execute(
+                    "SELECT linkedin_access_token FROM linkedin_oauth_tokens WHERE user_id = ?",
+                    (ctx.user_id,),
+                ).fetchone()
+                # Second pass: should be a no-op (the gate is set)
+                svc._migrate_plaintext_tokens_if_needed(conn, ctx.user_id)
+                second_row = conn.execute(
+                    "SELECT linkedin_access_token FROM linkedin_oauth_tokens WHERE user_id = ?",
+                    (ctx.user_id,),
+                ).fetchone()
+
+        # Both reads should be the same encrypted value (no double-encryption).
+        assert first_row[0] == second_row[0]
+        assert first_row[0].startswith("gAAAAA")
+
+
+class TestLinkedInOAuthServiceKeyResolution:
+    """The service must use resolve_encryption_key("linkedin"), not a
+    hand-rolled os.getenv chain. This makes it consistent with the
+    other 4 providers.
+    """
+
+    def test_resolve_encryption_key_linkedin_added(self):
+        """The PROVIDER_ENV_VARS registry must include 'linkedin' so
+        resolve_encryption_key works for it."""
+        from services.integrations.oauth_provider_base import (
+            PROVIDER_ENV_VARS,
+            resolve_encryption_key,
+        )
+        assert "linkedin" in PROVIDER_ENV_VARS
+        assert PROVIDER_ENV_VARS["linkedin"] == "LINKEDIN_TOKEN_ENCRYPTION_KEY"
+        # And resolve_encryption_key returns the expected value.
+        with patch.dict(
+            os.environ,
+            {"LINKEDIN_TOKEN_ENCRYPTION_KEY": "test-key"},
+            clear=False,
+        ):
+            assert resolve_encryption_key("linkedin") == "test-key"
+        # Falls back to the shared key.
+        with patch.dict(
+            os.environ,
+            {"OAUTH_TOKEN_ENCRYPTION_KEY": "shared-key"},
+            clear=False,
+        ):
+            os.environ.pop("LINKEDIN_TOKEN_ENCRYPTION_KEY", None)
+            assert resolve_encryption_key("linkedin") == "shared-key"

--- a/backend/tests/test_oauth_token_monitoring_service.py
+++ b/backend/tests/test_oauth_token_monitoring_service.py
@@ -1,0 +1,299 @@
+"""
+Tests for services.oauth_token_monitoring_service.get_connected_platforms.
+
+The function is the dispatch loop that decides which platforms a user has
+connected tokens for. It is called by:
+- The OAuth status route (api.oauth_token_monitoring_routes.get_oauth_token_status)
+- The task creation route
+- Indirectly by the readiness panel in Step 5 of onboarding
+
+These tests pin down:
+- Return shape and ordering
+- Per-platform "considered connected" rules
+- Resilience: one platform's failure must not poison the rest
+- YouTube is integrated via the real YouTubeOAuthService (was an inline
+  sqlite3 block in the legacy version)
+"""
+
+import os
+import sqlite3
+import sys
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+# The ``patch_user_db_path`` fixture is provided by conftest.py at the
+# tests/ root.
+
+
+# The WordPress / Bing / Wix services all encrypt access_token at rest
+# using Fernet. For test purposes we need to encrypt a known plaintext
+# token with the same key the services use. The encryption key is read
+# from environment variables (set in .env).
+def _encrypt_for_storage(plaintext: str) -> str:
+    """Encrypt a token the same way the OAuth services do.
+
+    If the Fernet key is missing for any reason, fall back to writing
+    plaintext so the test data is at least discoverable. The services
+    will treat the plaintext as 'not encrypted' and use it as-is.
+    """
+    try:
+        from cryptography.fernet import Fernet
+        key = os.environ.get("OAUTH_TOKEN_ENCRYPTION_KEY")
+        if not key:
+            return plaintext
+        return Fernet(key.encode("utf-8")).encrypt(plaintext.encode("utf-8")).decode("utf-8")
+    except Exception:
+        return plaintext
+
+
+class TestGetConnectedPlatforms:
+    """End-to-end tests for get_connected_platforms."""
+
+    def test_empty_user_returns_empty_list(self, patch_user_db_path):
+        with patch_user_db_path("user_empty") as ctx:
+            from services.oauth_token_monitoring_service import get_connected_platforms
+            result = get_connected_platforms(ctx.user_id)
+        assert result == []
+
+    def test_full_list_preserves_canonical_order(self, patch_user_db_path):
+        """When all 6 platforms are connected, the result must match the
+        canonical order: gsc, bing, wordpress, wix, youtube, linkedin.
+        Callers may rely on this order (e.g. for the readiness panel)."""
+        with patch_user_db_path("user_full") as ctx:
+            with sqlite3.connect(ctx.db_path) as conn:
+                far_future = (datetime.utcnow() + timedelta(days=30)).isoformat()
+                conn.execute(
+                    "INSERT INTO bing_oauth_tokens (user_id, access_token, refresh_token, expires_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (ctx.user_id, _encrypt_for_storage("at"), _encrypt_for_storage("rt"), far_future),
+                )
+                conn.execute(
+                    "INSERT INTO wordpress_oauth_tokens (user_id, access_token, blog_url) "
+                    "VALUES (?, ?, ?)",
+                    (ctx.user_id, _encrypt_for_storage("at"), "https://blog.example.com"),
+                )
+                conn.execute(
+                    "INSERT INTO wix_oauth_tokens (user_id, access_token, refresh_token, expires_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (ctx.user_id, _encrypt_for_storage("at"), _encrypt_for_storage("rt"), far_future),
+                )
+                conn.execute(
+                    "INSERT INTO youtube_oauth_tokens (user_id, channel_name, is_active) "
+                    "VALUES (?, ?, 1)",
+                    (ctx.user_id, "MyChannel"),
+                )
+                conn.execute(
+                    "INSERT INTO linkedin_oauth_tokens (user_id, provider_mode, linkedin_access_token, linkedin_refresh_token, expires_at, is_active) "
+                    "VALUES (?, 'native', ?, ?, ?, 1)",
+                    (ctx.user_id, _encrypt_for_storage("at"), _encrypt_for_storage("rt"), far_future),
+                )
+                conn.commit()
+
+            # GSC is special: it doesn't use the user DB; it stores
+            # credentials in gsc_credentials.json. Mock GSCService to
+            # return truthy so the dispatch finds it.
+            with patch(
+                "services.oauth_token_monitoring_service.GSCService"
+            ) as GSC:
+                GSC.return_value.load_user_credentials.return_value = object()
+                from services.oauth_token_monitoring_service import get_connected_platforms
+                result = get_connected_platforms(ctx.user_id)
+
+        assert result == ["gsc", "bing", "wordpress", "wix", "youtube", "linkedin"]
+
+    def test_mixed_returns_only_connected_in_canonical_order(self, patch_user_db_path):
+        with patch_user_db_path("user_mixed") as ctx:
+            with sqlite3.connect(ctx.db_path) as conn:
+                # Only Bing and YouTube are "on" here.
+                far_future = (datetime.utcnow() + timedelta(days=30)).isoformat()
+                conn.execute(
+                    "INSERT INTO bing_oauth_tokens (user_id, access_token, expires_at) "
+                    "VALUES (?, ?, ?)",
+                    (ctx.user_id, _encrypt_for_storage("at"), far_future),
+                )
+                conn.execute(
+                    "INSERT INTO youtube_oauth_tokens (user_id, channel_name, is_active) "
+                    "VALUES (?, ?, 1)",
+                    (ctx.user_id, "Ch"),
+                )
+                conn.commit()
+
+            with patch(
+                "services.oauth_token_monitoring_service.GSCService"
+            ) as GSC:
+                GSC.return_value.load_user_credentials.return_value = None
+                from services.oauth_token_monitoring_service import get_connected_platforms
+                result = get_connected_platforms(ctx.user_id)
+
+        assert result == ["bing", "youtube"]
+
+    def test_one_platform_raising_does_not_poison_others(self, patch_user_db_path):
+        """If GSC raises, the others must still be detected."""
+        with patch_user_db_path("user_gsc_fail") as ctx:
+            with sqlite3.connect(ctx.db_path) as conn:
+                far_future = (datetime.utcnow() + timedelta(days=30)).isoformat()
+                conn.execute(
+                    "INSERT INTO bing_oauth_tokens (user_id, access_token, expires_at) "
+                    "VALUES (?, ?, ?)",
+                    (ctx.user_id, _encrypt_for_storage("at"), far_future),
+                )
+                conn.commit()
+
+            with patch(
+                "services.oauth_token_monitoring_service.GSCService"
+            ) as GSC:
+                GSC.return_value.load_user_credentials.side_effect = RuntimeError(
+                    "GSC DB corrupt"
+                )
+                from services.oauth_token_monitoring_service import get_connected_platforms
+                result = get_connected_platforms(ctx.user_id)
+
+        assert "gsc" not in result
+        assert "bing" in result
+
+    def test_youtube_constructor_failure_is_handled(self, patch_user_db_path):
+        """If YouTubeOAuthService() raises (e.g. missing env key), the
+        dispatch must not propagate the exception."""
+        with patch_user_db_path("user_yt_fail") as ctx:
+            with patch(
+                "services.youtube.youtube_oauth_service.YouTubeOAuthService"
+            ) as YT:
+                YT.side_effect = ValueError(
+                    "YOUTUBE_TOKEN_ENCRYPTION_KEY not set"
+                )
+                from services.oauth_token_monitoring_service import get_connected_platforms
+                result = get_connected_platforms(ctx.user_id)
+
+        assert "youtube" not in result
+        assert result == []
+
+    def test_bing_expired_with_refresh_counted_as_connected(self, patch_user_db_path):
+        """Bing tokens that are expired but have a refresh_token are still
+        considered connected (they can be auto-refreshed)."""
+        with patch_user_db_path("user_bing_exp") as ctx:
+            with sqlite3.connect(ctx.db_path) as conn:
+                expired = (datetime.utcnow() - timedelta(hours=1)).isoformat()
+                conn.execute(
+                    "INSERT INTO bing_oauth_tokens (user_id, access_token, refresh_token, expires_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (
+                        ctx.user_id,
+                        _encrypt_for_storage("at"),
+                        _encrypt_for_storage("rt"),
+                        expired,
+                    ),
+                )
+                conn.commit()
+
+            from services.oauth_token_monitoring_service import get_connected_platforms
+            result = get_connected_platforms(ctx.user_id)
+
+        assert "bing" in result
+
+    def test_wix_expired_with_refresh_counted_as_connected(self, patch_user_db_path):
+        with patch_user_db_path("user_wix_exp") as ctx:
+            with sqlite3.connect(ctx.db_path) as conn:
+                expired = (datetime.utcnow() - timedelta(hours=1)).isoformat()
+                conn.execute(
+                    "INSERT INTO wix_oauth_tokens (user_id, access_token, refresh_token, expires_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (
+                        ctx.user_id,
+                        _encrypt_for_storage("at"),
+                        _encrypt_for_storage("rt"),
+                        expired,
+                    ),
+                )
+                conn.commit()
+
+            from services.oauth_token_monitoring_service import get_connected_platforms
+            result = get_connected_platforms(ctx.user_id)
+
+        assert "wix" in result
+
+    def test_wordpress_any_token_counts_as_connected(self, patch_user_db_path):
+        """WordPress tokens cannot be auto-refreshed (they expire in 2 weeks
+        and require re-authorization). The original code treats any stored
+        token row as 'connected' so the user can still see they're set up."""
+        with patch_user_db_path("user_wp") as ctx:
+            with sqlite3.connect(ctx.db_path) as conn:
+                # Even an expired WP token should count as connected.
+                expired = (datetime.utcnow() - timedelta(days=30)).isoformat()
+                conn.execute(
+                    "INSERT INTO wordpress_oauth_tokens (user_id, access_token, blog_url, expires_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (ctx.user_id, _encrypt_for_storage("at"), "https://blog.example.com", expired),
+                )
+                conn.commit()
+
+            from services.oauth_token_monitoring_service import get_connected_platforms
+            result = get_connected_platforms(ctx.user_id)
+
+        assert "wordpress" in result
+
+
+class TestSafeCheckHelper:
+    """Unit tests for the _safe_check wrapper."""
+
+    def test_exploding_checker_returns_false(self):
+        from services.oauth_token_monitoring_service import _safe_check
+
+        def boom(_uid):
+            raise RuntimeError("kaboom")
+
+        assert _safe_check("test_platform", boom, "u1") is False
+
+    def test_true_checker_returns_true(self):
+        from services.oauth_token_monitoring_service import _safe_check
+
+        assert _safe_check("test_platform", lambda _u: True, "u1") is True
+
+    def test_false_checker_returns_false(self):
+        from services.oauth_token_monitoring_service import _safe_check
+
+        assert _safe_check("test_platform", lambda _u: False, "u1") is False
+
+    def test_non_bool_truthy_return_normalised_to_true(self):
+        """A checker that returns a non-empty string should count as True."""
+        from services.oauth_token_monitoring_service import _safe_check
+
+        assert _safe_check("test_platform", lambda _u: "truthy", "u1") is True
+
+
+class TestPlatformChecksRegistry:
+    """The dispatch list must contain all 5 platforms in the documented order."""
+
+    def test_registry_order_is_canonical(self):
+        from services.oauth_token_monitoring_service import _PLATFORM_CHECKS
+
+        ids = [p for p, _ in _PLATFORM_CHECKS]
+        assert ids == ["gsc", "bing", "wordpress", "wix", "youtube", "linkedin"]
+
+    def test_registry_callables_are_independent(self):
+        """Each checker is an independent callable."""
+        from services.oauth_token_monitoring_service import _PLATFORM_CHECKS
+
+        call_counts = {}
+
+        def make_spy(name):
+            def spy(uid):
+                call_counts.setdefault(name, []).append(uid)
+                return False
+
+            return spy
+
+        spies = [(p, make_spy(p)) for p, _ in _PLATFORM_CHECKS]
+        for platform_id, checker in spies:
+            checker("user_xyz")
+        assert set(call_counts.keys()) == {
+            "gsc",
+            "bing",
+            "wordpress",
+            "wix",
+            "youtube",
+            "linkedin",
+        }
+        for calls in call_counts.values():
+            assert calls == ["user_xyz"]

--- a/docs/cs4-oauth-base-class.md
+++ b/docs/cs4-oauth-base-class.md
@@ -1,0 +1,137 @@
+# OAuth Common Framework — Phase 4 Plan
+
+## Context
+
+The user remembered a "common OAuth framework" that was supposedly merged to
+main. **It was not.** Two attempts exist:
+
+- `c66f2c1d "Add Common OAuth Framework"` (on `common-oauth-framework`
+  branch only, never merged) — 3 frontend files, 848 lines, **does not
+  actually replace anything** despite the commit message claim. Branch is
+  3 months stale, 1,198 files diverged from main, a straight merge is
+  catastrophic.
+- `e4142c7f "OAuth framework production-ready"` (on main) — a 41-file
+  bundle that ships **partial** OAuth framework: `WordPressOAuthContentManager`
+  bearer mirror, `_check_wix_token` 1d/24h/3-attempt logic,
+  `_PLATFORM_CHECKS` dispatch in `get_connected_platforms`, 56 OAuth tests
+  passing, and the `oauth_callback_utils.py` shared callback HTML
+  generator. But the per-provider **token storage** is not common — 4
+  services each implement their own.
+
+## State of the 4 OAuth services on local main
+
+| Service | LOC | Fernet | `_is_likely_encrypted_blob` | `_migrate_plaintext_tokens_if_needed` | `_initialize_fernet` failure mode |
+|---|---|---|---|---|---|
+| `WixOAuthService` | 505 | ✅ | ✅ | ✅ | warn + return None |
+| `WordPressOAuthService` | 506 | ✅ | ✅ | ✅ | warn + return None |
+| `BingOAuthService` | 971 | **❌ plaintext** | **❌** | **❌** | n/a |
+| `YouTubeOAuthService` | 493 | ✅ | ✅ | ✅ | **raise on missing** (different) |
+
+`_initialize_fernet`, `_encrypt_token`, `_decrypt_token`, `_is_likely_encrypted_blob`,
+`_migrate_plaintext_tokens_if_needed` are **word-for-word the same** in Wix and
+WordPress, and nearly identical in YouTube. Bing lacks all of them.
+
+## Plan: 3 small commits on local main only
+
+Per the user's directive ("work on local main only, not multiple branches"),
+no new branches. Per the audit, all work lands on main directly.
+
+### Step 1 — Bing token encryption (P0, security)
+
+**File**: `backend/services/integrations/bing_oauth.py`
+
+**What**:
+- Add `_initialize_fernet`, `_encrypt_token`, `_decrypt_token`,
+  `_is_likely_encrypted_blob`, `_migrate_plaintext_tokens_if_needed`
+  matching the Wix/WordPress pattern
+- New env var: `BING_TOKEN_ENCRYPTION_KEY` (falls back to
+  `OAUTH_TOKEN_ENCRYPTION_KEY`)
+- Modify `store_tokens` and `update_tokens` to encrypt access/refresh
+  before insert
+- Modify `get_user_tokens` and `get_user_token_status` to decrypt
+  on read, with the same try/except + skip-on-InvalidToken behavior Wix uses
+- Add the `_migrate_plaintext_tokens_if_needed` call to the read paths
+
+**Net**: +60 lines, fixes real security gap.
+
+**Test**: existing Bing tests must still pass; add 1 round-trip
+encryption test.
+
+**Risk**: low — only changes internal token storage format, not the
+public API.
+
+### Step 2 — Extract `OAuthProviderBase` (P1, dedup)
+
+**New file**: `backend/services/integrations/oauth_provider_base.py` (~120 lines)
+
+**What**:
+- Pull `_initialize_fernet`, `_encrypt_token`, `_decrypt_token`,
+  `_is_likely_encrypted_blob`, `_migrate_plaintext_tokens_if_needed`,
+  `_get_db_path` into a single base class
+- `WixOAuthService`, `WordPressOAuthService`, `YouTubeOAuthService`,
+  `BingOAuthService` all inherit from it
+- Each provider keeps its own `__init__` (provider-specific client
+  config), `_init_db` (provider-specific schema), and
+  `generate_authorization_url` / `handle_oauth_callback` (provider-specific
+  OAuth flow)
+- Resolve the Fernet failure-mode inconsistency: base class returns
+  `Optional[Fernet]` (matches Wix/WordPress; YouTube currently raises).
+  This is also addressed in step 3.
+
+**Net**: -150 lines (3 services × ~50 lines duplicate removed, +120
+lines base class added).
+
+**Test**: 56 existing OAuth tests must still pass (mocking pattern
+preserved). Add 1 base-class unit test.
+
+**Risk**: low — mechanical refactor, no behavior change.
+
+### Step 3 — Normalize YouTube's `_initialize_fernet` to return None (P2, consistency)
+
+**File**: `backend/services/youtube/youtube_oauth_service.py`
+
+**What**: change `_initialize_fernet` to return `Optional[Fernet]` and
+log a warning instead of raising on missing key. Token ops then fail with
+a clearer error than "Fernet is None" deep in the call stack.
+
+**Alternative**: invert the base class to require Fernet at
+construction (constructor raises). The user's "we can't tolerate
+fallbacks" mandate suggests this. **Decision pending sign-off** — both
+options are valid. If inverted, this commit becomes a one-line change
+to the base class constructor (not YouTube-specific).
+
+## Out of scope
+
+- **Merging `c66f2c1d`**: dead scaffolding, 3 months stale, would
+  require 1,198-file merge with massive conflicts. Skip.
+- **Per-CRUD-method template-method refactor** (`store_tokens` /
+  `get_user_tokens` / `update_tokens` / `get_user_token_status` /
+  `revoke_token` / `get_connection_status`): 3 of 4 services duplicate
+  ~50 lines each, but the SQL differs per provider. Would save another
+  ~150 lines but the template-method risk is higher (~3 days work). Defer
+  to a separate phase.
+- **Frontend unification**: per-platform `wordpressOAuth.ts` /
+  `bingOAuth.ts` could become a single `oauthClient.ts`. The c66f2c1d
+  scaffolding was an attempt at this but was 3 months stale. Defer to
+  a separate phase.
+- **Deleting the `common-oauth-framework` branch**: branch still exists
+  locally. After the 3 commits ship and pass review, deleting it is
+  safe. Not part of this plan.
+
+## Verification
+
+After each step:
+- All 56 existing OAuth tests pass
+- New tests for the step's behavior pass
+- No regression in `routes/strategies.py` / `routes/wix_routes.py` /
+  `routes/wordpress_oauth.py` / `routes/bing_oauth.py` etc.
+- Manual smoke test: connect + disconnect one OAuth flow per
+  provider (Wix, WordPress, Bing, YouTube) and confirm tokens are
+  encrypted at rest in the SQLite DB
+
+## Estimated effort
+
+- Step 1: 30-60 min
+- Step 2: 2-3 hours
+- Step 3: 30 min
+- Total: ~3-4 hours, 3 commits on local main


### PR DESCRIPTION
## Goal

Two-part change:

**Part 1: OAuthProviderBase framework (already merged to local main, not yet on origin)**

Commits `e383d08c` (P0), `1ca38b01` (P1), `386f7813` (P2) ship the shared `OAuthProviderBase` class with 5 reusable methods (`_initialize_fernet`, `_encrypt_token`, `_decrypt_token`, `_is_likely_encrypted_blob`, `_migrate_plaintext_tokens_if_needed`, `_get_db_path`) and the `resolve_encryption_key` helper. The 4 existing providers (Bing, Wix, WordPress, YouTube) all inherit the base. P2 normalized Fernet init to fail-fast at construction (no more fail-soft "log and return None").

**Part 2: LinkedInOAuthService follows the framework**

After PR #738 (Unipile LinkedIn Growth Engine) merged, the new `LinkedInOAuthService` had its own copies of the Fernet init / encrypt / decrypt / migration logic, with three divergences from the framework best practices:

1. `_initialize_fernet` returned `Optional[Fernet]` and logged a warning on missing key (fail-soft) — P2 normalized all 4 other providers to fail-fast.
2. `_decrypt_token` swallowed `InvalidToken` and returned None — base class propagates.
3. All 5 base-class methods were re-implemented inline instead of inherited.

This PR:
- Makes `LinkedInOAuthService` inherit from `OAuthProviderBase`, removing the 5 inline re-implementations.
- Switches env-var lookup to `resolve_encryption_key("linkedin")`. Adds `linkedin` to `PROVIDER_ENV_VARS` in the base module.
- Generalizes the base `_initialize_fernet` error message to enumerate all 5 provider env vars (was hard-coded to 4).
- Keeps `_migrate_plaintext_tokens_if_needed` as a deliberate 3-column override (Zernio API key + LinkedIn access/refresh). The base class's 2-column migration doesn't fit LinkedIn's schema.
- Wires LinkedIn into the OAuth token monitoring dispatcher (`_PLATFORM_CHECKS` in `oauth_token_monitoring_service.py`). Lazy import + try/except (YouTube pattern) keeps the dispatcher safe to call when the encryption key isn't configured.
- Fixes a pre-existing unpacking bug in `_token_row_metadata` (expected 15 columns, schema has 17 with the Unipile additions) — surfaced by the new test.
- Adds `linkedin_oauth_tokens` schema to `conftest.py` so tests can seed data.
- New `backend/tests/test_linkedin_oauth.py` (15 tests) pinning down inheritance, fail-fast behavior, env-var resolution, and 3-column migration (idempotency + per-user gate).
- Updates `test_oauth_token_monitoring_service.py` assertions for the 6-platform canonical order.

## Test status

All 53 OAuth-related tests pass:
- `test_linkedin_oauth.py` (new): 15/15
- `test_oauth_token_monitoring_service.py`: 14/14
- `test_wordpress_oauth_content.py`: 24/24

Run with: `OAUTH_TOKEN_ENCRYPTION_KEY=<key> pytest backend/tests/test_linkedin_oauth.py backend/tests/test_oauth_token_monitoring_service.py backend/tests/test_wordpress_oauth_content.py`

## Out of scope

- Adding a `_check_linkedin_token` to `OAuthTokenMonitoringExecutor` (the executor refreshes tokens; the dispatcher just detects connection state). The LinkedIn check is now in the dispatcher's `_PLATFORM_CHECKS`. A refresh-and-retry executor entry is a follow-up if/when LinkedIn OAuth tokens start expiring in production.

## Depends on

- Part 1 (cs4 OAuth framework commits) must be merged first or together with Part 2.
