### PR TITLE
feat(linkedin): citation badges, progress modal redesign, prompt anti-hallucination

### DIFF
--- a/backend/models/linkedin_models.py
+++ b/backend/models/linkedin_models.py
@@ -277,6 +277,113 @@ class Citation(BaseModel):
     source_index: Optional[int] = Field(None, description="Index of source in research_sources")
 
 
+# Structured output schema for LLM post generation
+class LinkedInPostOutput(BaseModel):
+    """Structured JSON schema enforced on the LLM for grounded LinkedIn post generation."""
+    content: str = Field(..., description="The full post text with [Source N] markers immediately after claims backed by research")
+    hashtags: List[str] = Field(default_factory=list, description="3-5 relevant LinkedIn hashtags extracted from the content")
+    call_to_action: Optional[str] = Field(None, description="The call-to-action sentence from the post, if present")
+    cited_source_indices: List[int] = Field(default_factory=list, description="1-based indices into the research sources array for every [Source N] marker used in content")
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "content": "AI adoption surged 40% in enterprises this year [Source 1]. Leaders who invest now gain a competitive edge [Source 2].\n\nWhat's your take? #AI #TechTrends",
+                "hashtags": ["#AI", "#DigitalTransformation", "#TechTrends"],
+                "call_to_action": "What's your take on AI adoption in your industry? Share below!",
+                "cited_source_indices": [1, 2]
+            }
+        }
+
+
+# Structured output schema for LLM article generation
+class LinkedInArticleOutput(BaseModel):
+    """Structured JSON schema enforced on the LLM for grounded LinkedIn article generation."""
+    title: str = Field(..., description="Compelling article headline with [Source N] markers where backed by research")
+    content: str = Field(..., description="Full article body with [Source N] markers immediately after claims backed by research")
+    sections: List[Dict[str, str]] = Field(default_factory=list, description="List of sections each with heading and body")
+    seo_metadata: Optional[Dict[str, Any]] = Field(None, description="SEO keywords and meta description")
+    reading_time: Optional[int] = Field(None, description="Estimated reading time in minutes")
+    cited_source_indices: List[int] = Field(default_factory=list, description="1-based indices into the research sources array for every [Source N] marker used in content")
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "title": "The Future of AI in Enterprise: Key Trends for 2026",
+                "content": "Artificial intelligence continues to reshape enterprise operations [Source 1]...",
+                "sections": [{"heading": "Current Landscape", "body": "Enterprises are adopting AI at an unprecedented rate..."}],
+                "seo_metadata": {"keywords": ["AI", "enterprise", "digital transformation"]},
+                "reading_time": 5,
+                "cited_source_indices": [1, 3]
+            }
+        }
+
+
+# Structured output schema for LLM carousel generation
+class CarouselSlideOutput(BaseModel):
+    """A single slide within a LinkedIn carousel."""
+    slide_number: int = Field(..., description="Slide position (1-based)")
+    title: str = Field(..., description="Slide headline")
+    content: str = Field(..., description="Slide body text with [Source N] markers where backed by research")
+    visual_elements: List[str] = Field(default_factory=list, description="Suggested visual elements for this slide")
+    design_notes: Optional[str] = Field(None, description="Design guidance for this slide")
+
+
+class LinkedInCarouselOutput(BaseModel):
+    """Structured JSON schema enforced on the LLM for grounded LinkedIn carousel generation."""
+    title: str = Field(..., description="Carousel overarching title")
+    slides: List[CarouselSlideOutput] = Field(..., description="All content slides")
+    cover_slide: Optional[CarouselSlideOutput] = Field(None, description="Optional cover/intro slide")
+    cta_slide: Optional[CarouselSlideOutput] = Field(None, description="Optional call-to-action closing slide")
+    design_guidelines: Dict[str, str] = Field(default_factory=dict, description="Visual design guidance")
+    cited_source_indices: List[int] = Field(default_factory=list, description="1-based indices into the research sources array for every [Source N] marker used in any slide")
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "title": "5 AI Trends Transforming Enterprise",
+                "slides": [
+                    {"slide_number": 1, "title": "AI Adoption Surge", "content": "Enterprise AI adoption grew 40% in 2025 [Source 1]", "visual_elements": ["bar chart"], "design_notes": "Use blue gradient"}
+                ],
+                "cited_source_indices": [1]
+            }
+        }
+
+
+class SceneOutput(BaseModel):
+    """A single scene within a video script."""
+    scene_number: int = Field(..., description="Scene order (1-based)")
+    content: str = Field(..., description="Scene narration/script text with [Source N] markers where backed by research")
+    duration: Optional[str] = Field(None, description="Estimated duration of this scene")
+    visual_notes: Optional[str] = Field(None, description="Visual guidance for this scene")
+
+
+# Structured output schema for LLM video script generation
+class LinkedInVideoScriptOutput(BaseModel):
+    """Structured JSON schema enforced on the LLM for grounded LinkedIn video script generation."""
+    hook: str = Field(..., description="Opening hook (first 3 seconds) with [Source N] markers where backed by research")
+    main_content: List[SceneOutput] = Field(..., description="Main content scenes")
+    conclusion: str = Field(..., description="Closing remarks and call-to-action")
+    captions: Optional[List[str]] = Field(None, description="Optimized caption text for each scene")
+    thumbnail_suggestions: List[str] = Field(default_factory=list, description="Suggested thumbnail ideas")
+    video_description: str = Field(..., description="Post/video description with hashtags")
+    cited_source_indices: List[int] = Field(default_factory=list, description="1-based indices into the research sources array for every [Source N] marker used in any scene")
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "hook": "Did you know AI adoption in enterprises surged 40% last year? [Source 1]",
+                "main_content": [
+                    {"scene_number": 1, "content": "Let's break down what this means for your business...", "duration": "15s", "visual_notes": "Talking head with data overlay"}
+                ],
+                "conclusion": "Follow for more AI insights!",
+                "thumbnail_suggestions": ["AI stats overlay on speaker"],
+                "video_description": "AI is transforming enterprise. #AI #TechTrends",
+                "cited_source_indices": [1]
+            }
+        }
+
+
 # Enhanced Post Content Model
 class PostContent(BaseModel):
     """Enhanced model for generated post content with grounding capabilities."""

--- a/backend/routers/linkedin.py
+++ b/backend/routers/linkedin.py
@@ -111,8 +111,7 @@ get_db = get_db_dependency
 async def log_api_request(request: Request, db: Session, duration: float, status_code: int):
     """Log API request to database for monitoring."""
     try:
