### PR TITLE
fix(onboarding): six runtime crashes blocking step 3 / 4 / 5

### DIFF
--- a/backend/services/intelligence/txtai_service.py
+++ b/backend/services/intelligence/txtai_service.py
@@ -286,6 +286,30 @@ class TxtaiIntelligenceService:
         message = str(error)
         return "nprobe" in message and "IndexIDMap" in message
 
+    # Phase 5 / Issue #8: explicit guard for missing txtai. The
+    # previous inline check on ``TXTAI_AVAILABLE`` was buried in
+    # ``_initialize_embeddings`` and a misconfigured deployment
+    # would silently fall back to no-op rather than fail fast, which
+    # is what the user explicitly asked for in the content-strategy
+    # P0 work. Promote the check to a method so every public
+    # operation (``index_content`` / ``delete_content`` /
+    # ``reindex_all``) starts with the same explicit guard and the
+    # call site doesn't have to import ``TXTAI_AVAILABLE`` directly.
+    def _require_txtai_available(self) -> None:
+        if not TXTAI_AVAILABLE:
+            message = (
+                "txtai is not available. Please install with: "
+                "pip install txtai[pipeline,similarity]"
+            )
+            logger.error(message)
+            if self.fail_fast:
+                raise RuntimeError(message)
+            # The historical fail-soft path: return None (no exception)
+            # and let the caller fall through to the "not initialized"
+            # branch. The fail-fast branch above is the new default.
+            return
+        return
+
     def _mark_ann_incompatible(self):
         """Disable ANN-dependent code paths after FAISS nprobe incompatibility is observed."""
         if not self._disable_ann_queries:

--- a/backend/services/persona/facebook/facebook_persona_scheduler.py
+++ b/backend/services/persona/facebook/facebook_persona_scheduler.py
@@ -70,8 +70,9 @@ async def generate_facebook_persona_task(user_id: str):
         facebook_service = FacebookPersonaService()
         try:
             generated_persona = facebook_service.generate_facebook_persona(
-                core_persona, 
-                onboarding_data
+                core_persona,
+                onboarding_data,
+                user_id=user_id,
             )
             execution_time = (datetime.utcnow() - start_time).total_seconds()
             

--- a/backend/services/persona/facebook/facebook_persona_service.py
+++ b/backend/services/persona/facebook/facebook_persona_service.py
@@ -40,14 +40,24 @@ class FacebookPersonaService:
             logger.debug("FacebookPersonaService initialized")
             self._initialized = True
     
-    def generate_facebook_persona(self, core_persona: Dict[str, Any], onboarding_data: Dict[str, Any]) -> Dict[str, Any]:
+    def generate_facebook_persona(
+        self,
+        core_persona: Dict[str, Any],
+        onboarding_data: Dict[str, Any],
+        user_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """
         Generate Facebook-specific persona adaptation using optimized chained prompts.
-        
+
         Args:
             core_persona: The core persona data
             onboarding_data: User onboarding data
-            
+            user_id: Optional explicit Clerk user ID. Used for subscription
+                checks / usage tracking. Falls back to looking up
+                ``onboarding_data["session_info"]["user_id"]`` so
+                direct callers (which embed the user_id in the
+                onboarding dict) still work.
+
         Returns:
             Facebook-optimized persona data
         """
@@ -62,9 +72,14 @@ class FacebookPersonaService:
 
             # Get Facebook-specific schema
             schema = self._get_enhanced_facebook_schema()
-            
-            # Extract user_id for tracking
-            user_id = onboarding_data.get("session_info", {}).get("user_id")
+
+            # Resolve user_id for the LLM gateway's subscription check.
+            # Prefer the explicit kwarg (the scheduler passes it that
+            # way), fall back to the legacy nested key.
+            if not user_id and isinstance(onboarding_data, dict):
+                session_info = onboarding_data.get("session_info")
+                if isinstance(session_info, dict):
+                    user_id = session_info.get("user_id")
 
             # Generate structured response using the provider-agnostic gateway
             # (handles GPT_PROVIDER routing, subscription/usage checks, fallbacks)

--- a/backend/services/research/research_persona_prompt_builder.py
+++ b/backend/services/research/research_persona_prompt_builder.py
@@ -5,7 +5,7 @@ Handles building comprehensive prompts for research persona generation.
 Generates personalized research defaults, suggestions, and configurations.
 """
 
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 import json
 from loguru import logger
 
@@ -225,32 +225,32 @@ Generate a comprehensive research persona in JSON format with the following stru
      * Match the enhancement style to the user's writing guidelines and preferences
 
 6. RECOMMENDED PRESETS:
-   - "recommended_presets": **PHASE 3 ENHANCEMENT** - Generate 3-5 personalized research preset templates using comprehensive analysis:
-     * **USE CONTENT THEMES**: If content_themes available, create at least one preset per major theme (up to 3 themes)
-       - Example: If themes include ["AI automation", "content marketing", "SEO strategies"], create presets for each
-       - Use theme names in preset keywords: "Research latest {theme} trends and best practices"
-     * **USE CRAWL ANALYSIS**: Leverage crawl_analysis.content_categories and crawl_analysis.main_topics for preset generation
-       - Create presets that match the user's actual website content categories
-       - Use main_topics for preset keywords and descriptions
-     * **CONTENT TYPE BASED**: Generate presets based on content_type (from Phase 1):
-     * **Content-Type-Specific Presets**: Use content_type.primary_type and content_type.secondary_types to create presets:
-       - If primary_type == "blog": Create "Blog Topic Research" preset with trending topics
-       - If primary_type == "article": Create "Article Research" preset with in-depth analysis
-       - If primary_type == "case_study": Create "Case Study Research" preset with real-world examples
-       - If primary_type == "tutorial": Create "Tutorial Research" preset with step-by-step guides
-       - If "tutorial" in secondary_types: Add "How-To Guide Research" preset
-       - If "comparison" in secondary_types or style_patterns: Add "Comparison Research" preset
-       - If content_type.purpose == "thought_leadership": Create "Thought Leadership Research" with expert insights
-       - If content_type.purpose == "education": Create "Educational Content Research" preset
-     * **Use Extracted Topics**: If extracted_topics available, create at least one preset using actual website topics:
-       - "Latest {extracted_topic} Trends" preset
-       - "{extracted_topic} Best Practices" preset
+    - "recommended_presets": **PHASE 3 ENHANCEMENT** - Generate 3-5 personalized research preset templates using comprehensive analysis:
+      * **USE CONTENT THEMES**: If content_themes available, create at least one preset per major theme (up to 3 themes)
+        - Example: If themes include ["AI automation", "content marketing", "SEO strategies"], create presets for each
+        - Use theme names in preset keywords: "Research latest {{theme}} trends and best practices"
+      * **USE CRAWL ANALYSIS**: Leverage crawl_analysis.content_categories and crawl_analysis.main_topics for preset generation
+        - Create presets that match the user's actual website content categories
+        - Use main_topics for preset keywords and descriptions
+      * **CONTENT TYPE BASED**: Generate presets based on content_type (from Phase 1):
+      * **Content-Type-Specific Presets**: Use content_type.primary_type and content_type.secondary_types to create presets:
+        - If primary_type == "blog": Create "Blog Topic Research" preset with trending topics
+        - If primary_type == "article": Create "Article Research" preset with in-depth analysis
+        - If primary_type == "case_study": Create "Case Study Research" preset with real-world examples
+        - If primary_type == "tutorial": Create "Tutorial Research" preset with step-by-step guides
+        - If "tutorial" in secondary_types: Add "How-To Guide Research" preset
+        - If "comparison" in secondary_types or style_patterns: Add "Comparison Research" preset
+        - If content_type.purpose == "thought_leadership": Create "Thought Leadership Research" with expert insights
+        - If content_type.purpose == "education": Create "Educational Content Research" preset
+      * **Use Extracted Topics**: If extracted_topics available, create at least one preset using actual website topics:
+        - "Latest {{extracted_topic}} Trends" preset
+        - "{{extracted_topic}} Best Practices" preset
      * Each preset should include:
        - name: Descriptive, action-oriented name that clearly indicates what research will be done
-         * Use research_angles as inspiration for preset names (e.g., "Compare {Industry} Tools", "{Industry} ROI Analysis")
-         * If competitor_analysis exists, create at least one competitive analysis preset (e.g., "Competitive Landscape Analysis")
-         * Make names specific and actionable, not generic
-         * **NEW**: Include content type in name when relevant (e.g., "Blog: {Industry} Trends", "Tutorial: {Topic} Guide")
+          * Use research_angles as inspiration for preset names (e.g., "Compare {{Industry}} Tools", "{{Industry}} ROI Analysis")
+          * If competitor_analysis exists, create at least one competitive analysis preset (e.g., "Competitive Landscape Analysis")
+          * Make names specific and actionable, not generic
+          * **NEW**: Include content type in name when relevant (e.g., "Blog: {{Industry}} Trends", "Tutorial: {{Topic}} Guide")
        - keywords: Research query string that is:
          * **NEW**: Use extracted_topics and extracted_keywords when available for more relevant queries
          * Specific and detailed (not vague like "AI tools")
@@ -651,6 +651,132 @@ Generate the research persona now:
             logger.debug(f"Error extracting style guidelines: {e}")
             return []
     
+    def _analyze_crawl_result_comprehensive(self, crawl_result: Dict[str, Any]) -> Dict[str, Any]:
+        """Comprehensive crawl-result analysis used by the Phase 3 prompt.
+
+        Returns a dict shaped for ``json.dumps``-friendly consumption in
+        the LLM prompt. Safe to call with an empty / non-dict input —
+        returns an empty dict so the prompt template can fall back to
+        "No crawl analysis available" without raising.
+
+        The original implementation lived in an unreleased branch and
+        was never merged; calling code (build_research_persona_prompt)
+        was, however, already wired up. Without this method the
+        scheduled research-persona task crashes with
+        ``'ResearchPersonaPromptBuilder' object has no attribute
+        '_analyze_crawl_result_comprehensive'`` and the user is blocked
+        at onboarding step 4.
+        """
+        if not isinstance(crawl_result, dict) or not crawl_result:
+            return {}
+
+        try:
+            topics = self._extract_topics_from_crawl(crawl_result) or []
+            keywords = self._extract_keywords_from_crawl(crawl_result) or []
+            metadata = (
+                crawl_result.get("metadata", {})
+                if isinstance(crawl_result.get("metadata"), dict)
+                else {}
+            )
+            analysis: Dict[str, Any] = {
+                "content_categories": [],
+                "main_topics": topics[:10],
+                "main_keywords": keywords[:15],
+                "title": metadata.get("title") or crawl_result.get("title") or "",
+                "description": metadata.get("description") or crawl_result.get("description") or "",
+                "language": metadata.get("language") or crawl_result.get("language") or "",
+            }
+            # Derive lightweight categories from headings/sections if
+            # the upstream crawl didn't already tag them.
+            if isinstance(crawl_result.get("headings"), list):
+                analysis["heading_count"] = len(crawl_result["headings"])
+            if isinstance(crawl_result.get("sections"), list):
+                analysis["section_count"] = len(crawl_result["sections"])
+                analysis["content_categories"] = [
+                    s.get("category")
+                    for s in crawl_result["sections"][:10]
+                    if isinstance(s, dict) and s.get("category")
+                ]
+            return analysis
+        except Exception as exc:
+            logger.debug(f"_analyze_crawl_result_comprehensive failed: {exc}")
+            return {}
+
+    def _map_writing_style_comprehensive(
+        self,
+        writing_style: Dict[str, Any],
+        content_characteristics: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Phase 3 writing-style → research-depth mapping.
+
+        Mirrors the prompt's priority order:
+        1. writing_style.complexity ("high" / "medium" / "low")
+        2. content_characteristics.vocabulary_level
+        3. fallback to "medium" (targeted research)
+
+        Returns a dict the prompt template can render; an empty dict
+        signals "no style mapping available".
+        """
+        if not isinstance(writing_style, dict):
+            writing_style = {}
+        if not isinstance(content_characteristics, dict):
+            content_characteristics = {}
+
+        complexity = (writing_style.get("complexity") or "").lower()
+        vocabulary_level = (content_characteristics.get("vocabulary_level") or "").lower()
+
+        # Phase 3 priority order from the prompt template.
+        if complexity == "high" or vocabulary_level in {"advanced", "high"}:
+            research_depth_preference = "comprehensive"
+            provider_preference = "exa"
+        elif complexity == "low" or vocabulary_level in {"simple", "low", "beginner"}:
+            research_depth_preference = "basic"
+            provider_preference = "exa"
+        else:
+            research_depth_preference = "targeted"
+            provider_preference = "exa"
+
+        return {
+            "research_depth_preference": research_depth_preference,
+            "provider_preference": provider_preference,
+            "complexity": complexity or "medium",
+            "vocabulary_level": vocabulary_level or "medium",
+        }
+
+    def _extract_content_themes(
+        self,
+        crawl_result: Dict[str, Any],
+        topics: Optional[List[str]] = None,
+    ) -> List[str]:
+        """Phase 3 theme extraction for preset generation.
+
+        Combines crawl-derived topics with metadata keywords. Returns
+        a deduplicated, normalised list (max 8 themes) for the LLM
+        prompt to render into the ``recommended_presets`` section.
+        """
+        if not isinstance(crawl_result, dict):
+            crawl_result = {}
+        if not isinstance(topics, list):
+            topics = []
+
+        themes: List[str] = []
+        seen: set = set()
+
+        for candidate in list(topics) + self._extract_keywords_from_crawl(crawl_result)[:8]:
+            if not candidate or not isinstance(candidate, str):
+                continue
+            cleaned = candidate.strip()
+            if not cleaned:
+                continue
+            key = cleaned.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            themes.append(cleaned)
+            if len(themes) >= 8:
+                break
+        return themes
+
     def get_json_schema(self) -> Dict[str, Any]:
         """Return JSON schema for structured LLM response."""
         # This will be used with llm_text_gen(json_struct=...)

--- a/backend/services/scheduler/core/failure_detection_service.py
+++ b/backend/services/scheduler/core/failure_detection_service.py
@@ -475,7 +475,7 @@ class FailureDetectionService:
                 })
             
             # Check advertools tasks (paused tasks may also need attention)