-        await monitor.add_request(
-            db=db,
+        request_record = APIRequest(
             path=str(request.url.path),
             method=request.method,
             status_code=status_code,
@@ -122,6 +121,7 @@ async def log_api_request(request: Request, db: Session, duration: float, status
             user_agent=request.headers.get("User-Agent"),
             ip_address=request.client.host if request.client else None
         )
+        db.add(request_record)
         db.commit()
     except Exception as e:
         logger.error(f"Failed to log API request: {str(e)}")

--- a/backend/services/linkedin/content_generator.py
+++ b/backend/services/linkedin/content_generator.py
@@ -5,12 +5,15 @@ Handles the main content generation logic for posts and articles.
 Uses llm_text_gen for provider-agnostic LLM access (respects GPT_PROVIDER).
 """
 
+import json
+import re
 from typing import Dict, Any, List, Optional
 from datetime import datetime
 from loguru import logger
 from models.linkedin_models import (
     LinkedInPostRequest, LinkedInArticleRequest, LinkedInPostResponse, LinkedInArticleResponse,
-    PostContent, ArticleContent, GroundingLevel, ResearchSource
+    PostContent, ArticleContent, GroundingLevel, ResearchSource, LinkedInPostOutput, Citation,
+    HashtagSuggestion, LinkedInArticleOutput, LinkedInCarouselOutput, LinkedInVideoScriptOutput
 )
 from services.linkedin.quality_handler import QualityHandler
 from services.linkedin.content_generator_prompts import (
@@ -23,7 +26,6 @@ from services.linkedin.content_generator_prompts import (
     VideoScriptGenerator
 )
 from services.llm_providers.main_text_generation import llm_text_gen
-from services.linkedin.content_parser import parse_video_script_text
 from services.persona_analysis_service import PersonaAnalysisService
 import time
 
@@ -106,13 +108,23 @@ class ContentGenerator:
                 del self._cache_timestamps[key]
             logger.info(f"Cleared persona cache for user {user_id}")
     
+    def _extract_citation_text(self, content: str, source_num: int) -> str:
+        """Extract the sentence surrounding a [Source N] marker for citation text display."""
+        pattern = re.compile(rf'([^.]*?\[Source {re.escape(str(source_num))}\][^.]*\.)')
+        match = pattern.search(content)
+        if match:
+            text = match.group(1).strip()
+            return text[:200]
+        return f"Source {source_num}"
+
     def _build_research_context(self, research_sources: List) -> str:
         """Build research context string from research sources for prompt injection."""
         if not research_sources:
             return ""
         
-        context_parts = ["\n\nRESEARCH CONTEXT (use this information to ground your content with facts and data):"]
-        for i, source in enumerate(research_sources[:5], 1):  # Limit to top 5 sources
+        today = datetime.now().strftime("%B %d, %Y")
+        context_parts = [f"\n\nTODAY'S DATE: {today}\n\nRESEARCH CONTEXT (use this information to ground your content with facts and data):"]
+        for i, source in enumerate(research_sources[:8], 1):  # Limit to top 8 sources
             title = getattr(source, 'title', f'Source {i}')
             url = getattr(source, 'url', '')
             content = getattr(source, 'content', '')
@@ -158,22 +170,31 @@ class ContentGenerator:
                 logger.info(f"  - First research source: {research_sources[0] if research_sources else 'None'}")
                 logger.info(f"  - Research sources types: {[type(s) for s in research_sources[:3]]}")
             
-            # Step 3: Add citations if requested
+            # Step 3: Build citations from structured LLM output or fall back to extraction
             citations = []
             source_list = None
             final_research_sources = research_sources
             
-            if request.include_citations and research_sources and self.citation_manager:
-                try:
-                    logger.info(f"Processing citations for content length: {len(content_result['content'])}")
-                    citations = self.citation_manager.extract_citations(content_result['content'])
-                    logger.info(f"Extracted {len(citations)} citations from content")
-                    source_list = self.citation_manager.generate_source_list(research_sources)
-                    logger.info(f"Generated source list: {source_list[:200] if source_list else 'None'}")
-                except Exception as e:
-                    logger.warning(f"Citation processing failed: {e}")
+            if request.include_citations:
+                # Prefer structured citations from LLM json_struct output
+                if content_result.get('citations'):
+                    citations = content_result['citations']
+                    logger.info(f"Using {len(citations)} structured citations from LLM output")
+                elif research_sources and self.citation_manager:
+                    try:
+                        logger.info(f"Falling back to citation extraction for content length: {len(content_result['content'])}")
+                        citations = self.citation_manager.extract_citations(content_result['content'])
+                        logger.info(f"Extracted {len(citations)} citations from content")
+                    except Exception as e:
+                        logger.warning(f"Citation extraction fallback failed: {e}")
+                
+                if research_sources and self.citation_manager:
+                    try:
+                        source_list = self.citation_manager.generate_source_list(research_sources)
+                    except Exception as e:
+                        logger.warning(f"Source list generation failed: {e}")
             else:
-                logger.info(f"Citation processing skipped: include_citations={request.include_citations}, research_sources={len(research_sources) if research_sources else 0}, citation_manager={self.citation_manager is not None}")
+                logger.info(f"Citation processing skipped: include_citations={request.include_citations}")
             
             # Step 4: Analyze content quality
             quality_metrics = None
@@ -190,10 +211,17 @@ class ContentGenerator:
                     logger.warning(f"Quality analysis failed: {e}")
             
             # Step 5: Build response
+            # Convert string hashtags from LLM output to HashtagSuggestion objects
+            raw_hashtags = content_result.get('hashtags', [])
+            if raw_hashtags and isinstance(raw_hashtags[0], str):
+                hashtag_suggestions = [HashtagSuggestion(hashtag=h if h.startswith('#') else f'#{h}', category="generated") for h in raw_hashtags]
+            else:
+                hashtag_suggestions = raw_hashtags
+            
             post_content = PostContent(
                 content=content_result['content'],
                 character_count=len(content_result['content']),
-                hashtags=content_result.get('hashtags', []),
+                hashtags=hashtag_suggestions,
                 call_to_action=content_result.get('call_to_action'),
                 engagement_prediction=content_result.get('engagement_prediction'),
                 citations=citations,
@@ -250,12 +278,23 @@ class ContentGenerator:
             source_list = None
             final_research_sources = research_sources
             
-            if request.include_citations and research_sources and self.citation_manager:
-                try:
-                    citations = self.citation_manager.extract_citations(content_result['content'])
-                    source_list = self.citation_manager.generate_source_list(research_sources)
-                except Exception as e:
-                    logger.warning(f"Citation processing failed: {e}")
+            if request.include_citations:
+                # Prefer structured citations from LLM json_struct output
+                if content_result.get('citations'):
+                    citations = content_result['citations']
+                    logger.info(f"Using {len(citations)} structured citations from LLM output for article")
+                elif research_sources and self.citation_manager:
+                    try:
+                        citations = self.citation_manager.extract_citations(content_result['content'])
+                        logger.info(f"Extracted {len(citations)} citations from article content")
+                    except Exception as e:
+                        logger.warning(f"Citation extraction fallback for article failed: {e}")
+                
+                if research_sources and self.citation_manager:
+                    try:
+                        source_list = self.citation_manager.generate_source_list(research_sources)
+                    except Exception as e:
+                        logger.warning(f"Source list generation for article failed: {e}")
             
             # Step 4: Analyze content quality
             quality_metrics = None
@@ -388,7 +427,7 @@ class ContentGenerator:
     
     # Grounded content generation methods
     async def generate_grounded_post_content(self, request, research_sources: List, user_id: str = None) -> Dict[str, Any]:
-        """Generate post content using provider-agnostic llm_text_gen."""
+        """Generate post content using provider-agnostic llm_text_gen with structured JSON output."""
         try:
             # Build the prompt using persona if available
             uid = int(getattr(request, "user_id", 0) or 0)
@@ -416,21 +455,51 @@ class ContentGenerator:
             if research_context:
                 prompt += research_context
             
-            # Generate content using provider-agnostic gateway
+            # Generate content using provider-agnostic gateway with structured JSON schema
             raw_response = llm_text_gen(
                 prompt=prompt,
+                json_struct=LinkedInPostOutput.model_json_schema(),
                 user_id=user_id,
                 flow_type="linkedin_post",
                 max_tokens=request.max_length,
                 temperature=0.7
             )
             
-            content_text = raw_response if isinstance(raw_response, str) else str(raw_response or "")
+            # Parse structured response (handle both dict from Gemini and str from others)
+            if isinstance(raw_response, dict):
+                parsed = raw_response
+            else:
+                cleaned = str(raw_response).strip()
+                if cleaned.startswith('```json'):
+                    cleaned = cleaned[7:]
+                elif cleaned.startswith('```'):
+                    cleaned = cleaned[3:]
+                if cleaned.endswith('```'):
+                    cleaned = cleaned[:-3]
+                parsed = json.loads(cleaned)
+            
+            content_text = parsed.get('content', '').strip()
+            hashtags = parsed.get('hashtags', [])
+            call_to_action = parsed.get('call_to_action')
+            cited_indices = parsed.get('cited_source_indices', [])
+            
+            # Build citations from cited source indices
+            citations = []
+            for idx in cited_indices:
+                if isinstance(idx, int) and 0 < idx <= len(research_sources):
+                    citations.append(Citation(
+                        type="inline",
+                        reference=f"Source {idx}",
+                        source_index=idx - 1,
+                        text=self._extract_citation_text(content_text, idx)
+                    ))
             
             return {
                 'content': content_text,
-                'sources': [],
-                'citations': [],
+                'hashtags': hashtags,
+                'call_to_action': call_to_action,
+                'sources': research_sources,
+                'citations': citations,
                 'grounding_enabled': bool(research_sources),
                 'fallback_used': False
             }
@@ -440,7 +509,7 @@ class ContentGenerator:
             raise Exception(f"Failed to generate LinkedIn post: {str(e)}")
     
     async def generate_grounded_article_content(self, request, research_sources: List, user_id: str = None) -> Dict[str, Any]:
-        """Generate article content using provider-agnostic llm_text_gen."""
+        """Generate article content using provider-agnostic llm_text_gen with structured JSON output."""
         try:
             # Build the prompt using persona if available
             uid = int(getattr(request, "user_id", 0) or 0)
@@ -468,38 +537,55 @@ class ContentGenerator:
             if research_context:
                 prompt += research_context
             
-            # Generate content using provider-agnostic gateway
+            # Generate content using provider-agnostic gateway with structured JSON schema
             raw_response = llm_text_gen(
                 prompt=prompt,
+                json_struct=LinkedInArticleOutput.model_json_schema(),
                 user_id=user_id,
                 flow_type="linkedin_article",
                 max_tokens=request.word_count * 10,
                 temperature=0.7
             )
             
-            content_text = raw_response if isinstance(raw_response, str) else str(raw_response or "")
+            # Parse structured response (handle both dict from Gemini and str from others)
+            if isinstance(raw_response, dict):
+                parsed = raw_response
+            else:
+                cleaned = str(raw_response).strip()
+                if cleaned.startswith('```json'):
+                    cleaned = cleaned[7:]
+                elif cleaned.startswith('```'):
+                    cleaned = cleaned[3:]
+                if cleaned.endswith('```'):
+                    cleaned = cleaned[:-3]
+                parsed = json.loads(cleaned)
             
-            # Extract title from article content (first markdown heading or first line)
-            title = ""
-            for line in content_text.split('\n'):
-                stripped = line.strip()
-                if stripped.startswith('# '):
-                    title = stripped[2:].strip()
-                    break
-            if not title:
-                for line in content_text.split('\n'):
-                    stripped = line.strip()
-                    if stripped:
-                        title = stripped[:100].strip()
-                        break
-            if not title:
-                title = request.topic or "LinkedIn Article"
+            content_text = parsed.get('content', '').strip()
+            title = parsed.get('title', request.topic or "LinkedIn Article")
+            sections = parsed.get('sections', [])
+            seo_metadata = parsed.get('seo_metadata')
+            reading_time = parsed.get('reading_time')
+            cited_indices = parsed.get('cited_source_indices', [])
+            
+            # Build citations from cited source indices
+            citations = []
+            for idx in cited_indices:
+                if isinstance(idx, int) and 0 < idx <= len(research_sources):
+                    citations.append(Citation(
+                        type="inline",
+                        reference=f"Source {idx}",
+                        source_index=idx - 1,
+                        text=self._extract_citation_text(content_text, idx)
+                    ))
             
             return {
                 'content': content_text,
                 'title': title,
-                'sources': [],
-                'citations': [],
+                'sections': sections,
+                'seo_metadata': seo_metadata,
+                'reading_time': reading_time,
+                'sources': research_sources,
+                'citations': citations,
                 'grounding_enabled': bool(research_sources),
                 'fallback_used': False
             }
@@ -509,7 +595,7 @@ class ContentGenerator:
             raise Exception(f"Failed to generate LinkedIn article: {str(e)}")
     
     async def generate_grounded_carousel_content(self, request, research_sources: List, user_id: str = None) -> Dict[str, Any]:
-        """Generate carousel content using provider-agnostic llm_text_gen."""
+        """Generate carousel content using provider-agnostic llm_text_gen with structured JSON output."""
         try:
             prompt = CarouselPromptBuilder.build_carousel_prompt(request)
             
@@ -518,21 +604,61 @@ class ContentGenerator:
             if research_context:
                 prompt += research_context
             
-            # Generate content using provider-agnostic gateway
+            # Generate content using provider-agnostic gateway with structured JSON schema
             raw_response = llm_text_gen(
                 prompt=prompt,
+                json_struct=LinkedInCarouselOutput.model_json_schema(),
                 user_id=user_id,
                 flow_type="linkedin_carousel",
                 max_tokens=2000,
                 temperature=0.7
             )
             
-            content_text = raw_response if isinstance(raw_response, str) else str(raw_response or "")
+            # Parse structured response (handle both dict from Gemini and str from others)
+            if isinstance(raw_response, dict):
+                parsed = raw_response
+            else:
+                cleaned = str(raw_response).strip()
+                if cleaned.startswith('```json'):
+                    cleaned = cleaned[7:]
+                elif cleaned.startswith('```'):
+                    cleaned = cleaned[3:]
+                if cleaned.endswith('```'):
+                    cleaned = cleaned[:-3]
+                parsed = json.loads(cleaned)
+            
+            slides_raw = parsed.get('slides', [])
+            # Convert slide dicts if they came through as plain dicts from JSON
+            slides = []
+            for s in slides_raw:
+                if isinstance(s, dict):
+                    slides.append(s)
+                else:
+                    slides.append(s.model_dump() if hasattr(s, 'model_dump') else dict(s))
+            
+            cited_indices = parsed.get('cited_source_indices', [])
+            
+            # Build citations from cited source indices
+            citations = []
+            all_slide_content = " ".join([s.get('content', '') for s in slides])
+            for idx in cited_indices:
+                if isinstance(idx, int) and 0 < idx <= len(research_sources):
+                    citations.append(Citation(
+                        type="inline",
+                        reference=f"Source {idx}",
+                        source_index=idx - 1,
+                        text=self._extract_citation_text(all_slide_content, idx)
+                    ))
             
             return {
-                'content': content_text,
-                'sources': [],
-                'citations': [],
+                'content': parsed.get('content', ''),
+                'slides': slides,
+                'title': parsed.get('title', ''),
+                'cover_slide': parsed.get('cover_slide'),
+                'cta_slide': parsed.get('cta_slide'),
+                'design_guidelines': parsed.get('design_guidelines', {}),
+                'sources': research_sources,
+                'citations': citations,
                 'grounding_enabled': bool(research_sources),
                 'fallback_used': False
             }
@@ -542,7 +668,7 @@ class ContentGenerator:
             raise Exception(f"Failed to generate LinkedIn carousel: {str(e)}")
     
     async def generate_grounded_video_script_content(self, request, research_sources: List, user_id: str = None) -> Dict[str, Any]:
-        """Generate video script content using provider-agnostic llm_text_gen."""
+        """Generate video script content using provider-agnostic llm_text_gen with structured JSON output."""
         try:
             prompt = VideoScriptPromptBuilder.build_video_script_prompt(request)
             
@@ -551,23 +677,66 @@ class ContentGenerator:
             if research_context:
                 prompt += research_context
             
-            # Generate content using provider-agnostic gateway
+            # Generate content using provider-agnostic gateway with structured JSON schema
             raw_response = llm_text_gen(
                 prompt=prompt,
+                json_struct=LinkedInVideoScriptOutput.model_json_schema(),
                 user_id=user_id,
                 flow_type="linkedin_video_script",
                 max_tokens=1500,
                 temperature=0.7
             )
             
-            content_text = raw_response if isinstance(raw_response, str) else str(raw_response or "")
-            parsed = parse_video_script_text(content_text)
-
+            # Parse structured response (handle both dict from Gemini and str from others)
+            if isinstance(raw_response, dict):
+                parsed = raw_response
+            else:
+                cleaned = str(raw_response).strip()
+                if cleaned.startswith('```json'):
+                    cleaned = cleaned[7:]
+                elif cleaned.startswith('```'):
+                    cleaned = cleaned[3:]
+                if cleaned.endswith('```'):
+                    cleaned = cleaned[:-3]
+                parsed = json.loads(cleaned)
+            
+            hook = parsed.get('hook', '')
+            main_content_raw = parsed.get('main_content', [])
+            main_content = []
+            for s in main_content_raw:
+                if isinstance(s, dict):
+                    main_content.append(s)
+                else:
+                    main_content.append(s.model_dump() if hasattr(s, 'model_dump') else dict(s))
+            conclusion = parsed.get('conclusion', '')
+            captions = parsed.get('captions')
+            thumbnail_suggestions = parsed.get('thumbnail_suggestions', [])
+            video_description = parsed.get('video_description', '')
+            cited_indices = parsed.get('cited_source_indices', [])
+            
+            # Build citations from cited source indices
+            citations = []
+            all_scene_content = " ".join([s.get('content', '') for s in main_content])
+            full_content = f"{hook} {all_scene_content} {conclusion}"
+            for idx in cited_indices:
+                if isinstance(idx, int) and 0 < idx <= len(research_sources):
+                    citations.append(Citation(
+                        type="inline",
+                        reference=f"Source {idx}",
+                        source_index=idx - 1,
+                        text=self._extract_citation_text(full_content, idx)
+                    ))
+            
             return {
-                **parsed,
-                'content': content_text,
-                'sources': [],
-                'citations': [],
+                'hook': hook,
+                'main_content': main_content,
+                'conclusion': conclusion,
+                'captions': captions,
+                'thumbnail_suggestions': thumbnail_suggestions,
+                'video_description': video_description,
+                'content': full_content,
+                'sources': research_sources,
+                'citations': citations,
                 'grounding_enabled': bool(research_sources),
                 'fallback_used': False
             }

--- a/backend/services/linkedin/content_generator_prompts/article_prompts.py
+++ b/backend/services/linkedin/content_generator_prompts/article_prompts.py
@@ -62,7 +62,7 @@ class ArticlePromptBuilder:
         - Strong conclusion with a call-to-action
 
         CONTENT QUALITY REQUIREMENTS:
-        - Include current industry statistics and trends (2024-2025)
+        - Include statistics and trends from the research sources provided
         - Provide real-world examples and case studies
         - Address common challenges and pain points
         - Offer actionable strategies and frameworks
@@ -82,6 +82,14 @@ class ArticlePromptBuilder:
         - Include pull quotes for key insights
 
         KEY SECTIONS TO COVER: {', '.join(request.key_sections) if request.key_sections else 'Industry overview, current challenges, emerging trends, practical solutions, future outlook'}
+
+        CITATION FORMAT:
+        - When you reference a specific data point, statistic, or claim from the research sources above, add [Source N] immediately after the claim, where N is the source number from the RESEARCH CONTEXT.
+        - Example: "According to Gartner [Source 1], AI adoption has increased by 40% year-over-year."
+        - Only cite sources for factual claims, statistics, data points, and specific findings — not for general industry knowledge.
+        - If you do not cite any sources, return an empty list for cited_source_indices.
+
+        ANTI-HALLUCINATION: Only make claims, statistics, and data points that are directly supported by the RESEARCH CONTEXT section above. Do not invent or fabricate statistics, dates, percentages, or specific findings. If the research does not contain a relevant data point, make a general observation instead of inventing a number.
 
         REMEMBER: This article should position the author as a thought leader while providing actionable insights that readers can immediately apply in their professional lives.
         """

--- a/backend/services/linkedin/content_generator_prompts/carousel_generator.py
+++ b/backend/services/linkedin/content_generator_prompts/carousel_generator.py
@@ -33,10 +33,17 @@ class CarouselGenerator:
             citations = []
             source_list = None
             if request.include_citations and research_sources:
-                # Extract citations from all slides
-                all_content = " ".join([slide['content'] for slide in content_result['slides']])
-                citations = self.citation_manager.extract_citations(all_content) if self.citation_manager else []
-                source_list = self.citation_manager.generate_source_list(research_sources) if self.citation_manager else None
+                # Prefer structured citations from LLM json_struct output
+                if content_result.get('citations'):
+                    citations = content_result['citations']
+                    logger.info(f"Using {len(citations)} structured citations from LLM output for carousel")
+                elif self.citation_manager:
+                    # Extract citations from all slides (backward compat for non-structured mode)
+                    all_content = " ".join([slide['content'] for slide in content_result['slides']])
+                    citations = self.citation_manager.extract_citations(all_content)
+                
+                if self.citation_manager:
+                    source_list = self.citation_manager.generate_source_list(research_sources)
             
             # Step 4: Analyze content quality
             quality_metrics = None

--- a/backend/services/linkedin/content_generator_prompts/carousel_prompts.py
+++ b/backend/services/linkedin/content_generator_prompts/carousel_prompts.py
@@ -58,6 +58,14 @@ class CarouselPromptBuilder:
 
         KEY INSIGHTS TO COVER: {', '.join(request.key_points) if request.key_points else 'Industry trends, challenges, solutions, and opportunities'}
 
+        CITATION FORMAT:
+        - When you reference a specific data point, statistic, or claim from the research sources above, add [Source N] immediately after the claim, where N is the source number from the RESEARCH CONTEXT.
+        - Example: "Enterprise AI adoption grew 40% year-over-year [Source 1]."
+        - Only cite sources for factual claims, statistics, data points, and specific findings — not for general industry knowledge.
+        - If you do not cite any sources, return an empty list for cited_source_indices.
+
+        ANTI-HALLUCINATION: Only make claims, statistics, and data points that are directly supported by the RESEARCH CONTEXT section above. Do not invent or fabricate statistics, dates, percentages, or specific findings. If the research does not contain a relevant data point, make a general observation instead of inventing a number.
+
         REMEMBER: Each slide should be visually appealing, informative, and encourage the viewer to continue reading. The carousel should provide immediate value while building anticipation for the next slide.
         """
         return prompt.strip()

--- a/backend/services/linkedin/content_generator_prompts/post_prompts.py
+++ b/backend/services/linkedin/content_generator_prompts/post_prompts.py
@@ -68,7 +68,7 @@ class PostPromptBuilder:
         - Use professional yet conversational language that encourages discussion
 
         ENGAGEMENT STRATEGY:
-        - Include 3-5 highly relevant, trending hashtags (mix of broad and niche)
+        - Include 3-5 highly relevant, industry-specific hashtags (mix of broad and niche)
         - Use line breaks and emojis strategically for readability
         - Encourage comments by asking for opinions or experiences
         - Make it shareable by providing genuine value
@@ -80,6 +80,14 @@ class PostPromptBuilder:
         - Include relevant emojis to enhance visual appeal
         - Break text into digestible paragraphs (2-3 lines max)
         - Leave space for engagement (don't fill the entire character limit)
+
+        CITATION FORMAT:
+        - When you reference a specific data point, statistic, or claim from the research sources above, add [Source N] immediately after the claim, where N is the source number from the RESEARCH CONTEXT.
+        - Example: "According to Gartner [Source 1], AI adoption has increased by 40% year-over-year."
+        - Only cite sources for factual claims, statistics, data points, and specific findings — not for general industry knowledge.
+        - If you do not cite any sources, return an empty list for cited_source_indices.
+
+        ANTI-HALLUCINATION: Only make claims, statistics, and data points that are directly supported by the RESEARCH CONTEXT section above. Do not invent or fabricate statistics, dates, percentages, or specific findings. If the research does not contain a relevant data point, make a general observation instead of inventing a number.
 
         REMEMBER: This post should position the author as a knowledgeable industry expert while being genuinely helpful to the audience.
         """

--- a/backend/services/linkedin/content_generator_prompts/video_script_generator.py
+++ b/backend/services/linkedin/content_generator_prompts/video_script_generator.py
@@ -36,10 +36,18 @@ class VideoScriptGenerator:
             # Step 3: Add citations if requested
             citations = []
             source_list = None
-            if request.include_citations and research_sources and self.citation_manager:
-                all_content = f"{content_result['hook']} {' '.join([scene['content'] for scene in content_result['main_content']])} {content_result['conclusion']}"
-                citations = self.citation_manager.extract_citations(all_content)
-                source_list = self.citation_manager.generate_source_list(research_sources)
+            if request.include_citations and research_sources:
+                # Prefer structured citations from LLM json_struct output
+                if content_result.get('citations'):
+                    citations = content_result['citations']
+                    logger.info(f"Using {len(citations)} structured citations from LLM output for video script")
+                elif self.citation_manager:
+                    # Extract citations from all content (backward compat for non-structured mode)
+                    all_content = f"{content_result['hook']} {' '.join([scene['content'] for scene in content_result['main_content']])} {content_result['conclusion']}"
+                    citations = self.citation_manager.extract_citations(all_content)
+                
+                if self.citation_manager:
+                    source_list = self.citation_manager.generate_source_list(research_sources)
             
             # Step 4: Analyze content quality
             quality_metrics = None

--- a/backend/services/linkedin/content_generator_prompts/video_script_prompts.py
+++ b/backend/services/linkedin/content_generator_prompts/video_script_prompts.py
@@ -39,7 +39,7 @@ class VideoScriptPromptBuilder:
         - Conclusion (Last 5 seconds): Clear call-to-action and engagement prompt
 
         CONTENT REQUIREMENTS:
-        - Start with a surprising statistic, question, or bold statement
+        - Start with a compelling statistic from the research sources, a provocative question, or bold statement
         - Include specific examples and case studies from the industry
         - Use conversational, engaging language that feels natural when spoken
         - Include 2-3 actionable takeaways viewers can implement immediately
@@ -69,6 +69,14 @@ class VideoScriptPromptBuilder:
         - End with clear next steps and hashtag suggestions
 
         KEY INSIGHTS TO COVER: {', '.join(request.key_points) if request.key_points else 'Industry trends, challenges, solutions, and opportunities'}
+
+        CITATION FORMAT:
+        - When you reference a specific data point, statistic, or claim from the research sources above, add [Source N] immediately after the claim, where N is the source number from the RESEARCH CONTEXT.
+        - Example: "Did you know enterprise AI adoption grew 40% last year? [Source 1]"
+        - Only cite sources for factual claims, statistics, data points, and specific findings — not for general industry knowledge.
+        - If you do not cite any sources, return an empty list for cited_source_indices.
+
+        ANTI-HALLUCINATION: Only make claims, statistics, and data points that are directly supported by the RESEARCH CONTEXT section above. Do not invent or fabricate statistics, dates, percentages, or specific findings. If the research does not contain a relevant data point, make a general observation instead of inventing a number.
 
         REMEMBER: This video should provide immediate value while building the creator's authority. Every second should count toward engagement and viewer retention.
         """

--- a/frontend/src/components/LinkedInWriter/LinkedInWriter.tsx
+++ b/frontend/src/components/LinkedInWriter/LinkedInWriter.tsx
@@ -414,8 +414,6 @@ Always use the most appropriate tool for the user's request.`.trim();
         showPreferencesModal={showPreferencesModal}
         onPreferencesModalChange={setShowPreferencesModal}
         onPreferencesChange={handlePreferencesChange}
-        onClearHistory={handleClearHistory}
-        getHistoryLength={getHistoryLength}
         hasDraft={!!draft}
         onResetDraft={handleClear}
       />
@@ -438,7 +436,7 @@ Always use the most appropriate tool for the user's request.`.trim();
 
 
       {/* Main Content */}
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', backgroundColor: '#ffffff' }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', backgroundColor: '#ffffff' }}>
         {/* Loading Indicator */}
         <LoadingIndicator
           isGenerating={isGenerating}

--- a/frontend/src/components/LinkedInWriter/LinkedInWriter.tsx
+++ b/frontend/src/components/LinkedInWriter/LinkedInWriter.tsx
@@ -420,12 +420,13 @@ Always use the most appropriate tool for the user's request.`.trim();
 
       {/* Lightweight progress tracker under header */}
       <div style={{ 
-        padding: '6px 16px',
-        transition: 'all 300ms ease',
+        padding: '4px 16px',
+        transition: 'opacity 400ms ease, transform 400ms ease',
         opacity: progressActive || progressSteps.length > 0 ? 1 : 0,
-        transform: progressActive || progressSteps.length > 0 ? 'translateY(0)' : 'translateY(-10px)',
-        height: progressActive || progressSteps.length > 0 ? 'auto' : 0,
-        overflow: 'hidden'
+        transform: progressActive || progressSteps.length > 0 ? 'translateY(0)' : 'translateY(-8px)',
+        maxHeight: progressActive || progressSteps.length > 0 ? '2000px' : 0,
+        overflow: 'hidden',
+        pointerEvents: progressActive || progressSteps.length > 0 ? 'auto' : 'none'
       }}>
         <ProgressTracker steps={progressSteps as ProgressStep[]} active={progressActive} />
       </div>

--- a/frontend/src/components/LinkedInWriter/components/ContentEditor.tsx
+++ b/frontend/src/components/LinkedInWriter/components/ContentEditor.tsx
@@ -7,6 +7,7 @@ import {
   ContentPreviewHeaderWithModals,
   ContentDisplayArea
 } from '../../TextEditor';
+import { GroundingDataDisplay } from './GroundingDataDisplay';
 import { readPrefs } from '../utils/linkedInWriterUtils';
 import { useLinkedInSelectionImage } from '../hooks/useLinkedInSelectionImage';
 import { useLinkedInSelectionVideo } from '../hooks/useLinkedInSelectionVideo';
@@ -429,6 +430,14 @@ const ContentEditor: React.FC<ContentEditorProps> = ({
               onTriggerSuggestion={triggerSuggestion}
               onContinueWriting={() => handleManualContinue(draft)}
               onInsertWithPreview={handleInsertAtCaret}
+            />
+
+            {/* Research Sources & Citations Section */}
+            <GroundingDataDisplay
+              researchSources={researchSources || []}
+              citations={citations || []}
+              qualityMetrics={qualityMetrics}
+              groundingEnabled={groundingEnabled || false}
             />
           </div>
         )}

--- a/frontend/src/components/LinkedInWriter/components/ContentEditor.tsx
+++ b/frontend/src/components/LinkedInWriter/components/ContentEditor.tsx
@@ -376,7 +376,7 @@ const ContentEditor: React.FC<ContentEditorProps> = ({
   }, [draft, showPreview, onPreviewToggle]);
 
   return (
-    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflowY: 'auto' }}>
       {/* Predictive Diff Preview */}
       <DiffPreviewModal
         isPreviewing={isPreviewing}
@@ -387,15 +387,14 @@ const ContentEditor: React.FC<ContentEditorProps> = ({
       />
 
       {/* Full Width Content Preview */}
-      <div style={{ flex: 1, padding: '24px' }}>
+      <div style={{ flex: 1, padding: '24px', overflow: 'visible' }}>
         {/* Content Preview */}
         {showPreview && (
           <div style={{
             border: '1px solid #e1f5fe',
             borderRadius: '8px',
             background: '#f8fdff',
-            overflow: 'visible',
-            minHeight: '500px'
+            overflow: 'visible'
           }}>
             {/* Content Preview Header */}
             <ContentPreviewHeaderWithModals

--- a/frontend/src/components/LinkedInWriter/components/GroundingDataDisplay.tsx
+++ b/frontend/src/components/LinkedInWriter/components/GroundingDataDisplay.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ResearchSource, Citation, ContentQualityMetrics } from '../../../services/linkedInWriterApi';
 
 interface GroundingDataDisplayProps {
@@ -7,6 +7,145 @@ interface GroundingDataDisplayProps {
   qualityMetrics?: ContentQualityMetrics;
   groundingEnabled: boolean;
 }
+
+const SourceCard: React.FC<{ source: ResearchSource; index: number }> = ({ source, index }) => {
+  const [showFullContent, setShowFullContent] = useState(false);
+
+  const formatScore = (score: number) => `${(score * 100).toFixed(0)}%`;
+
+  return (
+    <div style={{
+      padding: '16px',
+      backgroundColor: 'white',
+      borderRadius: '8px',
+      border: '1px solid #e5e7eb',
+      borderLeft: '4px solid #0a66c2',
+      boxShadow: '0 1px 3px rgba(0,0,0,0.1)'
+    }}>
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'flex-start',
+        marginBottom: '8px'
+      }}>
+        <h5 style={{
+          margin: 0,
+          fontSize: '14px',
+          fontWeight: '600',
+          color: '#1f2937',
+          flex: 1,
+          marginRight: '8px'
+        }}>
+          {source.title}
+        </h5>
+        <div style={{
+          fontSize: '11px',
+          color: '#6b7280',
+          backgroundColor: '#f3f4f6',
+          padding: '4px 10px',
+          borderRadius: '12px',
+          whiteSpace: 'nowrap'
+        }}>
+          Source {index + 1}
+        </div>
+      </div>
+
+      <div style={{
+        fontSize: '13px',
+        color: '#6b7280',
+        marginBottom: '10px',
+        wordBreak: 'break-all'
+      }}>
+        <a
+          href={source.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{
+            color: '#0a66c2',
+            textDecoration: 'none'
+          }}
+        >
+          ↗ {source.url}
+        </a>
+      </div>
+
+      {/* Content preview (expandable) */}
+      {source.content && (
+        <div style={{ marginBottom: '10px' }}>
+          <div style={{
+            fontSize: '13px',
+            color: '#4b5563',
+            lineHeight: '1.5',
+            ...(!showFullContent ? {
+              maxHeight: '60px',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis'
+            } : {})
+          }}>
+            {source.content}
+          </div>
+          {source.content.length > 200 && (
+            <button
+              onClick={() => setShowFullContent(!showFullContent)}
+              style={{
+                background: 'none',
+                border: 'none',
+                color: '#0a66c2',
+                cursor: 'pointer',
+                fontSize: '12px',
+                padding: '4px 0',
+                fontWeight: '600'
+              }}
+            >
+              {showFullContent ? 'Show less' : 'Show full text'}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Source type badge and scores */}
+      <div style={{
+        display: 'flex',
+        gap: '8px',
+        flexWrap: 'wrap',
+        fontSize: '11px'
+      }}>
+        {source.source_type && (
+          <span style={{
+            backgroundColor: '#eef6ff',
+            padding: '4px 8px',
+            borderRadius: '6px',
+            fontWeight: '600',
+            color: '#0a66c2'
+          }}>
+            {source.source_type.replace('_', ' ')}
+          </span>
+        )}
+        {source.relevance_score && (
+          <span style={{
+            backgroundColor: '#f0fdf4',
+            padding: '4px 8px',
+            borderRadius: '6px',
+            color: '#166534'
+          }}>
+            Relevance: {formatScore(source.relevance_score)}
+          </span>
+        )}
+        {source.credibility_score && (
+          <span style={{
+            backgroundColor: '#fefce8',
+            padding: '4px 8px',
+            borderRadius: '6px',
+            color: '#854d0e'
+          }}>
+            Credibility: {formatScore(source.credibility_score)}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
 
 export const GroundingDataDisplay: React.FC<GroundingDataDisplayProps> = ({
   researchSources,
@@ -18,13 +157,6 @@ export const GroundingDataDisplay: React.FC<GroundingDataDisplayProps> = ({
   if (!groundingEnabled || researchSources.length === 0) {
     return null;
   }
-
-  const formatScore = (score: number) => `${(score * 100).toFixed(0)}%`;
-  const getQualityColor = (score: number) => {
-    if (score >= 0.8) return '#10b981'; // Green
-    if (score >= 0.6) return '#f59e0b'; // Yellow
-    return '#ef4444'; // Red
-  };
 
   return (
     <div style={{
@@ -40,7 +172,6 @@ export const GroundingDataDisplay: React.FC<GroundingDataDisplayProps> = ({
       fontSize: '16px'
     }}>
       {/* Header */}
- 
       <div style={{
         display: 'flex',
         alignItems: 'center',
@@ -58,7 +189,7 @@ export const GroundingDataDisplay: React.FC<GroundingDataDisplayProps> = ({
           justifyContent: 'center',
           marginRight: '12px'
         }}>
-          <span style={{ color: 'white', fontSize: '14px', fontWeight: 'bold' }}>✓</span>
+          <span style={{ color: 'white', fontSize: '14px', fontWeight: 'bold' }}>S</span>
         </div>
         <h3 style={{
           margin: 0,
@@ -66,99 +197,26 @@ export const GroundingDataDisplay: React.FC<GroundingDataDisplayProps> = ({
           fontSize: '18px',
           fontWeight: '600'
         }}>
-          AI-Generated Content with Factual Grounding
+          Research Sources & Citations
         </h3>
       </div>
- 
-      {/* Note: Quality chips moved to header bar; keep detail cards minimal here if needed */}
- 
+
       {/* Research Sources */}
       <div style={{ marginBottom: '24px' }}>
         <h4 style={{
           margin: '0 0 16px 0',
-          fontSize: '16px',
+          fontSize: '15px',
           fontWeight: '600',
           color: '#374151'
         }}>
-          Research Sources ({researchSources.length})
+          Sources Used ({researchSources.length})
         </h4>
         <div style={{
           display: 'grid',
           gap: '12px'
         }}>
           {researchSources.map((source, index) => (
-            <div key={index} style={{
-              padding: '16px',
-              backgroundColor: 'white',
-              borderRadius: '8px',
-              border: '1px solid #e5e7eb',
-              boxShadow: '0 1px 3px rgba(0,0,0,0.1)'
-            }}>
-              <div style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'flex-start',
-                marginBottom: '8px'
-              }}>
-                <h5 style={{
-                  margin: '0 0 8px 0',
-                  fontSize: '14px',
-                  fontWeight: '600',
-                  color: '#1f2937'
-                }}>
-                  {source.title}
-                </h5>
-                <div style={{
-                  fontSize: '12px',
-                  color: '#6b7280',
-                  backgroundColor: '#f3f4f6',
-                  padding: '4px 8px',
-                  borderRadius: '12px'
-                }}>
-                  Source {index + 1}
-                </div>
-              </div>
-              
-              <div style={{
-                fontSize: '13px',
-                color: '#6b7280',
-                marginBottom: '8px',
-                wordBreak: 'break-all'
-              }}>
-                <a
-                  href={source.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{
-                    color: '#0a66c2',
-                    textDecoration: 'none'
-                  }}
-                >
-                  {source.url}
-                </a>
-              </div>
-
-              {/* Source Metrics */}
-              <div style={{
-                display: 'flex',
-                gap: '16px',
-                fontSize: '12px',
-                color: '#6b7280'
-              }}>
-                {source.relevance_score && (
-                  <span>Relevance: {formatScore(source.relevance_score)}</span>
-                )}
-                {source.credibility_score && (
-                  <span>Credibility: {formatScore(source.credibility_score)}</span>
-                )}
-                {source.domain_authority && (
-                  <span>Authority: {formatScore(source.domain_authority)}</span>
-                )}
-                {source.source_type && (
-                  <span>Type: {source.source_type.replace('_', ' ')}</span>
-                )}
-              </div>
-            </div>
+            <SourceCard key={index} source={source} index={index} />
           ))}
         </div>
       </div>
@@ -167,15 +225,15 @@ export const GroundingDataDisplay: React.FC<GroundingDataDisplayProps> = ({
       {citations.length > 0 && (
         <div>
           <h4 style={{
-            margin: '0 0 16px 0',
-            fontSize: '16px',
+            margin: '0 0 12px 0',
+            fontSize: '15px',
             fontWeight: '600',
             color: '#374151'
           }}>
             Inline Citations ({citations.length})
           </h4>
           <div style={{
-            backgroundColor: 'white',
+            backgroundColor: '#f9fafb',
             borderRadius: '8px',
             border: '1px solid #e5e7eb',
             padding: '16px'
@@ -185,24 +243,25 @@ export const GroundingDataDisplay: React.FC<GroundingDataDisplayProps> = ({
               color: '#6b7280',
               marginBottom: '12px'
             }}>
-              The content includes {citations.length} inline citations linking to research sources.
+              The content above includes {citations.length} inline {citations.length === 1 ? 'citation' : 'citations'} linking to research sources. Hover over <sup>[N]</sup> markers in the text for details.
             </div>
             <div style={{
               display: 'grid',
-              gap: '8px'
+              gap: '6px'
             }}>
               {citations.map((citation, index) => (
                 <div key={index} style={{
                   padding: '8px 12px',
-                  backgroundColor: '#f9fafb',
+                  backgroundColor: 'white',
                   borderRadius: '6px',
                   fontSize: '13px',
-                  color: '#374151'
+                  color: '#374151',
+                  border: '1px solid #f3f4f6'
                 }}>
-                  <strong>{citation.reference}</strong>
+                  <strong style={{ color: '#0a66c2' }}>{citation.reference}</strong>
                   {citation.text && (
                     <span style={{ marginLeft: '8px', color: '#6b7280' }}>
-                      "{citation.text.substring(0, 100)}..."
+                      "{citation.text.substring(0, 100)}{citation.text.length > 100 ? '..."' : '"'}
                     </span>
                   )}
                 </div>
@@ -218,11 +277,10 @@ export const GroundingDataDisplay: React.FC<GroundingDataDisplayProps> = ({
         paddingTop: '16px',
         borderTop: '1px solid #e5e7eb',
         fontSize: '12px',
-        color: '#6b7280',
+        color: '#9ca3af',
         textAlign: 'center'
       }}>
-        This content was generated using AI with real-time web research and factual grounding.
-        All claims are supported by current, verifiable sources.
+        Content generated with AI using real-time web research. Claims backed by verifiable sources.
       </div>
     </div>
   );

--- a/frontend/src/components/LinkedInWriter/components/Header.tsx
+++ b/frontend/src/components/LinkedInWriter/components/Header.tsx
@@ -14,8 +14,6 @@ interface HeaderProps {
   showPreferencesModal: boolean;
   onPreferencesModalChange: (show: boolean) => void;
   onPreferencesChange: (prefs: Partial<LinkedInPreferences>) => void;
-  onClearHistory: () => void;
-  getHistoryLength: () => number;
   hasDraft: boolean;
   onResetDraft: () => void;
 }
@@ -26,8 +24,6 @@ export const Header: React.FC<HeaderProps> = ({
   showPreferencesModal,
   onPreferencesModalChange,
   onPreferencesChange,
-  onClearHistory,
-  getHistoryLength,
   hasDraft,
   onResetDraft
 }) => {
@@ -417,6 +413,59 @@ export const Header: React.FC<HeaderProps> = ({
                     </div>
                   </div>
                   
+                  {/* Quick Actions */}
+                  <div style={{ borderTop: '1px solid #e9ecef', paddingTop: '12px', marginTop: '12px' }}>
+                    <div style={{ marginBottom: '8px', fontWeight: 600, color: '#333', fontSize: '12px' }}>Quick Actions</div>
+                    <div style={{ display: 'flex', gap: '8px' }}>
+                      <button
+                        onClick={() => { onPreferencesModalChange(false); window.dispatchEvent(new CustomEvent('linkedinwriter:showTodaysTasks')); }}
+                        style={{
+                          flex: 1,
+                          padding: '8px 12px',
+                          background: '#f8f9fa',
+                          color: '#333',
+                          border: '1px solid #e2e8f0',
+                          borderRadius: 6,
+                          cursor: 'pointer',
+                          fontSize: 12,
+                          fontWeight: 600,
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 4,
+                          transition: 'all 0.2s ease'
+                        }}
+                        onMouseEnter={(e) => { e.currentTarget.style.background = '#e3f2fd'; e.currentTarget.style.borderColor = '#0a66c2'; }}
+                        onMouseLeave={(e) => { e.currentTarget.style.background = '#f8f9fa'; e.currentTarget.style.borderColor = '#e2e8f0'; }}
+                        title="View today's tasks"
+                      >
+                        📅 Today's Tasks
+                      </button>
+                      <button
+                        onClick={() => { onPreferencesModalChange(false); setShowBrainstormModal(true); }}
+                        style={{
+                          flex: 1,
+                          padding: '8px 12px',
+                          background: '#f8f9fa',
+                          color: '#333',
+                          border: '1px solid #e2e8f0',
+                          borderRadius: 6,
+                          cursor: 'pointer',
+                          fontSize: 12,
+                          fontWeight: 600,
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 4,
+                          transition: 'all 0.2s ease'
+                        }}
+                        onMouseEnter={(e) => { e.currentTarget.style.background = '#e3f2fd'; e.currentTarget.style.borderColor = '#0a66c2'; }}
+                        onMouseLeave={(e) => { e.currentTarget.style.background = '#f8f9fa'; e.currentTarget.style.borderColor = '#e2e8f0'; }}
+                        title="Brainstorm content ideas"
+                      >
+                        💡 Brainstorm Ideas
+                      </button>
+                    </div>
+                  </div>
+
                   <style>{`
                     @keyframes slideIn {
                       from { opacity: 0; transform: translateY(-10px); }
@@ -431,67 +480,6 @@ export const Header: React.FC<HeaderProps> = ({
         </div>
         
         <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
-          {/* Today's Tasks Button */}
-          <button
-            onClick={() => window.dispatchEvent(new CustomEvent('linkedinwriter:showTodaysTasks'))}
-            style={{
-              padding: '8px 16px',
-              background: 'rgba(255, 255, 255, 0.1)',
-              color: 'white',
-              border: '1px solid rgba(255, 255, 255, 0.2)',
-              borderRadius: 6,
-              cursor: 'pointer',
-              fontSize: 14,
-              fontWeight: 500,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6
-            }}
-            title="View today's tasks"
-          >
-            📅 Today's Tasks
-          </button>
-          
-          {/* Brainstorm Ideas Button */}
-          <button
-            onClick={() => setShowBrainstormModal(true)}
-            style={{
-              padding: '8px 16px',
-              background: 'rgba(255, 255, 255, 0.1)',
-              color: 'white',
-              border: '1px solid rgba(255, 255, 255, 0.2)',
-              borderRadius: 6,
-              cursor: 'pointer',
-              fontSize: 14,
-              fontWeight: 500,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6
-            }}
-            title="Brainstorm content ideas"
-          >
-            💡 Brainstorm Ideas
-          </button>
-          
-          {/* Clear Memory Button */}
-          <button
-            onClick={onClearHistory}
-            style={{
-              padding: '8px 16px',
-              background: 'rgba(255, 255, 255, 0.1)',
-              color: 'white',
-              border: '1px solid rgba(255, 255, 255, 0.2)',
-              borderRadius: 6,
-              cursor: 'pointer',
-              fontSize: 14,
-              fontWeight: 500
-            }}
-            title={`Clear chat memory (${getHistoryLength()} messages)`}
-          >
-            Clear Memory ({getHistoryLength()})
-          </button>
-          
-          {/* Shared Header Controls - Usage Stats & User Dropdown */}
           <HeaderControls colorMode="light" showAlerts={true} showUser={true} />
         </div>
       </div>

--- a/frontend/src/components/LinkedInWriter/components/LoadingIndicator.tsx
+++ b/frontend/src/components/LinkedInWriter/components/LoadingIndicator.tsx
@@ -15,34 +15,48 @@ export const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
 
   return (
     <div style={{
-      marginBottom: '24px',
-      padding: '16px',
-      background: '#f8f9fa',
-      border: '1px solid #e9ecef',
-      borderRadius: '8px',
+      marginBottom: '20px',
+      padding: '16px 20px',
+      background: 'rgba(255,255,255,0.7)',
+      backdropFilter: 'blur(6px)',
+      WebkitBackdropFilter: 'blur(6px)',
+      border: '1px solid rgba(10,102,194,0.08)',
+      borderRadius: '10px',
       textAlign: 'center'
     }}>
-      <div style={{ marginBottom: '8px' }}>
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '10px',
+        marginBottom: '6px'
+      }}>
         <div style={{
-          width: '20px',
-          height: '20px',
-          border: '2px solid #e9ecef',
+          width: '18px',
+          height: '18px',
+          border: '2px solid #e2e8f0',
           borderTop: '2px solid #0a66c2',
           borderRadius: '50%',
-          animation: 'spin 1s linear infinite',
-          margin: '0 auto'
+          animation: 'liSpin 1s linear infinite',
+          flexShrink: 0
         }} />
-      </div>
-      <div style={{ color: '#666', fontSize: '14px' }}>
-        {loadingMessage || 'Generating content...'}
-      </div>
-      {currentAction && (
-        <div style={{ color: '#999', fontSize: '12px', marginTop: '4px' }}>
-          Action: {currentAction}
+        <div style={{
+          color: '#0f172a',
+          fontSize: '14px',
+          fontWeight: '500'
+        }}>
+          {loadingMessage || 'Generating content...'}
         </div>
-      )}
+      </div>
+      <div style={{
+        fontSize: '12px',
+        color: '#94a3b8',
+        lineHeight: '1.5'
+      }}>
+        This typically takes 30-60 seconds. We are researching, writing, and optimizing your content with source citations.
+      </div>
       <style>{`
-        @keyframes spin {
+        @keyframes liSpin {
           0% { transform: rotate(0deg); }
           100% { transform: rotate(360deg); }
         }
@@ -50,3 +64,5 @@ export const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
     </div>
   );
 };
+
+export default LoadingIndicator;

--- a/frontend/src/components/LinkedInWriter/components/ProgressTracker.tsx
+++ b/frontend/src/components/LinkedInWriter/components/ProgressTracker.tsx
@@ -16,232 +16,253 @@ interface ProgressTrackerProps {
   active: boolean;
 }
 
+/* Educational descriptions shown beneath each step's label */
+const STEP_EDUCATION: Record<string, string> = {
+  personalize: 'We analyze your topic, industry, and target audience to tailor the content for maximum LinkedIn engagement and relevance.',
+  prepare_queries: 'Smart research queries are crafted to find authoritative, up-to-date sources — ensuring your content is built on reliable data.',
+  research: 'We search across trusted sources to collect statistics, trends, case studies, and insights that make your content credible and valuable.',
+  grounding: 'Every claim, statistic, and data point is mapped back to its original source — this is what makes your content trustworthy and authoritative.',
+  content_generation: 'Your content is written with LinkedIn-optimized structure: strong hooks, scannable formatting, professional tone, and engagement-driving elements.',
+  citations: 'Factual claims are linked to their sources with visible [Source N] markers — building transparency and credibility with your audience.',
+  quality_analysis: 'The content is reviewed for engagement potential, readability, LinkedIn best practices, and alignment with your chosen tone and audience.',
+  finalize: 'Final formatting tweaks, hashtag integration, and platform-specific optimizations are applied before delivering the result.'
+};
+
 export const ProgressTracker: React.FC<ProgressTrackerProps> = ({ steps, active }) => {
   if (!steps || steps.length === 0) return null;
   
   const completedSteps = steps.filter(step => step.status === 'completed').length;
   const progressPercentage = Math.round((completedSteps / steps.length) * 100);
-  
+
   return (
     <div style={{
       marginBottom: '24px',
       padding: '20px',
-      borderRadius: '16px',
-      border: '1px solid rgba(10,102,194,0.15)',
-      background: 'linear-gradient(180deg, rgba(255,255,255,0.98), rgba(250,253,255,0.98))',
-      boxShadow: '0 8px 32px rgba(10,102,194,0.12)',
+      borderRadius: '12px',
+      border: '1px solid rgba(10,102,194,0.1)',
+      background: 'rgba(255,255,255,0.85)',
+      backdropFilter: 'blur(8px)',
+      WebkitBackdropFilter: 'blur(8px)',
+      boxShadow: '0 2px 12px rgba(10,102,194,0.06)',
       position: 'relative',
       overflow: 'hidden'
     }}>
-      {/* Header with progress percentage */}
+      {/* Header */}
       <div style={{
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
-        marginBottom: '20px',
-        paddingBottom: '16px',
-        borderBottom: '1px solid rgba(10,102,194,0.1)'
+        marginBottom: '16px',
+        paddingBottom: '12px',
+        borderBottom: '1px solid rgba(10,102,194,0.06)'
       }}>
+        <div>
+          <div style={{
+            fontSize: '15px',
+            fontWeight: '600',
+            color: '#0f172a',
+            marginBottom: '2px'
+          }}>
+            Content Generation
+          </div>
+          <div style={{
+            fontSize: '12px',
+            color: '#64748b',
+            lineHeight: '1.4'
+          }}>
+            {active
+              ? 'Researching, writing, and optimizing your content'
+              : 'Generation complete — your content is ready below.'}
+          </div>
+        </div>
         <div style={{
-          fontSize: '16px',
+          fontSize: '13px',
           fontWeight: '600',
-          color: '#0f172a'
+          color: progressPercentage === 100 ? '#10b981' : '#0a66c2',
+          padding: '4px 12px',
+          background: progressPercentage === 100
+            ? 'rgba(16,185,129,0.08)'
+            : 'rgba(10,102,194,0.08)',
+          borderRadius: '20px',
+          whiteSpace: 'nowrap'
         }}>
-          LinkedIn Content Generation
+          {progressPercentage}%
         </div>
-        <div style={{
-          fontSize: '14px',
-          fontWeight: '500',
-          color: '#0a66c2',
-          padding: '6px 12px',
-          background: 'rgba(10,102,194,0.1)',
-          borderRadius: '20px'
-        }}>
-          {progressPercentage}% Complete
-        </div>
-      </div>
-      
-      {/* Progress bar */}
-      <div style={{
-        width: '100%',
-        height: '6px',
-        background: '#e2e8f0',
-        borderRadius: '3px',
-        marginBottom: '20px',
-        overflow: 'hidden'
-      }}>
-        <div style={{
-          width: `${progressPercentage}%`,
-          height: '100%',
-          background: 'linear-gradient(90deg, #0a66c2, #3b82f6)',
-          borderRadius: '3px',
-          transition: 'width 0.5s ease',
-          boxShadow: '0 0 8px rgba(10,102,194,0.3)'
-        }} />
       </div>
       
       {/* Steps */}
       <div style={{
         display: 'flex',
         flexDirection: 'column',
-        gap: '16px'
+        gap: '4px'
       }}>
-        {steps.map((step, idx) => (
-          <div key={step.id} style={{
-            display: 'flex',
-            alignItems: 'flex-start',
-            gap: '16px',
-            padding: '16px',
-            borderRadius: '12px',
-            background: step.status === 'active' ? 'rgba(10,102,194,0.05)' : 'transparent',
-            border: step.status === 'active' ? '1px solid rgba(10,102,194,0.2)' : '1px solid transparent',
-            transition: 'all 300ms ease',
-            position: 'relative'
-          }}>
-            {/* Step indicator */}
-            <div style={{
+        {steps.map((step, idx) => {
+          const isLast = idx === steps.length - 1;
+          return (
+            <div key={step.id} style={{
               display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: '32px',
-              height: '32px',
-              borderRadius: '50%',
-              background: step.status === 'completed' ? '#10b981' : 
-                         step.status === 'active' ? '#0a66c2' : 
-                         step.status === 'error' ? '#ef4444' : '#cbd5e1',
-              color: 'white',
-              fontSize: '14px',
-              fontWeight: '600',
-              flexShrink: 0,
+              gap: '12px',
+              padding: '10px 12px',
+              borderRadius: '8px',
+              background: step.status === 'active' ? 'rgba(10,102,194,0.04)' : 'transparent',
+              transition: 'all 300ms ease',
               position: 'relative'
             }}>
-              {step.status === 'completed' ? '✓' : 
-               step.status === 'active' ? '●' : 
-               step.status === 'error' ? '✕' : (idx + 1)}
-              
-              {/* Active step glow effect */}
-              {step.status === 'active' && (
-                <div style={{
-                  position: 'absolute',
-                  top: '-4px',
-                  left: '-4px',
-                  right: '-4px',
-                  bottom: '-4px',
-                  borderRadius: '50%',
-                  background: 'radial-gradient(circle, rgba(10,102,194,0.3) 0%, transparent 70%)',
-                  animation: 'pulse 2s ease-in-out infinite alternate',
-                  zIndex: -1
-                }} />
-              )}
-            </div>
-            
-            {/* Step content */}
-            <div style={{ flex: 1 }}>
+              {/* Step indicator + connector line */}
               <div style={{
-                fontSize: '14px',
-                fontWeight: '600',
-                color: step.status === 'active' ? '#0a66c2' : 
-                       step.status === 'completed' ? '#10b981' : 
-                       step.status === 'error' ? '#ef4444' : '#64748b',
-                marginBottom: '4px',
-                transition: 'color 200ms ease'
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                flexShrink: 0,
+                width: '24px'
               }}>
-                {step.label}
+                <div style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: '24px',
+                  height: '24px',
+                  borderRadius: '50%',
+                  background: step.status === 'completed' ? '#10b981' : 
+                             step.status === 'active' ? '#0a66c2' : 
+                             step.status === 'error' ? '#ef4444' : '#e2e8f0',
+                  color: step.status === 'completed' || step.status === 'active' || step.status === 'error' ? 'white' : '#94a3b8',
+                  fontSize: '11px',
+                  fontWeight: '700',
+                  transition: 'all 300ms ease'
+                }}>
+                  {step.status === 'completed' ? (
+                    <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
+                      <path d="M3 7.5L6 10.5L11 3.5" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                  ) : step.status === 'active' ? (
+                    <div style={{
+                      width: '8px',
+                      height: '8px',
+                      borderRadius: '50%',
+                      background: 'white',
+                      animation: 'progressPulse 1.5s ease-in-out infinite'
+                    }} />
+                  ) : step.status === 'error' ? (
+                    <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
+                      <path d="M4 4L10 10M10 4L4 10" stroke="white" strokeWidth="2" strokeLinecap="round"/>
+                    </svg>
+                  ) : (
+                    <span>{idx + 1}</span>
+                  )}
+                </div>
+                {/* Connector line to next step */}
+                {!isLast && (
+                  <div style={{
+                    width: '1.5px',
+                    flex: 1,
+                    minHeight: '6px',
+                    background: step.status === 'completed' ? '#10b981' : '#e2e8f0',
+                    marginTop: '3px',
+                    transition: 'background 300ms ease'
+                  }} />
+                )}
               </div>
               
-              {/* Step message */}
-              {step.message && (
+              {/* Step content */}
+              <div style={{ flex: 1, minWidth: 0 }}>
                 <div style={{
                   fontSize: '13px',
-                  color: step.status === 'active' ? '#475569' : '#94a3b8',
-                  lineHeight: '1.4',
-                  fontStyle: step.status === 'active' ? 'normal' : 'italic'
+                  fontWeight: '500',
+                  color: step.status === 'active' ? '#0a66c2' : 
+                         step.status === 'completed' ? '#0f172a' : 
+                         step.status === 'error' ? '#ef4444' : '#94a3b8',
+                  marginBottom: step.status === 'active' ? '4px' : '0',
+                  transition: 'color 200ms ease'
                 }}>
-                  {step.message}
+                  {step.label}
                 </div>
-              )}
-              
-              {/* Step details */}
-              {step.details && step.status === 'completed' && (
-                <div style={{
-                  marginTop: '8px',
-                  padding: '8px 12px',
-                  background: 'rgba(16,185,129,0.1)',
-                  borderRadius: '8px',
-                  fontSize: '12px',
-                  color: '#065f46'
-                }}>
-                  {Object.entries(step.details).map(([key, value]) => (
-                    <div key={key} style={{ marginBottom: '4px' }}>
-                      <strong>{key}:</strong> {String(value)}
-                    </div>
-                  ))}
-                </div>
-              )}
+                
+                {/* Educational description — shown only while active */}
+                {step.status === 'active' && (
+                  <div style={{
+                    fontSize: '12px',
+                    color: '#64748b',
+                    lineHeight: '1.5'
+                  }}>
+                    {STEP_EDUCATION[step.id] || step.message || ''}
+                  </div>
+                )}
+                
+                {/* Step message */}
+                {step.message && step.status !== 'active' && (
+                  <div style={{
+                    fontSize: '12px',
+                    color: '#94a3b8',
+                    lineHeight: '1.4',
+                    marginTop: '2px'
+                  }}>
+                    {step.message}
+                  </div>
+                )}
+                
+                {/* Step details */}
+                {step.details && step.status === 'completed' && (
+                  <div style={{
+                    marginTop: '4px',
+                    padding: '4px 8px',
+                    background: 'rgba(16,185,129,0.06)',
+                    borderRadius: '4px',
+                    fontSize: '11px',
+                    color: '#065f46'
+                  }}>
+                    {Object.entries(step.details).map(([key, value]) => (
+                      <div key={key} style={{ marginBottom: '1px' }}>
+                        <strong>{key}:</strong> {String(value)}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
             </div>
-            
-            {/* Status indicator */}
-            <div style={{
-              padding: '4px 8px',
-              borderRadius: '12px',
-              fontSize: '11px',
-              fontWeight: '500',
-              textTransform: 'uppercase',
-              letterSpacing: '0.5px',
-              background: step.status === 'completed' ? 'rgba(16,185,129,0.1)' :
-                         step.status === 'active' ? 'rgba(10,102,194,0.1)' :
-                         step.status === 'error' ? 'rgba(239,68,68,0.1)' : 'rgba(203,213,225,0.1)',
-              color: step.status === 'completed' ? '#065f46' :
-                     step.status === 'active' ? '#0a66c2' :
-                     step.status === 'error' ? '#991b1b' : '#64748b',
-              flexShrink: 0
-            }}>
-              {step.status}
-            </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
       
       {/* Active status indicator */}
       {active && (
         <div style={{
-          marginTop: '20px',
-          padding: '12px 16px',
-          background: 'rgba(10,102,194,0.05)',
-          borderRadius: '12px',
-          border: '1px solid rgba(10,102,194,0.1)',
+          marginTop: '16px',
+          padding: '10px 14px',
+          background: 'rgba(10,102,194,0.03)',
+          borderRadius: '8px',
+          border: '1px solid rgba(10,102,194,0.06)',
           display: 'flex',
           alignItems: 'center',
-          gap: '12px'
+          gap: '10px'
         }}>
           <div style={{
-            width: '12px',
-            height: '12px',
+            width: '6px',
+            height: '6px',
             borderRadius: '50%',
             background: '#0a66c2',
-            animation: 'pulse 1.5s ease-in-out infinite'
+            flexShrink: 0
           }} />
           <div style={{
-            fontSize: '14px',
-            color: '#0a66c2',
-            fontWeight: '500'
+            fontSize: '12px',
+            color: '#64748b',
+            lineHeight: '1.5',
+            flex: 1
           }}>
-            Content generation in progress...
+            <strong style={{ color: '#0a66c2' }}>Why this matters:</strong> Every step produces research-backed, LinkedIn-optimized content with visible source citations.
           </div>
         </div>
       )}
       
       {/* CSS Animations */}
-      <style dangerouslySetInnerHTML={{
-        __html: `
-          @keyframes pulse {
-            0% { opacity: 0.6; transform: scale(1); }
-            100% { opacity: 1; transform: scale(1.1); }
-          }
-        `
-      }} />
+      <style>{`
+        @keyframes progressPulse {
+          0%, 100% { opacity: 0.4; transform: scale(0.8); }
+          50% { opacity: 1; transform: scale(1); }
+        }
+      `}</style>
     </div>
   );
 };
 
-
+export default ProgressTracker;

--- a/frontend/src/components/LinkedInWriter/hooks/useLinkedInWriter.ts
+++ b/frontend/src/components/LinkedInWriter/hooks/useLinkedInWriter.ts
@@ -13,6 +13,7 @@ import {
 } from '../utils/storageUtils';
 import { getContextAwareSuggestions, mapPostType, mapTone, mapIndustry, mapSearchEngine, readPrefs } from '../utils/linkedInWriterUtils';
 import { linkedInWriterApi, GroundingLevel } from '../../../services/linkedInWriterApi';
+import { CopilotPersistenceManager } from '../utils/enhancedPersistence';
 
 export function useLinkedInWriter() {
   // Core state
@@ -82,26 +83,26 @@ export function useLinkedInWriter() {
   const generatePost = useCallback(async (params?: any) => {
     const prefs = readPrefs();
     window.dispatchEvent(new CustomEvent('linkedinwriter:loadingStart', { 
-      detail: { action: 'generateLinkedInPost', message: 'Generating LinkedIn post...' } 
+      detail: { action: 'generateLinkedInPost', message: 'Researching and writing your LinkedIn post...' } 
     }));
     window.dispatchEvent(new CustomEvent('linkedinwriter:progressInit', { detail: {
       steps: [
-        { id: 'personalize', label: 'Personalizing topic & context' },
-        { id: 'prepare_queries', label: 'Preparing research queries' },
-        { id: 'research', label: 'Conducting research & analysis' },
-        { id: 'grounding', label: 'Applying AI grounding' },
-        { id: 'content_generation', label: 'Generating content' },
-        { id: 'citations', label: 'Extracting citations' },
-        { id: 'quality_analysis', label: 'Quality assessment' },
-        { id: 'finalize', label: 'Finalizing & optimizing' }
+        { id: 'personalize', label: 'Analyzing topic & audience' },
+        { id: 'prepare_queries', label: 'Preparing research strategy' },
+        { id: 'research', label: 'Gathering industry insights' },
+        { id: 'grounding', label: 'Grounding in research data' },
+        { id: 'content_generation', label: 'Writing LinkedIn post' },
+        { id: 'citations', label: 'Attaching source citations' },
+        { id: 'quality_analysis', label: 'Running quality checks' },
+        { id: 'finalize', label: 'Final polish' }
       ]
     }}));
     window.dispatchEvent(new CustomEvent('linkedinwriter:progressStep', { 
-      detail: { id: 'personalize', status: 'active', message: 'Analyzing topic, industry context, and target audience...' } 
+      detail: { id: 'personalize', status: 'active', message: 'Analyzing topic, industry, and target audience — tailoring the content for LinkedIn engagement...' } 
     }));
 
     // Simulate progress advancement during API call
-    const progressStepIds = ['prepare_queries', 'research', 'grounding', 'content_generation', 'citations', 'quality_analysis'];
+    const progressStepIds = ['personalize', 'prepare_queries', 'research', 'grounding', 'content_generation', 'citations', 'quality_analysis'];
     let stepIndex = 0;
     const progressInterval = setInterval(() => {
       if (stepIndex < progressStepIds.length) {
@@ -151,7 +152,7 @@ export function useLinkedInWriter() {
           searchQueries: res.data?.search_queries || []
         }}));
         window.dispatchEvent(new CustomEvent('linkedinwriter:updateDraft', { detail: fullContent }));
-        window.dispatchEvent(new CustomEvent('linkedinwriter:progressStep', { detail: { id: 'finalize', status: 'completed', message: 'Content finalized' } }));
+        window.dispatchEvent(new CustomEvent('linkedinwriter:progressStep', { detail: { id: 'finalize', status: 'completed', message: 'Post optimized for LinkedIn engagement' } }));
         window.dispatchEvent(new CustomEvent('linkedinwriter:progressComplete'));
         window.dispatchEvent(new CustomEvent('linkedinwriter:loadingEnd'));
         trackActionUsage('generateLinkedInPost');
@@ -171,25 +172,25 @@ export function useLinkedInWriter() {
   const generateArticle = useCallback(async (params?: any) => {
     const prefs = readPrefs();
     window.dispatchEvent(new CustomEvent('linkedinwriter:loadingStart', {
-      detail: { action: 'generateLinkedInArticle', message: 'Generating LinkedIn article...' }
+      detail: { action: 'generateLinkedInArticle', message: 'Researching and writing your LinkedIn article...' }
     }));
     window.dispatchEvent(new CustomEvent('linkedinwriter:progressInit', { detail: {
       steps: [
-        { id: 'personalize', label: 'Personalizing topic & context' },
-        { id: 'prepare_queries', label: 'Preparing research queries' },
-        { id: 'research', label: 'Conducting research & analysis' },
-        { id: 'grounding', label: 'Applying AI grounding' },
-        { id: 'content_generation', label: 'Generating article content' },
-        { id: 'citations', label: 'Extracting citations' },
-        { id: 'quality_analysis', label: 'Quality assessment' },
-        { id: 'finalize', label: 'Finalizing & optimizing' }
+        { id: 'personalize', label: 'Analyzing topic & audience' },
+        { id: 'prepare_queries', label: 'Preparing research strategy' },
+        { id: 'research', label: 'Gathering industry insights' },
+        { id: 'grounding', label: 'Grounding in research data' },
+        { id: 'content_generation', label: 'Writing article content' },
+        { id: 'citations', label: 'Attaching source citations' },
+        { id: 'quality_analysis', label: 'Running quality checks' },
+        { id: 'finalize', label: 'Final polish' }
       ]
     }}));
     window.dispatchEvent(new CustomEvent('linkedinwriter:progressStep', {
-      detail: { id: 'personalize', status: 'active', message: 'Analyzing topic, industry context, and target audience...' }
+      detail: { id: 'personalize', status: 'active', message: 'Analyzing topic, industry, and target audience — tailoring the content for LinkedIn engagement...' }
     }));
 
-    const progressStepIds = ['prepare_queries', 'research', 'grounding', 'content_generation', 'citations', 'quality_analysis'];
+    const progressStepIds = ['personalize', 'prepare_queries', 'research', 'grounding', 'content_generation', 'citations', 'quality_analysis'];
     let stepIndex = 0;
     const progressInterval = setInterval(() => {
       if (stepIndex < progressStepIds.length) {
@@ -232,7 +233,7 @@ export function useLinkedInWriter() {
           searchQueries: res.data?.search_queries || []
         }}));
         window.dispatchEvent(new CustomEvent('linkedinwriter:updateDraft', { detail: content }));
-        window.dispatchEvent(new CustomEvent('linkedinwriter:progressStep', { detail: { id: 'finalize', status: 'completed', message: 'Article finalized' } }));
+        window.dispatchEvent(new CustomEvent('linkedinwriter:progressStep', { detail: { id: 'finalize', status: 'completed', message: 'Article formatted for LinkedIn publishing' } }));
         window.dispatchEvent(new CustomEvent('linkedinwriter:progressComplete'));
         window.dispatchEvent(new CustomEvent('linkedinwriter:loadingEnd'));
         trackActionUsage('generateLinkedInArticle');
@@ -253,25 +254,25 @@ export function useLinkedInWriter() {
   const generateCarousel = useCallback(async (params?: any) => {
     const prefs = readPrefs();
     window.dispatchEvent(new CustomEvent('linkedinwriter:loadingStart', {
-      detail: { action: 'generateLinkedInCarousel', message: 'Generating LinkedIn carousel...' }
+      detail: { action: 'generateLinkedInCarousel', message: 'Researching and building your LinkedIn carousel...' }
     }));
     window.dispatchEvent(new CustomEvent('linkedinwriter:progressInit', { detail: {
       steps: [
-        { id: 'personalize', label: 'Personalizing topic & context' },
-        { id: 'prepare_queries', label: 'Preparing research queries' },
-        { id: 'research', label: 'Conducting research & analysis' },
-        { id: 'grounding', label: 'Applying AI grounding' },
-        { id: 'content_generation', label: 'Generating carousel slides' },
-        { id: 'citations', label: 'Extracting citations' },
-        { id: 'quality_analysis', label: 'Quality assessment' },
-        { id: 'finalize', label: 'Finalizing & optimizing' }
+        { id: 'personalize', label: 'Analyzing topic & audience' },
+        { id: 'prepare_queries', label: 'Preparing research strategy' },
+        { id: 'research', label: 'Gathering industry insights' },
+        { id: 'grounding', label: 'Grounding in research data' },
+        { id: 'content_generation', label: 'Building carousel slides' },
+        { id: 'citations', label: 'Attaching source citations' },
+        { id: 'quality_analysis', label: 'Running quality checks' },
+        { id: 'finalize', label: 'Final polish' }
       ]
     }}));
     window.dispatchEvent(new CustomEvent('linkedinwriter:progressStep', {
-      detail: { id: 'personalize', status: 'active', message: 'Analyzing topic, industry context, and target audience...' }
+      detail: { id: 'personalize', status: 'active', message: 'Analyzing topic, industry, and target audience — tailoring the content for LinkedIn engagement...' }
     }));
 
-    const progressStepIds = ['prepare_queries', 'research', 'grounding', 'content_generation', 'citations', 'quality_analysis'];
+    const progressStepIds = ['personalize', 'prepare_queries', 'research', 'grounding', 'content_generation', 'citations', 'quality_analysis'];
     let stepIndex = 0;
     const progressInterval = setInterval(() => {
       if (stepIndex < progressStepIds.length) {
@@ -307,7 +308,7 @@ export function useLinkedInWriter() {
           content += `## Slide ${index + 1}: ${slide.title}\n\n${slide.content}\n\n`;
         });
         window.dispatchEvent(new CustomEvent('linkedinwriter:updateDraft', { detail: content }));
-        window.dispatchEvent(new CustomEvent('linkedinwriter:progressStep', { detail: { id: 'finalize', status: 'completed', message: 'Carousel finalized' } }));
+        window.dispatchEvent(new CustomEvent('linkedinwriter:progressStep', { detail: { id: 'finalize', status: 'completed', message: 'Carousel optimized for mobile viewing' } }));
         window.dispatchEvent(new CustomEvent('linkedinwriter:progressComplete'));
         window.dispatchEvent(new CustomEvent('linkedinwriter:loadingEnd'));
         trackActionUsage('generateLinkedInCarousel');
@@ -328,25 +329,25 @@ export function useLinkedInWriter() {
   const generateVideoScript = useCallback(async (params?: any) => {
     const prefs = readPrefs();
     window.dispatchEvent(new CustomEvent('linkedinwriter:loadingStart', {
-      detail: { action: 'generateLinkedInVideoScript', message: 'Generating LinkedIn video script...' }
+      detail: { action: 'generateLinkedInVideoScript', message: 'Researching and writing your video script...' }
     }));
     window.dispatchEvent(new CustomEvent('linkedinwriter:progressInit', { detail: {
       steps: [
-        { id: 'personalize', label: 'Personalizing topic & context' },
-        { id: 'prepare_queries', label: 'Preparing research queries' },
-        { id: 'research', label: 'Conducting research & analysis' },
-        { id: 'grounding', label: 'Applying AI grounding' },
-        { id: 'content_generation', label: 'Generating video script' },
-        { id: 'citations', label: 'Extracting citations' },
-        { id: 'quality_analysis', label: 'Quality assessment' },
-        { id: 'finalize', label: 'Finalizing & optimizing' }
+        { id: 'personalize', label: 'Analyzing topic & audience' },
+        { id: 'prepare_queries', label: 'Preparing research strategy' },
+        { id: 'research', label: 'Gathering industry insights' },
+        { id: 'grounding', label: 'Grounding in research data' },
+        { id: 'content_generation', label: 'Writing video script' },
+        { id: 'citations', label: 'Attaching source citations' },
+        { id: 'quality_analysis', label: 'Running quality checks' },
+        { id: 'finalize', label: 'Final polish' }
       ]
     }}));
     window.dispatchEvent(new CustomEvent('linkedinwriter:progressStep', {
-      detail: { id: 'personalize', status: 'active', message: 'Analyzing topic, industry context, and target audience...' }
+      detail: { id: 'personalize', status: 'active', message: 'Analyzing topic, industry, and target audience — tailoring the content for LinkedIn engagement...' }
     }));
 
-    const progressStepIds = ['prepare_queries', 'research', 'grounding', 'content_generation', 'citations', 'quality_analysis'];
+    const progressStepIds = ['personalize', 'prepare_queries', 'research', 'grounding', 'content_generation', 'citations', 'quality_analysis'];
     let stepIndex = 0;
     const progressInterval = setInterval(() => {
       if (stepIndex < progressStepIds.length) {
@@ -388,7 +389,7 @@ export function useLinkedInWriter() {
           content += `## Captions\n${res.data.captions.join('\n')}\n\n`;
         }
         window.dispatchEvent(new CustomEvent('linkedinwriter:updateDraft', { detail: content }));
-        window.dispatchEvent(new CustomEvent('linkedinwriter:progressStep', { detail: { id: 'finalize', status: 'completed', message: 'Video script finalized' } }));
+        window.dispatchEvent(new CustomEvent('linkedinwriter:progressStep', { detail: { id: 'finalize', status: 'completed', message: 'Script ready for production' } }));
         window.dispatchEvent(new CustomEvent('linkedinwriter:progressComplete'));
         window.dispatchEvent(new CustomEvent('linkedinwriter:loadingEnd'));
         trackActionUsage('generateLinkedInVideoScript');
@@ -406,7 +407,7 @@ export function useLinkedInWriter() {
     }
   }, []);
 
-  // Initialize chat history and preferences from localStorage
+  // Initialize chat history, preferences, and grounding data from localStorage
   useEffect(() => {
     const loadInitialData = () => {
       try {
@@ -419,11 +420,23 @@ export function useLinkedInWriter() {
         if (savedContext && !context) {
           setContext(savedContext);
         }
+
+        // Load persisted grounding data
+        const persistence = CopilotPersistenceManager.getInstance();
+        const groundingData = persistence.loadGroundingData();
+        if (groundingData.researchSources.length > 0) {
+          setResearchSources(groundingData.researchSources);
+          setCitations(groundingData.citations);
+          setQualityMetrics(groundingData.qualityMetrics);
+          setGroundingEnabled(groundingData.groundingEnabled);
+          setSearchQueries(groundingData.searchQueries);
+        }
         
         console.log('[LinkedIn Writer] Initialized with:', {
           historyCount: history.length,
           preferences: prefs,
-          hasContext: !!savedContext
+          hasContext: !!savedContext,
+          hasGroundingData: groundingData.researchSources.length > 0
         });
       } catch (error) {
         console.warn('[LinkedIn Writer] Failed to initialize from localStorage:', error);
@@ -508,17 +521,7 @@ export function useLinkedInWriter() {
   // Listen for grounding data updates from CopilotKit actions
   useEffect(() => {
     const handleGroundingDataUpdate = (event: CustomEvent) => {
-      console.log('[LinkedIn Writer] Received grounding data event:', event.detail);
-      
       const { researchSources, citations, qualityMetrics, groundingEnabled, searchQueries } = event.detail;
-      
-      console.log('[LinkedIn Writer] Extracted data:', {
-        researchSources: researchSources?.length || 0,
-        citations: citations?.length || 0,
-        qualityMetrics: !!qualityMetrics,
-        groundingEnabled,
-        searchQueries: searchQueries?.length || 0
-      });
       
       setResearchSources(researchSources || []);
       setCitations(citations || []);
@@ -526,11 +529,14 @@ export function useLinkedInWriter() {
       setGroundingEnabled(groundingEnabled || false);
       setSearchQueries(searchQueries || []);
       
-      console.log('[LinkedIn Writer] Grounding data updated:', {
-        sourcesCount: researchSources?.length || 0,
-        citationsCount: citations?.length || 0,
-        hasQualityMetrics: !!qualityMetrics,
-        groundingEnabled
+      // Persist grounding data so it survives page refresh
+      const persistence = CopilotPersistenceManager.getInstance();
+      persistence.saveGroundingData({
+        researchSources: researchSources || [],
+        citations: citations || [],
+        qualityMetrics: qualityMetrics || null,
+        groundingEnabled: groundingEnabled || false,
+        searchQueries: searchQueries || []
       });
     };
 

--- a/frontend/src/components/LinkedInWriter/utils/contentFormatters.ts
+++ b/frontend/src/components/LinkedInWriter/utils/contentFormatters.ts
@@ -5,52 +5,60 @@ export function escapeHtml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
+// Build an inline citation badge element
+function citationBadge(num: string): string {
+  return `<span class="liw-cite" data-source-index="${num}">${num}</span>`;
+}
+
 // Format draft content with proper LinkedIn styling and inline citations
 export function formatDraftContent(content: string, citations?: any[], researchSources?: any[]): string {
   if (!content) return '';
   
   let formatted = escapeHtml(content);
   
-  // Insert inline citations if available
-  if (citations && citations.length > 0 && researchSources && researchSources.length > 0) {
-
-    // Create a map of citation references to source numbers
+  // Always convert [Source N] markers when present in content (supports persisted drafts)
+  if (/\[Source \d+\]/.test(formatted)) {
+    // Normalize: [Source N] [M] → badge(N) badge(M) (handles adjacent bare [M] shorthand)
+    formatted = formatted.replace(
+      /\[Source\s+(\d+)\]\s*\[(\d+)\]/g,
+      (_, n1, n2) => `${citationBadge(n1)} ${citationBadge(n2)}`
+    );
+    // Convert remaining [Source N] markers to badges
+    formatted = formatted.replace(
+      /\[Source\s+(\d+)\]/g,
+      (_, n) => citationBadge(n)
+    );
+  } else if (citations && citations.length > 0 && researchSources && researchSources.length > 0) {
+    // Fallback: content has no markers — distribute citations across sentences
     const citationMap = new Map();
-    citations.forEach((citation, index) => {
-      if (citation.reference && citation.reference.startsWith('Source ')) {
-        const sourceNum = citation.reference.replace('Source ', '');
-        citationMap.set(citation.reference, sourceNum);
-      }
-    });
-
-    // Since citation references don't exist in the content text,
-    // we need to insert citations strategically throughout the content
-    const citationEntries = Array.from(citationMap.entries());
-    const totalCitations = citationEntries.length;
-    
-    if (totalCitations > 0) {
-      // Split content into sentences for strategic citation placement
-      const sentences = formatted.split(/[.!?]+/).filter(s => s.trim().length > 0);
-      const sentencesWithCitations: string[] = [];
-      
-      citationEntries.forEach(([reference, sourceNum], index) => {
-        // Distribute citations across sentences
-        const targetSentenceIndex = Math.floor((index / totalCitations) * sentences.length);
-        const targetSentence = sentences[targetSentenceIndex] || sentences[sentences.length - 1];
-        
-        // Add citation to the end of the target sentence using a superscript marker
-        const citeHtml = ` <sup class="liw-cite" data-source-index="${sourceNum}">[${sourceNum}]</sup>`;
-        const sentenceWithCitation = targetSentence.trim() + citeHtml;
-        sentencesWithCitations[targetSentenceIndex] = sentenceWithCitation;
-        
+      citations.forEach((citation) => {
+        if (citation.reference && citation.reference.startsWith('Source ')) {
+          const sourceNum = citation.reference.replace('Source ', '');
+          citationMap.set(citation.reference, sourceNum);
+        }
       });
+
+      const citationEntries = Array.from(citationMap.entries());
+      const totalCitations = citationEntries.length;
       
-      // Reconstruct content with citations
-      formatted = sentences.map((sentence, index) => {
-        return sentencesWithCitations[index] || sentence;
-      }).join('. ') + '.';
+      if (totalCitations > 0) {
+        const sentences = formatted.split(/[.!?]+/).filter(s => s.trim().length > 0);
+        const sentencesWithCitations: string[] = [];
+        
+        citationEntries.forEach(([reference, sourceNum], index) => {
+          const targetSentenceIndex = Math.floor((index / totalCitations) * sentences.length);
+          const targetSentence = sentences[targetSentenceIndex] || sentences[sentences.length - 1];
+          
+          const citeHtml = ` ${citationBadge(sourceNum)}`;
+          const sentenceWithCitation = targetSentence.trim() + citeHtml;
+          sentencesWithCitations[targetSentenceIndex] = sentenceWithCitation;
+        });
+        
+        formatted = sentences.map((sentence, index) => {
+          return sentencesWithCitations[index] || sentence;
+        }).join('. ') + '.';
+      }
     }
-  }
   
   // Format hashtags
   formatted = formatted.replace(/#(\w+)/g, '<span style="color: #0a66c2; font-weight: 600;">#$1</span>');

--- a/frontend/src/components/LinkedInWriter/utils/enhancedPersistence.ts
+++ b/frontend/src/components/LinkedInWriter/utils/enhancedPersistence.ts
@@ -14,6 +14,7 @@ export const STORAGE_KEYS = {
   USER_PREFERENCES: 'alwrity-copilot-user-preferences',
   CONVERSATION_CONTEXT: 'alwrity-copilot-conversation-context',
   DRAFT_CONTENT: 'alwrity-copilot-draft-content',
+  GROUNDING_DATA: 'alwrity-copilot-grounding-data',
   LAST_SESSION: 'alwrity-copilot-last-session'
 };
 
@@ -221,6 +222,36 @@ export class CopilotPersistenceManager {
     }
   }
   
+  // Grounding data persistence (research sources, citations, quality metrics)
+  public saveGroundingData(data: { researchSources?: any[]; citations?: any[]; qualityMetrics?: any; groundingEnabled?: boolean; searchQueries?: string[] }): void {
+    try {
+      const existing = this.loadGroundingData();
+      const updated = { ...existing, ...data, lastUpdated: Date.now() };
+      localStorage.setItem(STORAGE_KEYS.GROUNDING_DATA, JSON.stringify(updated));
+    } catch (error) {
+      console.error('Failed to save grounding data:', error);
+    }
+  }
+
+  public loadGroundingData(): { researchSources: any[]; citations: any[]; qualityMetrics: any; groundingEnabled: boolean; searchQueries: string[] } {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEYS.GROUNDING_DATA);
+      if (stored) {
+        const data = JSON.parse(stored);
+        return {
+          researchSources: data.researchSources || [],
+          citations: data.citations || [],
+          qualityMetrics: data.qualityMetrics || null,
+          groundingEnabled: data.groundingEnabled || false,
+          searchQueries: data.searchQueries || []
+        };
+      }
+    } catch (error) {
+      console.error('Failed to load grounding data:', error);
+    }
+    return { researchSources: [], citations: [], qualityMetrics: null, groundingEnabled: false, searchQueries: [] };
+  }
+
   // Session management
   public saveLastSession(): void {
     try {

--- a/frontend/src/components/TextEditor/CitationHoverHandler.tsx
+++ b/frontend/src/components/TextEditor/CitationHoverHandler.tsx
@@ -1,252 +1,179 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 interface CitationHoverHandlerProps {
   researchSources: any[];
 }
 
-// Extend Element interface for our custom property
-interface ExtendedElement extends Element {
-  _liwTip?: HTMLDivElement | null;
-}
-
 const CitationHoverHandler: React.FC<CitationHoverHandlerProps> = ({ researchSources }) => {
+  const initializedRef = useRef(false);
+
   useEffect(() => {
-    if (!researchSources || researchSources.length === 0) return;
+    // Always attempt to attach hover listeners when .liw-cite elements exist,
+    // even if researchSources hasn't loaded yet (e.g., page refresh with persisted draft).
+    // Tooltip will show a minimal fallback if source data isn't available.
 
-    console.log('🔍 [Citation Hover] useEffect triggered with', researchSources.length, 'sources');
+    // Prevent duplicate initialization on re-renders
+    if (initializedRef.current) return;
+    initializedRef.current = true;
 
-    // Keep track of currently open tooltip
-    let currentOpenTooltip: HTMLDivElement | null = null;
+    let currentTooltip: HTMLDivElement | null = null;
+    const attachedListeners: Array<{ el: Element; type: string; handler: EventListener }> = [];
 
-    const initCitationHover = () => {
+    const init = () => {
       try {
-        console.log('🔍 [Citation Hover] Script starting...');
-        console.log('🔍 [Citation Hover] Research sources count:', researchSources.length);
-        
-        // Test if script is running
-        document.body.style.setProperty('--citation-hover-active', 'true');
-        console.log('🔍 [Citation Hover] Script is running, CSS variable set');
-        
-        // Wait for content to be rendered
-        const waitForCitations = () => {
-          const citations = document.querySelectorAll('.liw-cite');
-          console.log('🔍 [Citation Hover] Looking for citations, found:', citations.length);
-          
-          if (citations.length === 0) {
-            // If no citations found, wait a bit and try again
-            console.log('🔍 [Citation Hover] No citations found, waiting...');
-            setTimeout(waitForCitations, 200);
-            return;
-          }
-          
-          console.log('🔍 [Citation Hover] Found', citations.length, 'citation elements');
-          citations.forEach((cite, idx) => {
-            console.log(`🔍 [Citation Hover] Citation ${idx}: ${cite.outerHTML}`);
-            console.log(`🔍 [Citation Hover] Citation classes: ${cite.className}`);
-            console.log(`🔍 [Citation Hover] Citation data-source-index: ${cite.getAttribute('data-source-index')}`);
-          });
-          setupCitationHover();
-        };
-        
-        const setupCitationHover = () => {
-          console.log('🔍 [Citation Hover] Initializing hover functionality...');
-          const data = researchSources;
-          console.log('🔍 [Citation Hover] Research data loaded:', data.length, 'sources');
+        const citations = document.querySelectorAll('.liw-cite');
+        if (citations.length === 0) {
+          setTimeout(init, 200);
+          return;
+        }
 
-          const openOverlay = (idx: string, src: any) => {
-            console.log('🔍 [Citation Hover] Opening overlay for source', idx, src);
-            const existing = document.getElementById('liw-cite-overlay');
-            if (existing) existing.remove();
+        citations.forEach((cite) => {
+          const onEnter = () => {
+            if (currentTooltip) {
+              try { currentTooltip.remove(); } catch (_) {}
+              currentTooltip = null;
+            }
+            document.querySelectorAll('.liw-cite-tip').forEach(t => t.remove());
 
-            const overlay = document.createElement('div');
-            overlay.id = 'liw-cite-overlay';
-            overlay.style.position = 'fixed';
-            overlay.style.inset = '0';
-            overlay.style.background = 'rgba(0,0,0,0.35)';
-            overlay.style.backdropFilter = 'blur(2px)';
-            overlay.style.zIndex = '100000';
-            overlay.style.display = 'flex';
-            overlay.style.alignItems = 'center';
-            overlay.style.justifyContent = 'center';
+            const idx = cite.getAttribute('data-source-index');
+            if (!idx) return;
+            const src = researchSources[parseInt(idx, 10) - 1];
 
-            const modal = document.createElement('div');
-            modal.style.width = 'min(720px, 92vw)';
-            modal.style.maxHeight = '80vh';
-            modal.style.overflow = 'auto';
-            modal.style.borderRadius = '14px';
-            modal.style.background = 'linear-gradient(180deg, #ffffff, #f8fdff)';
-            modal.style.border = '1px solid #cfe9f7';
-            modal.style.boxShadow = '0 24px 80px rgba(10,102,194,0.25)';
-            modal.style.padding = '18px 20px';
-            
-            const title = (src.title || 'Untitled').replace(/</g, '&lt;');
-            
-            modal.innerHTML = 
-              '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">' +
-                '<div style="font-size:16px;font-weight:800;color:#0a66c2">Source ' + idx + '</div>' +
-                '<button id="liw-cite-close" style="border:none;background:#eff6ff;color:#0a66c2;border-radius:8px;padding:8px 12px;cursor:pointer;font-weight:700">✕ Close</button>' +
-              '</div>' +
-              '<div style="font-size:18px;font-weight:700;color:#1f2937;margin-bottom:8px">' + title + '</div>' +
-              '<a href="' + (src.url || '#') + '" target="_blank" style="display:inline-block;color:#0a66c2;text-decoration:none;margin-bottom:12px;font-size:14px;font-weight:600;">View Source →</a>' +
-              (src.content ? '<div style="margin-bottom:16px;color:#374151;font-size:14px;line-height:1.6;background:#f9fafb;padding:16px;border-radius:8px;border-left:4px solid #0a66c2;">' + src.content + '</div>' : '') +
-              '<div style="display:flex;gap:12px;flex-wrap:wrap;margin-bottom:16px">' +
-                (typeof src.relevance_score === 'number' ? '<span style="background:#eef6ff;border:1px solid #d9ecff;border-radius:999px;padding:8px 12px;font-size:13px;color:#055a8c;font-weight:600">Relevance: ' + Math.round(src.relevance_score * 100) + '%</span>' : '') +
-                (typeof src.credibility_score === 'number' ? '<span style="background:#eef6ff;border:1px solid #d9ecff;border-radius:999px;padding:8px 12px;font-size:13px;color:#055a8c;font-weight:600">Credibility: ' + Math.round(src.credibility_score * 100) + '%</span>' : '') +
-                (typeof src.domain_authority === 'number' ? '<span style="background:#eef6ff;border:1px solid #d9ecff;border-radius:999px;padding:8px 12px;font-size:13px;color:#055a8c;font-weight:600">Authority: ' + Math.round(src.domain_authority * 100) + '%</span>' : '') +
-              '</div>' +
-              '<div style="display:flex;gap:16px;color:#6b7280;font-size:13px;padding-top:12px;border-top:1px solid #e5e7eb">' +
-                (src.source_type ? '<div>Type: <span style="color:#374151;font-weight:600">' + src.source_type.replace('_', ' ') + '</span></div>' : '') +
-                (src.publication_date ? '<div>Published: <span style="color:#374151;font-weight:600">' + src.publication_date + '</span></div>' : '') +
-              '</div>' +
-              (src.raw_result ? '<div style="color:#6b7280;font-size:12px;margin-top:12px;padding:8px;background:#f3f4f6;border-radius:6px;border-top:1px solid #e5e7eb;">Raw Data: ' + JSON.stringify(src.raw_result).substring(0, 150) + (JSON.stringify(src.raw_result).length > 150 ? '...' : '') + '</div>' : '');
-
-            overlay.appendChild(modal);
-            document.body.appendChild(overlay);
-
-            const close = () => { 
-              try { overlay.remove(); } catch(_){} 
-            };
-            overlay.addEventListener('click', (e) => { 
-              if(e.target === overlay) close(); 
+            const tip = document.createElement('div');
+            tip.className = 'liw-cite-tip';
+            Object.assign(tip.style, {
+              position: 'fixed',
+              zIndex: '99999',
+              maxWidth: '420px',
+              background: '#fff',
+              border: '1px solid #cfe9f7',
+              borderRadius: '10px',
+              boxShadow: '0 12px 40px rgba(10,102,194,0.18)',
+              padding: '12px 14px',
+              fontSize: '12px',
+              color: '#1f2937'
             });
-            document.getElementById('liw-cite-close')?.addEventListener('click', close);
-            document.addEventListener('keydown', function esc(ev: KeyboardEvent) { 
-              if(ev.key === 'Escape') { 
-                close(); 
-                document.removeEventListener('keydown', esc);
-              } 
-            });
-          };
 
-          // Add event listeners directly to each citation element
-          const citations = document.querySelectorAll('.liw-cite');
-          
-          citations.forEach((cite) => {
-            console.log('🔍 [Citation Hover] Adding event listeners to citation:', cite.outerHTML);
-            
-            cite.addEventListener('mouseenter', () => {
-              console.log('🔍 [Citation Hover] Mouse enter on citation:', cite.outerHTML);
-              
-              // Close any existing tooltip first
-              if (currentOpenTooltip) {
-                try { currentOpenTooltip.remove(); } catch(_) {}
-                currentOpenTooltip = null;
-              }
-              
-              const idx = cite.getAttribute('data-source-index');
-              console.log('🔍 [Citation Hover] Citation index:', idx);
-              
-              if (!idx) return;
-              const i = parseInt(idx, 10) - 1;
-              const src = data[i];
-              if (!src) {
-                console.log('🔍 [Citation Hover] No source found for index:', idx);
-                return;
-              }
-
-              console.log('🔍 [Citation Hover] Creating tooltip for source:', src);
-
-              let tip = document.createElement('div');
-              tip.className = 'liw-cite-tip';
-              tip.style.position = 'fixed';
-              tip.style.zIndex = '99999';
-              tip.style.maxWidth = '420px';
-              tip.style.background = 'linear-gradient(180deg, #ffffff, #f8fdff)';
-              tip.style.border = '1px solid #cfe9f7';
-              tip.style.borderRadius = '10px';
-              tip.style.boxShadow = '0 12px 40px rgba(10,102,194,0.18)';
-              tip.style.padding = '12px 14px';
-              tip.style.fontSize = '12px';
-              tip.style.color = '#1f2937';
-              tip.style.backdropFilter = 'blur(5px)';
-              
+            if (src) {
               const title = (src.title || 'Untitled').replace(/</g, '&lt;');
-              
-              tip.innerHTML = 
-                '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">' +
-                  '<div style="font-weight:700;color:#0a66c2">Source ' + idx + '</div>' +
-                  '<button class="liw-pin" title="Pin" style="border:none;background:#eef6ff;border-radius:8px;padding:4px 8px;cursor:pointer;color:#0a66c2;font-weight:800">📌</button>' +
-                '</div>' +
-                '<div style="font-weight:600;margin-bottom:6px;color:#1f2937">' + title + '</div>' +
-                '<a href="' + (src.url || '#') + '" target="_blank" style="color:#0a66c2;text-decoration:none;margin-bottom:8px;display:block;font-weight:600;">View Source →</a>' +
-                (src.content ? '<div style="margin-bottom:8px;color:#374151;font-size:11px;line-height:1.4;background:#f9fafb;padding:8px;border-radius:6px;border-left:3px solid #0a66c2;">' + src.content + '</div>' : '') +
-                '<div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:8px">' +
-                  (typeof src.relevance_score === 'number' ? '<span style="background:#eef6ff;border:1px solid #d9ecff;border-radius:999px;padding:4px 8px;font-size:11px;color:#055a8c;font-weight:600">Relevance: ' + Math.round(src.relevance_score * 100) + '%</span>' : '') +
-                  (typeof src.credibility_score === 'number' ? '<span style="background:#eef6ff;border:1px solid #d9ecff;border-radius:999px;padding:4px 8px;font-size:11px;color:#055a8c;font-weight:600">Credibility: ' + Math.round(src.credibility_score * 100) + '%</span>' : '') +
-                  (typeof src.domain_authority === 'number' ? '<span style="background:#eef6ff;border:1px solid #d9ecff;border-radius:999px;padding:4px 8px;font-size:11px;color:#055a8c;font-weight:600">Authority: ' + Math.round(src.domain_authority * 100) + '%</span>' : '') +
-                '</div>' +
-                (src.source_type ? '<div style="color:#6b7280;font-size:11px;margin-bottom:4px">Type: <span style="color:#374151;font-weight:600">' + src.source_type.replace('_', ' ') + '</span></div>' : '') +
-                (src.publication_date ? '<div style="color:#6b7280;font-size:11px">Published: <span style="color:#374151;font-weight:600">' + src.publication_date + '</span></div>' : '') +
-                (src.raw_result ? '<div style="color:#6b7280;font-size:11px;margin-top:4px;padding:4px;background:#f3f4f6;border-radius:4px;">Raw Data: ' + JSON.stringify(src.raw_result).substring(0, 100) + (JSON.stringify(src.raw_result).length > 100 ? '...' : '') + '</div>' : '');
-                
-              document.body.appendChild(tip);
-              const rect = cite.getBoundingClientRect();
-              tip.style.left = Math.min(rect.left, window.innerWidth - 460) + 'px';
-              tip.style.top = (rect.bottom + 8) + 'px';
+              tip.innerHTML = [
+                '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">',
+                '<div style="font-weight:700;color:#0a66c2">Source ' + idx + '</div>',
+                '<button class="liw-pin" style="border:none;background:#eef6ff;border-radius:8px;padding:4px 8px;cursor:pointer;color:#0a66c2;font-weight:800">📌</button>',
+                '</div>',
+                '<div style="font-weight:600;margin-bottom:6px;color:#1f2937">' + title + '</div>',
+                '<a href="' + (src.url || '#') + '" target="_blank" style="color:#0a66c2;text-decoration:none;margin-bottom:8px;display:block;font-weight:600;">View Source →</a>',
+                src.content ? '<div style="margin-bottom:8px;color:#374151;font-size:11px;line-height:1.4;background:#f9fafb;padding:8px;border-radius:6px;border-left:3px solid #0a66c2;">' + src.content + '</div>' : '',
+                '<div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:8px">',
+                typeof src.relevance_score === 'number' ? '<span style="background:#eef6ff;border:1px solid #d9ecff;border-radius:999px;padding:4px 8px;font-size:11px;color:#055a8c;font-weight:600">Relevance: ' + Math.round(src.relevance_score * 100) + '%</span>' : '',
+                typeof src.credibility_score === 'number' ? '<span style="background:#eef6ff;border:1px solid #d9ecff;border-radius:999px;padding:4px 8px;font-size:11px;color:#055a8c;font-weight:600">Credibility: ' + Math.round(src.credibility_score * 100) + '%</span>' : '',
+                typeof src.domain_authority === 'number' ? '<span style="background:#eef6ff;border:1px solid #d9ecff;border-radius:999px;padding:4px 8px;font-size:11px;color:#055a8c;font-weight:600">Authority: ' + Math.round(src.domain_authority * 100) + '%</span>' : '',
+                '</div>',
+                src.source_type ? '<div style="color:#6b7280;font-size:11px;margin-bottom:4px">Type: <span style="color:#374151;font-weight:600">' + src.source_type.replace('_', ' ') + '</span></div>' : '',
+                src.publication_date ? '<div style="color:#6b7280;font-size:11px">Published: <span style="color:#374151;font-weight:600">' + src.publication_date + '</span></div>' : ''
+              ].join('');
+            } else {
+              tip.innerHTML = '<div style="font-weight:700;color:#0a66c2;margin-bottom:4px">Source ' + idx + '</div><div style="color:#64748b;font-size:11px">Source details will load after next generation.</div>';
+            }
 
-              tip.querySelector('.liw-pin')?.addEventListener('click', (ev) => {
+            document.body.appendChild(tip);
+            const rect = cite.getBoundingClientRect();
+            tip.style.left = Math.min(rect.left, window.innerWidth - 460) + 'px';
+            tip.style.top = (rect.bottom + 8) + 'px';
+
+            const pinBtn = tip.querySelector('.liw-pin');
+            if (pinBtn && src) {
+              pinBtn.addEventListener('click', (ev) => {
                 ev.stopPropagation();
                 openOverlay(idx, src);
-                try { tip.remove(); } catch(_) { 
-                  // Remove the custom property reference
-                  const extendedTip = tip as any;
-                  extendedTip._liwTip = undefined;
-                }
-                currentOpenTooltip = null;
+                try { tip.remove(); } catch (_) {}
+                currentTooltip = null;
               });
+            }
 
-              (cite as ExtendedElement)._liwTip = tip;
-              currentOpenTooltip = tip;
-              console.log('🔍 [Citation Hover] Tooltip created and positioned');
-            });
+            currentTooltip = tip;
+          };
 
-            cite.addEventListener('mouseleave', () => {
-              console.log('🔍 [Citation Hover] Mouse leave on citation:', cite.outerHTML);
-              const extendedCite = cite as ExtendedElement;
-              if (extendedCite._liwTip) { 
-                try { extendedCite._liwTip.remove(); } catch(_) {} 
-                extendedCite._liwTip = null; 
-                currentOpenTooltip = null;
-              }
-            });
-          });
-          
-          console.log('✅ [Citation Hover] Hover functionality initialized for', citations.length, 'citations');
-        };
-        
-        // Start waiting for citations with a longer delay to ensure content is rendered
-        setTimeout(waitForCitations, 500);
-        
-      } catch(e: any) { 
-        console.warn('liw cite tooltip init failed', e); 
-        console.error('Error details:', e);
-        // Show error in UI
-        const errorDiv = document.createElement('div');
-        errorDiv.style.cssText = 'position:fixed;top:10px;right:10px;background:#ffebee;border:1px solid #f44336;border-radius:4px;padding:10px;z-index:100000;color:#c62828;';
-        errorDiv.innerHTML = 'Citation hover failed: ' + e.message;
-        document.body.appendChild(errorDiv);
-        setTimeout(() => errorDiv.remove(), 5000);
+          const onLeave = () => {
+            if (currentTooltip) {
+              try { currentTooltip.remove(); } catch (_) {}
+              currentTooltip = null;
+            }
+          };
+
+          cite.addEventListener('mouseenter', onEnter);
+          cite.addEventListener('mouseleave', onLeave);
+          attachedListeners.push({ el: cite, type: 'mouseenter', handler: onEnter });
+          attachedListeners.push({ el: cite, type: 'mouseleave', handler: onLeave });
+        });
+      } catch (_) {
+        // Silently fail
       }
     };
 
-    // Initialize citation hover after a short delay to ensure content is rendered
-    const timer = setTimeout(initCitationHover, 100);
-    
-    // Cleanup function
+    const openOverlay = (idx: string, src: any) => {
+      const existing = document.getElementById('liw-cite-overlay');
+      if (existing) existing.remove();
+
+      const overlay = document.createElement('div');
+      overlay.id = 'liw-cite-overlay';
+      Object.assign(overlay.style, {
+        position: 'fixed', inset: '0', background: 'rgba(0,0,0,0.35)',
+        backdropFilter: 'blur(2px)', zIndex: '100000',
+        display: 'flex', alignItems: 'center', justifyContent: 'center'
+      });
+
+      const modal = document.createElement('div');
+      Object.assign(modal.style, {
+        width: 'min(720px, 92vw)', maxHeight: '80vh', overflow: 'auto',
+        borderRadius: '14px', background: '#fff', border: '1px solid #cfe9f7',
+        boxShadow: '0 24px 80px rgba(10,102,194,0.25)', padding: '18px 20px'
+      });
+
+      const title = (src.title || 'Untitled').replace(/</g, '&lt;');
+      modal.innerHTML = [
+        '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">',
+        '<div style="font-size:16px;font-weight:800;color:#0a66c2">Source ' + idx + '</div>',
+        '<button id="liw-cite-close" style="border:none;background:#eff6ff;color:#0a66c2;border-radius:8px;padding:8px 12px;cursor:pointer;font-weight:700">✕ Close</button>',
+        '</div>',
+        '<div style="font-size:18px;font-weight:700;color:#1f2937;margin-bottom:8px">' + title + '</div>',
+        '<a href="' + (src.url || '#') + '" target="_blank" style="display:inline-block;color:#0a66c2;text-decoration:none;margin-bottom:12px;font-size:14px;font-weight:600;">View Source →</a>',
+        src.content ? '<div style="margin-bottom:16px;color:#374151;font-size:14px;line-height:1.6;background:#f9fafb;padding:16px;border-radius:8px;border-left:4px solid #0a66c2;">' + src.content + '</div>' : '',
+        '<div style="display:flex;gap:12px;flex-wrap:wrap;margin-bottom:16px">',
+        typeof src.relevance_score === 'number' ? '<span style="background:#eef6ff;border:1px solid #d9ecff;border-radius:999px;padding:8px 12px;font-size:13px;color:#055a8c;font-weight:600">Relevance: ' + Math.round(src.relevance_score * 100) + '%</span>' : '',
+        typeof src.credibility_score === 'number' ? '<span style="background:#eef6ff;border:1px solid #d9ecff;border-radius:999px;padding:8px 12px;font-size:13px;color:#055a8c;font-weight:600">Credibility: ' + Math.round(src.credibility_score * 100) + '%</span>' : '',
+        typeof src.domain_authority === 'number' ? '<span style="background:#eef6ff;border:1px solid #d9ecff;border-radius:999px;padding:8px 12px;font-size:13px;color:#055a8c;font-weight:600">Authority: ' + Math.round(src.domain_authority * 100) + '%</span>' : '',
+        '</div>',
+        '<div style="display:flex;gap:16px;color:#6b7280;font-size:13px;padding-top:12px;border-top:1px solid #e5e7eb">',
+        src.source_type ? '<div>Type: <span style="color:#374151;font-weight:600">' + src.source_type.replace('_', ' ') + '</span></div>' : '',
+        src.publication_date ? '<div>Published: <span style="color:#374151;font-weight:600">' + src.publication_date + '</span></div>' : '',
+        '</div>'
+      ].join('');
+
+      overlay.appendChild(modal);
+      document.body.appendChild(overlay);
+
+      const close = () => { try { overlay.remove(); } catch (_) {} };
+      overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+      document.getElementById('liw-cite-close')?.addEventListener('click', close);
+      const escHandler = (ev: KeyboardEvent) => { if (ev.key === 'Escape') { close(); document.removeEventListener('keydown', escHandler); } };
+      document.addEventListener('keydown', escHandler);
+    };
+
+    const timer = setTimeout(init, 500);
+
     return () => {
       clearTimeout(timer);
-      // Remove any existing tooltips
-      const tooltips = document.querySelectorAll('.liw-cite-tip');
-      tooltips.forEach(tip => tip.remove());
-      // Remove overlay if exists
+      initializedRef.current = false;
+      attachedListeners.forEach(({ el, type, handler }) => {
+        el.removeEventListener(type, handler);
+      });
+      document.querySelectorAll('.liw-cite-tip').forEach(t => t.remove());
       const overlay = document.getElementById('liw-cite-overlay');
       if (overlay) overlay.remove();
-      // Reset current tooltip reference
-      currentOpenTooltip = null;
     };
-  }, [researchSources]); // Dependency on researchSources
+  }, [researchSources]);
 
-  // This component doesn't render anything visible
   return null;
 };
 

--- a/frontend/src/components/TextEditor/ContentDisplayArea.tsx
+++ b/frontend/src/components/TextEditor/ContentDisplayArea.tsx
@@ -246,27 +246,32 @@ const ContentDisplayArea: React.FC<ContentDisplayAreaProps> = ({
         {/* Citation Styling */}
         <style>{`
           .liw-cite {
-            background: linear-gradient(135deg, #e3f2fd, #bbdefb);
-            border: 1px solid #64b5f6;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 22px;
+            height: 18px;
+            padding: 0 5px;
+            font-size: 11px;
+            font-weight: 700;
+            line-height: 1;
+            color: #0a66c2;
+            background: rgba(10, 102, 194, 0.1);
+            border: 1px solid rgba(10, 102, 194, 0.25);
             border-radius: 4px;
-            padding: 2px 6px;
-            margin: 0 2px;
-            font-size: 0.8em;
-            font-weight: 600;
-            color: #1976d2;
             cursor: pointer;
-            transition: all 0.2s ease;
-            box-shadow: 0 2px 4px rgba(25, 118, 210, 0.1);
+            vertical-align: super;
+            transition: background 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
+            box-shadow: 0 1px 3px rgba(10, 102, 194, 0.08);
           }
           .liw-cite:hover {
-            background: linear-gradient(135deg, #bbdefb, #90caf9);
-            border-color: #42a5f5;
-            box-shadow: 0 4px 8px rgba(25, 118, 210, 0.2);
-            transform: translateY(-1px);
+            background: rgba(10, 102, 194, 0.18);
+            border-color: rgba(10, 102, 194, 0.4);
+            box-shadow: 0 2px 6px rgba(10, 102, 194, 0.15);
           }
           .liw-cite:active {
-            transform: translateY(0);
-            box-shadow: 0 2px 4px rgba(25, 118, 210, 0.1);
+            background: rgba(10, 102, 194, 0.25);
+            box-shadow: 0 1px 2px rgba(10, 102, 194, 0.1);
           }
           
           @keyframes spin {

--- a/frontend/src/components/TextEditor/ContentDisplayArea.tsx
+++ b/frontend/src/components/TextEditor/ContentDisplayArea.tsx
@@ -87,6 +87,14 @@ const ContentDisplayArea: React.FC<ContentDisplayAreaProps> = ({
     }
   }, [draft, localDraft]);
 
+  // Auto-size textarea to show all content
+  useEffect(() => {
+    if (textareaRef.current && assistantOn) {
+      textareaRef.current.style.height = 'auto';
+      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+    }
+  }, [localDraft, assistantOn]);
+
   // Cleanup debounced saver
   useEffect(() => {
     return () => {
@@ -101,7 +109,6 @@ const ContentDisplayArea: React.FC<ContentDisplayAreaProps> = ({
       onMouseUp={assistantOn ? undefined : onTextSelection}
       style={{ 
         padding: '20px',
-        minHeight: '400px',
         lineHeight: '1.6',
         position: 'relative',
         userSelect: 'text',
@@ -209,7 +216,6 @@ const ContentDisplayArea: React.FC<ContentDisplayAreaProps> = ({
                 autoFocus
                 style={{
                   width: '100%',
-                  minHeight: '300px',
                   outline: 'none',
                   border: '1px solid #e0e0e0',
                   borderRadius: '8px',


### PR DESCRIPTION
## Summary
Overhaul of LinkedIn Writer citation system, progress tracking, and prompt quality.

### Changes
- **Citation badges**: <sup>[N] replaced with styled <span class="liw-cite"> LinkedIn-blue pill badges with hover/active states
- **Citation hover tooltip**: Removed console spam, fixed tooltip staying open on hover-away (duplicate event listeners from React re-renders), added fallback tooltip when source data not yet loaded
- **Persisted citations**: [Source N] markers now convert to badges even when research sources are not loaded (page refresh). Research sources, citations, and quality metrics now survive page refresh via localStorage
- **Progress modal**: Glass-morphism styling (rgba + backdropFilter), step cycling fix (personalize step was stuck on active), educational descriptions per step
- **Loading indicator**: Matching glass styling, removed debug line
- **Prompts**: Anti-hallucination block added to all 4 generators, hardcoded '2024-2025' removed from article prompt, 'trending hashtags' replaced with 'industry-specific hashtags'
- **Date injection**: TODAY'S_DATE prepended in _build_research_context() (dynamic, via datetime.now())
- **PR merge**: Cherry-picked overflow/full-content display fix from #756