-            from models.website_analysis_monitoring_models import AdvertoolsTask
+            from models.advertools_monitoring_models import AdvertoolsTask
             advertools_tasks = self.db.query(AdvertoolsTask).filter(
                 AdvertoolsTask.status.in_(["needs_intervention", "failed"])
             )

--- a/backend/services/seo/advertools_service.py
+++ b/backend/services/seo/advertools_service.py
@@ -284,7 +284,18 @@ class AdvertoolsService:
             if not all_text.strip():
                 return {"success": False, "error": "Extracted text is empty."}
 
-            word_freq = await loop.run_in_executor(None, lambda: adv.word_frequency([all_text], rm_stopwords=True))
+            word_freq = await loop.run_in_executor(
+                None,
+                # advertools >=0.13 renamed the ``rm_stopwords`` boolean
+                # to ``rm_words`` (a set of stopwords). The default
+                # English stopword set is what the old boolean True
+                # behaviour produced, so use ``adv.stopwords['english']``
+                # to preserve the original behaviour.
+                lambda: adv.word_frequency(
+                    [all_text],
+                    rm_words=adv.stopwords.get("english", set()),
+                ),
+            )
             top_themes = word_freq.head(20).to_dict(orient='records')
 
             # Additional metrics: Readability, word count

--- a/backend/tests/test_onboarding_step3_fixes.py
+++ b/backend/tests/test_onboarding_step3_fixes.py
@@ -1,0 +1,376 @@
+"""
+Tests for the second wave of onboarding fixes (post PR #742).
+
+These tests pin down:
+1. ``TxtaiIntelligenceService._require_txtai_available`` exists and
+   fails fast when txtai is unavailable.
+2. ``failure_detection_service`` imports ``AdvertoolsTask`` from the
+   right module (was the wrong module pre-fix, causing every
+   ``get_tasks_needing_intervention`` call to error).
+3. ``ResearchPersonaPromptBuilder._analyze_crawl_result_comprehensive``
+   and the two sibling methods exist and return non-empty results on
+   a populated crawl_result.
+4. ``AdvertoolsService.audit_content`` no longer crashes on the
+   ``word_frequency`` API change (rm_stopwords → rm_words).
+5. ``FacebookPersonaService.generate_facebook_persona`` accepts an
+   explicit ``user_id`` argument and falls back to
+   ``onboarding_data["session_info"]["user_id"]`` when not provided.
+"""
+
+import asyncio
+import sys
+import types
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. TxtaiIntelligenceService._require_txtai_available
+# ---------------------------------------------------------------------------
+
+
+class TestTxtaiRequireTxtaiAvailable:
+    """Phase 5 / Issue #8: explicit guard for missing txtai."""
+
+    def test_method_exists_on_class(self):
+        from services.intelligence.txtai_service import TxtaiIntelligenceService
+
+        assert hasattr(TxtaiIntelligenceService, "_require_txtai_available")
+        # Must be a callable (instance method)
+        assert callable(getattr(TxtaiIntelligenceService, "_require_txtai_available"))
+
+    def test_returns_none_when_txtai_available(self):
+        # If txtai is importable, the method is a no-op.
+        from services.intelligence import txtai_service
+        from services.intelligence.txtai_service import TxtaiIntelligenceService
+
+        if not getattr(txtai_service, "TXTAI_AVAILABLE", False):
+            pytest.skip("txtai is not installed in this environment")
+
+        # We don't construct a real instance (that loads a model).
+        # We patch __init__ to a no-op so we can call the method.
+        svc = TxtaiIntelligenceService.__new__(TxtaiIntelligenceService, user_id="test_user")
+        svc.fail_fast = False
+        # Should not raise when txtai is available.
+        assert svc._require_txtai_available() is None
+
+    def test_raises_when_txtai_missing_and_fail_fast(self, monkeypatch):
+        # Simulate "txtai not available" by stubbing the module-level
+        # TXTAI_AVAILABLE flag.
+        from services.intelligence import txtai_service
+        from services.intelligence.txtai_service import TxtaiIntelligenceService
+
+        monkeypatch.setattr(txtai_service, "TXTAI_AVAILABLE", False)
+
+        svc = TxtaiIntelligenceService.__new__(TxtaiIntelligenceService, user_id="test_user")
+        svc.fail_fast = True
+
+        with pytest.raises(RuntimeError) as exc_info:
+            svc._require_txtai_available()
+        assert "txtai is not available" in str(exc_info.value).lower()
+
+    def test_no_raise_when_txtai_missing_and_fail_soft(self, monkeypatch):
+        from services.intelligence import txtai_service
+        from services.intelligence.txtai_service import TxtaiIntelligenceService
+
+        monkeypatch.setattr(txtai_service, "TXTAI_AVAILABLE", False)
+
+        svc = TxtaiIntelligenceService.__new__(TxtaiIntelligenceService, user_id="test_user")
+        svc.fail_fast = False
+
+        # Should be a no-op (returns None) when fail_fast is disabled.
+        assert svc._require_txtai_available() is None
+
+
+# ---------------------------------------------------------------------------
+# 2. AdvertoolsTask import path
+# ---------------------------------------------------------------------------
+
+
+class TestAdvertoolsTaskImportPath:
+    """Pre-fix, failure_detection_service imported AdvertoolsTask from
+    the wrong module (``website_analysis_monitoring_models`` instead of
+    ``advertools_monitoring_models``). Every call to
+    ``get_tasks_needing_intervention`` errored out with ImportError.
+
+    We don't import failure_detection_service directly (the test
+    infrastructure can't load it for unrelated reasons). Instead we
+    grep the source for the right import statement.
+    """
+
+    def test_source_imports_advertools_task_from_correct_module(self):
+        from pathlib import Path
+
+        # This file is at backend/tests/test_onboarding_step3_fixes.py,
+        # so the backend root is parents[1] (not parents[2]).
+        repo = Path(__file__).resolve().parents[1]  # backend/
+        fds_path = (
+            repo
+            / "services"
+            / "scheduler"
+            / "core"
+            / "failure_detection_service.py"
+        )
+        assert fds_path.exists(), f"Could not find {fds_path}"
+
+        source = fds_path.read_text(encoding="utf-8")
+        # The pre-fix import was from ``website_analysis_monitoring_models``.
+        # After the fix it should be from ``advertools_monitoring_models``.
+        assert "from models.advertools_monitoring_models import AdvertoolsTask" in source, (
+            "failure_detection_service does not import AdvertoolsTask from "
+            "models.advertools_monitoring_models — the pre-fix ImportError "
+            "bug is back."
+        )
+        # And the wrong import should not be present.
+        assert (
+            "from models.website_analysis_monitoring_models import AdvertoolsTask"
+            not in source
+        ), (
+            "failure_detection_service still has the pre-fix wrong import "
+            "from models.website_analysis_monitoring_models — the bug is back."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. ResearchPersonaPromptBuilder comprehensive methods
+# ---------------------------------------------------------------------------
+
+
+class TestResearchPersonaPromptBuilderComprehensive:
+    """The Phase 3 prompt template calls three methods that were never
+    defined, causing the scheduled research-persona task to crash."""
+
+    def _builder(self):
+        from services.research.research_persona_prompt_builder import (
+            ResearchPersonaPromptBuilder,
+        )
+        return ResearchPersonaPromptBuilder()
+
+    def test_methods_exist(self):
+        b = self._builder()
+        assert callable(getattr(b, "_analyze_crawl_result_comprehensive", None))
+        assert callable(getattr(b, "_map_writing_style_comprehensive", None))
+        assert callable(getattr(b, "_extract_content_themes", None))
+
+    def test_analyze_crawl_result_comprehensive_with_empty_input(self):
+        b = self._builder()
+        # Empty / non-dict input should return {} without raising.
+        assert b._analyze_crawl_result_comprehensive({}) == {}
+        assert b._analyze_crawl_result_comprehensive(None) == {}
+        assert b._analyze_crawl_result_comprehensive("not a dict") == {}
+
+    def test_analyze_crawl_result_comprehensive_with_populated_input(self):
+        b = self._builder()
+        crawl = {
+            "metadata": {
+                "title": "My Site",
+                "description": "A great site",
+                "keywords": ["alpha", "beta", "gamma"],
+            },
+            "headings": ["Home", "About", "Contact"],
+            "sections": [
+                {"category": "blog", "title": "First Post"},
+                {"category": "tutorial", "title": "How To"},
+            ],
+            "topics": ["AI", "marketing"],
+        }
+        result = b._analyze_crawl_result_comprehensive(crawl)
+        assert result["title"] == "My Site"
+        assert result["description"] == "A great site"
+        assert "AI" in result["main_topics"]
+        assert "marketing" in result["main_topics"]
+        assert result["content_categories"] == ["blog", "tutorial"]
+
+    def test_map_writing_style_comprehensive_complexity_levels(self):
+        b = self._builder()
+        # High complexity → comprehensive research depth.
+        high = b._map_writing_style_comprehensive({"complexity": "high"}, {})
+        assert high["research_depth_preference"] == "comprehensive"
+        # Medium → targeted.
+        medium = b._map_writing_style_comprehensive({"complexity": "medium"}, {})
+        assert medium["research_depth_preference"] == "targeted"
+        # Low → basic.
+        low = b._map_writing_style_comprehensive({"complexity": "low"}, {})
+        assert low["research_depth_preference"] == "basic"
+        # Vocabulary fallback when complexity missing.
+        vocab_advanced = b._map_writing_style_comprehensive({}, {"vocabulary_level": "advanced"})
+        assert vocab_advanced["research_depth_preference"] == "comprehensive"
+
+    def test_extract_content_themes_dedupes(self):
+        b = self._builder()
+        crawl = {"metadata": {"keywords": ["alpha", "beta"]}}
+        # Provide duplicate topics to verify dedup.
+        themes = b._extract_content_themes(crawl, ["alpha", "Alpha", "BETA", "gamma"])
+        # "alpha" and "Alpha" should be deduped case-insensitively.
+        assert len(themes) == len(set(t.lower() for t in themes))
+        # The first occurrence wins (lowercase "alpha", uppercase "Alpha" both kept the first "alpha").
+        assert "alpha" in [t.lower() for t in themes]
+
+    def test_prompt_build_does_not_crash_with_empty_input(self):
+        """The end-to-end prompt build must not crash even when the
+        crawl_result is empty. This is the regression that was
+        blocking onboarding step 4."""
+        b = self._builder()
+        prompt = b.build_research_persona_prompt({})
+        assert isinstance(prompt, str)
+        assert "RESEARCH PERSONA GENERATION TASK" in prompt
+
+
+# ---------------------------------------------------------------------------
+# 4. advertools_service audit_content with the new rm_words API
+# ---------------------------------------------------------------------------
+
+
+class TestAdvertoolsAuditContent:
+    """Pre-fix, ``adv.word_frequency([text], rm_stopwords=True)`` raised
+    ``TypeError: word_frequency() got an unexpected keyword argument
+    'rm_stopwords'`` because advertools >=0.13 renamed the parameter
+    to ``rm_words``. The fix uses ``rm_words=adv.stopwords['english']``
+    to preserve the original behaviour (filter English stopwords)."""
+
+    def _patch_adv(self):
+        """Build a fake advertools module with the new API and inject
+        it into sys.modules so the import inside advertools_service
+        picks it up.
+        """
+        fake_adv = types.ModuleType("advertools")
+        fake_word_freq_result = MagicMock()
+        fake_word_freq_result.head.return_value.to_dict.return_value = [
+            {"word": "alpha", "abs_freq": 5},
+            {"word": "beta", "abs_freq": 3},
+        ]
+        fake_adv.word_frequency = MagicMock(return_value=fake_word_freq_result)
+        fake_adv.stopwords = {"english": {"the", "a", "an"}}
+        fake_adv.url_to_df = MagicMock()
+        fake_adv.crawl = MagicMock()
+        return fake_adv
+
+    def test_audit_content_uses_rm_words_not_rm_stopwords(self):
+        """Verify the call site uses ``rm_words`` (a set) not
+        ``rm_stopwords`` (a boolean, the pre-fix behaviour)."""
+        from pathlib import Path
+
+        repo = Path(__file__).resolve().parents[1]  # backend/
+        adv_path = (
+            repo / "services" / "seo" / "advertools_service.py"
+        )
+        assert adv_path.exists(), f"Could not find {adv_path}"
+        source = adv_path.read_text(encoding="utf-8")
+
+        # The pre-fix call was ``adv.word_frequency([text], rm_stopwords=True)``.
+        # After the fix it should be ``adv.word_frequency([text], rm_words=adv.stopwords[...])``.
+        assert "rm_stopwords=True" not in source, (
+            "advertools_service still uses rm_stopwords=True — "
+            "the pre-fix API mismatch is back."
+        )
+        assert "rm_words=" in source, (
+            "advertools_service does not use rm_words — the fix is missing."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. FacebookPersonaService.generate_facebook_persona user_id handling
+# ---------------------------------------------------------------------------
+
+
+class TestFacebookPersonaUserIdResolution:
+    """The Facebook persona service used to extract user_id from
+    ``onboarding_data["session_info"]["user_id"]`` which is None when
+    the scheduler passes a flat onboarding dict. The fix accepts
+    ``user_id`` as an explicit kwarg and falls back to the legacy
+    nested key.
+    """
+
+    def _service(self):
+        from services.persona.facebook.facebook_persona_service import (
+            FacebookPersonaService,
+        )
+        # Singleton; reset between tests.
+        FacebookPersonaService._instance = None
+        FacebookPersonaService._initialized = False
+        return FacebookPersonaService()
+
+    def _patch_llm(self):
+        """Patch ``llm_text_gen`` so we can capture the user_id that
+        the service passes through to the LLM gateway."""
+        return patch("services.persona.facebook.facebook_persona_service.llm_text_gen")
+
+    def test_explicit_user_id_is_passed_to_llm(self):
+        svc = self._service()
+        with self._patch_llm() as fake_llm:
+            fake_llm.return_value = {
+                "facebook_handle": "test",
+                "primary_topics": ["AI"],
+            }
+            # Stub the schema/prompt methods so the service doesn't
+            # need real persona data.
+            svc.prompts.build_focused_facebook_prompt = MagicMock(return_value="prompt")
+            svc.prompts.build_facebook_system_prompt = MagicMock(return_value="system")
+            svc._get_enhanced_facebook_schema = MagicMock(return_value={})
+            svc.validate_facebook_persona = MagicMock(return_value={"quality_score": 80.0})
+            svc.optimize_for_facebook_algorithm = MagicMock(
+                side_effect=lambda p: p
+            )
+
+            svc.generate_facebook_persona(
+                core_persona={"name": "test"},
+                onboarding_data={"website_url": "https://x.com"},
+                user_id="user_abc",
+            )
+
+            assert fake_llm.called
+            call_kwargs = fake_llm.call_args.kwargs
+            assert call_kwargs.get("user_id") == "user_abc"
+
+    def test_falls_back_to_session_info_user_id(self):
+        svc = self._service()
+        with self._patch_llm() as fake_llm:
+            fake_llm.return_value = {"facebook_handle": "test"}
+            svc.prompts.build_focused_facebook_prompt = MagicMock(return_value="prompt")
+            svc.prompts.build_facebook_system_prompt = MagicMock(return_value="system")
+            svc._get_enhanced_facebook_schema = MagicMock(return_value={})
+            svc.validate_facebook_persona = MagicMock(return_value={"quality_score": 80.0})
+            svc.optimize_for_facebook_algorithm = MagicMock(
+                side_effect=lambda p: p
+            )
+
+            # No explicit user_id, but the legacy nested key is set.
+            svc.generate_facebook_persona(
+                core_persona={"name": "test"},
+                onboarding_data={
+                    "website_url": "https://x.com",
+                    "session_info": {"user_id": "user_legacy"},
+                },
+            )
+
+            assert fake_llm.called
+            call_kwargs = fake_llm.call_args.kwargs
+            assert call_kwargs.get("user_id") == "user_legacy"
+
+    def test_explicit_user_id_wins_over_legacy_nested(self):
+        """If both are set, the explicit kwarg wins."""
+        svc = self._service()
+        with self._patch_llm() as fake_llm:
+            fake_llm.return_value = {"facebook_handle": "test"}
+            svc.prompts.build_focused_facebook_prompt = MagicMock(return_value="prompt")
+            svc.prompts.build_facebook_system_prompt = MagicMock(return_value="system")
+            svc._get_enhanced_facebook_schema = MagicMock(return_value={})
+            svc.validate_facebook_persona = MagicMock(return_value={"quality_score": 80.0})
+            svc.optimize_for_facebook_algorithm = MagicMock(
+                side_effect=lambda p: p
+            )
+
+            svc.generate_facebook_persona(
+                core_persona={"name": "test"},
+                onboarding_data={
+                    "website_url": "https://x.com",
+                    "session_info": {"user_id": "user_legacy"},
+                },
+                user_id="user_explicit",
+            )
+
+            assert fake_llm.called
+            call_kwargs = fake_llm.call_args.kwargs
+            assert call_kwargs.get("user_id") == "user_explicit"


### PR DESCRIPTION
## Goal

Six concrete crashes that were blocking the end user from completing
onboarding. All six were visible in the logs the user provided.

## What changed

1. **`TxtaiIntelligenceService._require_txtai_available`** — added the
   missing guard that `index_content` / `delete_content` / `reindex_all`
   were calling. Honours the existing `SIF_FAIL_FAST` env var.
   `services/intelligence/txtai_service.py`

2. **`failure_detection_service` import path** — `AdvertoolsTask` was
   being imported from the wrong module. Fixed to
   `models.advertools_monitoring_models` (the other 12 callers in the
   codebase were already correct).
   `services/scheduler/core/failure_detection_service.py:478`

3. **`ResearchPersonaPromptBuilder` Phase 3 methods** — implemented
   `_analyze_crawl_result_comprehensive`, `_map_writing_style_comprehensive`,
   and `_extract_content_themes`. The prompt template was already
   calling them; without definitions the scheduled research-persona
   task crashed with AttributeError. Also fixed a latent f-string bug
   in the prompt template: literal LLM placeholders like `{theme}`
   were being interpreted by Python's f-string parser. Escaped as
   `{{theme}}` etc.
   `services/research/research_persona_prompt_builder.py`

4. **`advertools_service.audit_content` API** — `adv.word_frequency`
   no longer accepts `rm_stopwords=True` (advertools >=0.13 renamed
   it to `rm_words=<set>`). Switched to `rm_words=adv.stopwords["english"]`
   to preserve the original behaviour.
   `services/seo/advertools_service.py:287`

5. **`FacebookPersonaService` user_id plumbing** — the service used
   to extract user_id from `onboarding_data["session_info"]["user_id"]`
   but the scheduler passed a flat dict, so user_id was None, which
   then errored in the LLM gateway with "user_id is required for
   subscription checking". Now accepts an explicit `user_id` kwarg
   (with the legacy nested-key fallback), and the scheduler passes
   it through. Also fixed the Facebook persona scheduler.
   `services/persona/facebook/facebook_persona_service.py`
   `services/persona/facebook/facebook_persona_scheduler.py`

6. **Test infrastructure** — `backend/tests/` is gitignored. The
   test files added in PR #742 (`test_sitemap_retry_and_dedup.py`,
   `test_oauth_token_monitoring_service.py`, `test_linkedin_oauth.py`)
   were force-added in commit `55312e59` but the working tree lost
   them on branch switch. Restored from that commit so the new tests
   run alongside the existing tests.

## Test status

All 82 OAuth + sitemap + onboarding tests pass:

- `test_onboarding_step3_fixes.py` (new): 15/15
- `test_sitemap_retry_and_dedup.py`: 14/14
- `test_oauth_token_monitoring_service.py`: 14/14
- `test_linkedin_oauth.py`: 15/15
- `test_wordpress_oauth_content.py`: 24/24

The `test_advertools_task_import` and `test_audit_content_uses_rm_words`
tests are grep-based regression tests (the test environment can't
import the full `advertools_service` or `failure_detection_service`
modules for unrelated pre-existing import reasons — see commit
`1cd8ab6b` "Pre-Phase-0: 6 hotfixes for SIF + scheduler bugs").

## Out of scope

- The LinkedIn push-2 (`feat/linkedin-oauth-common-framework`) and the
  step-3 first wave (`fix/step3-onboarding-thundering-herd`) PRs are
  still open. Once both are merged, this PR can be merged on top.
- `get_tasks_needing_intervention` still has the AdvertoolsTask path
  working; the deeper failure-pattern work is a separate concern.
