### PR TITLE
feat: add linkedin text post publish feature

### DIFF
--- a/backend/api/linkedin_social_routes.py
+++ b/backend/api/linkedin_social_routes.py
@@ -44,6 +44,8 @@ from models.linkedin_social_models import (
     ProfileValidationResponse,
     TopicRecommendationResponse,
     TopicRecommendationsMetaResponse,
+    LinkedInPublishPostRequest,
+    LinkedInPublishPostResponse,
 )
 from services.integrations.linkedin.profile_intelligence_llm import ProfileIntelligenceLLMError
 from services.integrations.linkedin.profile_intelligence_service import (
@@ -102,7 +104,8 @@ from services.integrations.linkedin.profile_repository import ProfileRepository
 from services.integrations.linkedin.profile_service import get_or_fetch_profile
 from services.integrations.linkedin.profile_validation_service import get_or_validate_profile_context
 from services.integrations.linkedin.profile_validation_types import ProfileValidationResult
-from services.integrations.linkedin.types import LinkedInNotConnectedError
+from services.integrations.linkedin.types import CreatePostRequest, LinkedInNotConnectedError
+from services.integrations.linkedin.exceptions import LinkedInDuplicateContentError
 from services.integrations.linkedin.unipile_client import UnipileAPIError
 from services.integrations.linkedin.zernio_client import ZernioAPIError
 from services.integrations.linkedin_oauth import LinkedInOAuthService
@@ -1862,6 +1865,135 @@ async def disconnect_linkedin(
     except Exception as e:
         logger.exception(f"[LinkedInConnect] disconnect failed user_id={user_id}: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/posts/publish", response_model=LinkedInPublishPostResponse)
+async def publish_linkedin_post(
+    body: LinkedInPublishPostRequest,
+    current_user: dict = Depends(get_current_user),
+) -> LinkedInPublishPostResponse:
+    """Publish a text-only post to the user's connected LinkedIn personal profile."""
+    user_id = _user_id(current_user)
+    debug_id = uuid.uuid4().hex[:12]
+    content = (body.content or "").strip()
+    provider = get_linkedin_provider()
+
+    logger.info(
+        "[LinkedInPublish] request user_id={} provider={} content_len={} "
+        "account_id_present={} debug_id={}",
+        user_id,
+        provider.provider_name,
+        len(content),
+        bool(body.account_id),
+        debug_id,
+    )
+
+    if not content:
+        logger.warning("[LinkedInPublish] empty content user_id={} debug_id={}", user_id, debug_id)
+        raise HTTPException(status_code=400, detail="Post content cannot be empty")
+
+    try:
+        creds = _oauth_service.resolve_credentials(user_id)
+        account_id = creds.unipile_account_id or creds.primary_account_id
+        if not account_id:
+            raise LinkedInNotConnectedError("No LinkedIn account connected")
+
+        if body.account_id and body.account_id != account_id:
+            raise ValueError(
+                "Account ID does not match your connected LinkedIn personal profile"
+            )
+
+        request = CreatePostRequest(account_id=account_id, content=content)
+        result = await provider.create_post(user_id, request)
+
+        logger.info(
+            "[LinkedInPublish] success user_id={} post_id={} post_urn={} debug_id={}",
+            user_id,
+            result.post_id,
+            result.post_urn,
+            debug_id,
+        )
+
+        return LinkedInPublishPostResponse(
+            success=True,
+            post_id=result.post_id,
+            post_urn=result.post_urn,
+            provider=provider.provider_name,
+            message="Published to LinkedIn.",
+            debug_id=debug_id,
+        )
+
+    except LinkedInNotConnectedError as exc:
+        logger.warning(
+            "[LinkedInPublish] not connected user_id={} debug_id={}: {}",
+            user_id,
+            debug_id,
+            exc,
+        )
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+    except LinkedInDuplicateContentError as exc:
+        logger.warning(
+            "[LinkedInPublish] duplicate content user_id={} debug_id={}: {}",
+            user_id,
+            debug_id,
+            exc,
+        )
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ValueError as exc:
+        logger.warning(
+            "[LinkedInPublish] validation failed user_id={} debug_id={}: {}",
+            user_id,
+            debug_id,
+            exc,
+        )
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except UnipileAPIError as exc:
+        status = exc.status_code or 502
+        if status == 403:
+            http_status = 403
+            message = "Insufficient permissions to publish to LinkedIn."
+        elif status == 401:
+            http_status = 401
+            message = "LinkedIn account disconnected. Please reconnect and try again."
+        elif status == 400:
+            http_status = 400
+            message = "Invalid publish request. Please check your post and try again."
+        elif status >= 500:
+            http_status = 502
+            message = "LinkedIn publishing service is temporarily unavailable."
+        else:
+            http_status = 502
+            message = "Could not publish to LinkedIn. Please try again."
+        logger.error(
+            "[LinkedInPublish] Unipile error user_id={} debug_id={} status={}: {}",
+            user_id,
+            debug_id,
+            status,
+            exc,
+        )
+        raise HTTPException(status_code=http_status, detail=message) from exc
+    except NotImplementedError as exc:
+        logger.error(
+            "[LinkedInPublish] provider not implemented user_id={} debug_id={}: {}",
+            user_id,
+            debug_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=501,
+            detail="LinkedIn publishing is not available for this provider.",
+        ) from exc
+    except Exception as exc:
+        logger.exception(
+            "[LinkedInPublish] unexpected error user_id={} debug_id={}: {}",
+            user_id,
+            debug_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Could not publish to LinkedIn. Please try again.",
+        ) from exc
 
 
 @router.get("/accounts", response_model=LinkedInAccountsListResponse)

--- a/backend/models/linkedin_social_models.py
+++ b/backend/models/linkedin_social_models.py
@@ -275,3 +275,21 @@ class LinkedInProfileCompleteResponse(BaseModel):
     profile_completion: ProfileCompletionResponse
     ai_profile_intelligence: Optional[AIProfileIntelligenceResponse] = None
     ai_profile_intelligence_meta: Optional[ProfileIntelligenceMetaResponse] = None
+
+
+class LinkedInPublishPostRequest(BaseModel):
+    """Request body for POST /api/linkedin-social/posts/publish."""
+
+    content: str
+    account_id: Optional[str] = None
+
+
+class LinkedInPublishPostResponse(BaseModel):
+    """Response for POST /api/linkedin-social/posts/publish."""
+
+    success: bool
+    post_id: Optional[str] = None
+    post_urn: Optional[str] = None
+    provider: str
+    message: str
+    debug_id: str

--- a/backend/services/integrations/linkedin/unipile_client.py
+++ b/backend/services/integrations/linkedin/unipile_client.py
@@ -44,6 +44,14 @@ def _auth_headers(api_key: str) -> dict[str, str]:
     }
 
 
+def _post_auth_headers(api_key: str) -> dict[str, str]:
+    """Headers for multipart POST endpoints (Content-Type set by httpx)."""
+    return {
+        "X-API-KEY": api_key,
+        "Accept": "application/json",
+    }
+
+
 def _raise_for_error(response: httpx.Response) -> None:
     """Raise UnipileAPIError for non-success status codes."""
     if response.status_code < 400:
@@ -451,6 +459,53 @@ class UnipileClient:
         except Exception as e:
             logger.error(f"[UnipileClient] Error deleting account {account_id}: {e}")
             return False
+
+    async def create_post(self, account_id: str, text: str) -> dict[str, Any]:
+        """
+        Publish a text-only LinkedIn post via Unipile.
+
+        Args:
+            account_id: Unipile account ID for the connected LinkedIn profile
+            text: Post body text
+
+        Returns:
+            Raw Unipile post response (includes id, social_id, share_url)
+
+        Raises:
+            UnipileAPIError: If the API request fails
+            ValueError: If API key is not configured
+        """
+        if not self._api_key:
+            raise ValueError("Unipile API key is required")
+
+        url = self._get_full_url("/api/v1/posts")
+        # Unipile POST /api/v1/posts requires multipart/form-data (not JSON).
+        # Send only account_id + text — omit attachments / video_thumbnail entirely.
+        form_fields = {
+            "account_id": (None, account_id),
+            "text": (None, text),
+        }
+
+        logger.info(
+            f"[UnipileClient] create_post account_id={account_id} text_len={len(text)}"
+        )
+
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.post(
+                url,
+                files=form_fields,
+                headers=_post_auth_headers(self._api_key),
+            )
+            _raise_for_error(response)
+            data = response.json()
+
+        post_id = data.get("id") if isinstance(data, dict) else None
+        social_id = data.get("social_id") if isinstance(data, dict) else None
+        logger.info(
+            f"[UnipileClient] create_post success account_id={account_id} "
+            f"status={response.status_code} post_id={post_id} social_id={social_id}"
+        )
+        return data
 
     async def reconnect_account(
         self,

--- a/backend/services/integrations/linkedin/unipile_provider.py
+++ b/backend/services/integrations/linkedin/unipile_provider.py
@@ -26,6 +26,7 @@ from services.integrations.linkedin.types import (
     ProfileAggregation,
     ReplyResult,
 )
+from services.integrations.linkedin.publish_preflight import run_publish_preflight
 from services.integrations.linkedin.unipile_client import (
     UnipileClient,
     UnipileAPIError,
@@ -596,15 +597,62 @@ class UnipileProvider:
         self, user_id: str, request: CreatePostRequest
     ) -> CreatePostResult:
         """
-        Create a LinkedIn post.
+        Publish a text-only post to the user's connected LinkedIn personal profile.
 
-        Phase 1: Not implemented. Raises NotImplementedError.
-        Phase 4: Will implement publishing.
+        v1: personal profile only; no first comment, media, or organization posting.
         """
-        logger.warning(
-            f"[UnipileProvider] create_post called but not implemented (Phase 1)"
+        logger.info(
+            f"[UnipileProvider] create_post user_id={user_id} "
+            f"content_len={len(request.content or '')}"
         )
-        raise NotImplementedError(_PUBLISHING_NOT_IMPLEMENTED)
+
+        creds = self._oauth.resolve_credentials(user_id)
+        if creds.provider_mode != "unipile" or not creds.unipile_account_id:
+            raise LinkedInNotConnectedError("Unipile LinkedIn account not connected")
+
+        account_id = creds.unipile_account_id
+        if request.account_id and request.account_id != account_id:
+            raise ValueError(
+                "Account ID does not match your connected LinkedIn personal profile"
+            )
+
+        if request.organization_urn:
+            raise ValueError(
+                "Organization posting is not supported yet. Switch to personal profile."
+            )
+
+        text = (request.content or "").strip()
+        if not text:
+            raise ValueError("Post content cannot be empty")
+
+        publish_request = CreatePostRequest(account_id=account_id, content=text)
+        await run_publish_preflight(user_id, publish_request)
+
+        try:
+            raw = await self._client.create_post(account_id, text)
+        except UnipileAPIError as exc:
+            logger.error(
+                f"[UnipileProvider] create_post Unipile error user_id={user_id} "
+                f"account_id={account_id} status={exc.status_code}: {exc}"
+            )
+            raise
+
+        post_id = raw.get("id") if isinstance(raw, dict) else None
+        post_urn = None
+        if isinstance(raw, dict):
+            post_urn = raw.get("social_id") or raw.get("urn") or post_id
+
+        logger.info(
+            f"[UnipileProvider] create_post success user_id={user_id} "
+            f"post_id={post_id} post_urn={post_urn}"
+        )
+
+        return CreatePostResult(
+            success=True,
+            post_id=str(post_id) if post_id else None,
+            post_urn=str(post_urn) if post_urn else None,
+            raw=raw if isinstance(raw, dict) else {},
+        )
 
     async def upload_media(
         self,

--- a/backend/tests/api/test_linkedin_publish_route.py
+++ b/backend/tests/api/test_linkedin_publish_route.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from cryptography.fernet import Fernet
+from fastapi import HTTPException
+from loguru import logger
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+
+@contextmanager
+def _linkedin_env():
+    key = Fernet.generate_key().decode("utf-8")
+    with patch.dict(
+        os.environ,
+        {"LINKEDIN_TOKEN_ENCRYPTION_KEY": key},
+        clear=False,
+    ):
+        yield
+
+
+def _load_linkedin_social_routes():
+    module_name = "_linkedin_social_routes_publish_under_test"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+
+    routes_path = _BACKEND_ROOT / "api" / "linkedin_social_routes.py"
+    spec = importlib.util.spec_from_file_location(module_name, routes_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load route module from {routes_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    if not hasattr(logger, "warn"):
+        setattr(logger, "warn", logger.warning)
+    stub_main_text_generation = ModuleType("services.llm_providers.main_text_generation")
+    stub_main_text_generation.llm_text_gen = SimpleNamespace()
+    stub_huggingface_provider = ModuleType("services.llm_providers.huggingface_provider")
+    stub_huggingface_provider.huggingface_text_response = lambda *args, **kwargs: None
+    stub_huggingface_provider.huggingface_structured_json_response = (
+        lambda *args, **kwargs: None
+    )
+    with patch.dict(
+        sys.modules,
+        {
+            "services.llm_providers.main_text_generation": stub_main_text_generation,
+            "services.llm_providers.huggingface_provider": stub_huggingface_provider,
+        },
+        clear=False,
+    ):
+        with _linkedin_env():
+            spec.loader.exec_module(module)
+    return module
+
+
+_routes = _load_linkedin_social_routes()
+
+
+@pytest.mark.anyio
+async def test_publish_linkedin_post_returns_success() -> None:
+    provider = SimpleNamespace(
+        provider_name="unipile",
+        create_post=AsyncMock(
+            return_value=SimpleNamespace(
+                success=True,
+                post_id="123",
+                post_urn="urn:li:activity:123",
+                raw={"id": "123", "social_id": "urn:li:activity:123"},
+            )
+        ),
+    )
+
+    with (
+        patch.object(_routes, "get_linkedin_provider", return_value=provider),
+        patch.object(
+            _routes._oauth_service,
+            "resolve_credentials",
+            return_value=SimpleNamespace(
+                provider_mode="unipile",
+                unipile_account_id="acct-1",
+                primary_account_id="acct-1",
+            ),
+        ),
+    ):
+        response = await _routes.publish_linkedin_post(
+            body=_routes.LinkedInPublishPostRequest(
+                content="Hello LinkedIn",
+                account_id="acct-1",
+            ),
+            current_user={"id": "user_1"},
+        )
+
+    assert response.success is True
+    assert response.post_urn == "urn:li:activity:123"
+    assert response.debug_id
+    provider.create_post.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_publish_linkedin_post_returns_401_when_not_connected() -> None:
+    from services.integrations.linkedin.types import LinkedInNotConnectedError
+
+    provider = SimpleNamespace(provider_name="unipile")
+
+    with (
+        patch.object(_routes, "get_linkedin_provider", return_value=provider),
+        patch.object(
+            _routes._oauth_service,
+            "resolve_credentials",
+            side_effect=LinkedInNotConnectedError("No LinkedIn credentials available"),
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await _routes.publish_linkedin_post(
+                body=_routes.LinkedInPublishPostRequest(
+                    content="Hello LinkedIn",
+                    account_id="acct-1",
+                ),
+                current_user={"id": "user_1"},
+            )
+
+    assert exc_info.value.status_code == 401
+    assert "No LinkedIn credentials" in str(exc_info.value.detail)
+
+
+@pytest.mark.anyio
+async def test_publish_linkedin_post_returns_400_for_empty_content() -> None:
+    provider = SimpleNamespace(provider_name="unipile")
+
+    with patch.object(_routes, "get_linkedin_provider", return_value=provider):
+        with pytest.raises(HTTPException) as exc_info:
+            await _routes.publish_linkedin_post(
+                body=_routes.LinkedInPublishPostRequest(content="   "),
+                current_user={"id": "user_1"},
+            )
+
+    assert exc_info.value.status_code == 400

--- a/backend/tests/test_linkedin_unipile_publish.py
+++ b/backend/tests/test_linkedin_unipile_publish.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+from services.integrations.linkedin.types import CreatePostRequest
+from services.integrations.linkedin.unipile_client import (
+    UnipileAPIError,
+    UnipileClient,
+)
+from services.integrations.linkedin.unipile_provider import UnipileProvider
+
+
+def _mock_async_http_client(response: Mock) -> AsyncMock:
+    client = AsyncMock()
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+    client.post = AsyncMock(return_value=response)
+    return client
+
+
+@pytest.mark.anyio
+async def test_unipile_client_create_post_uses_posts_endpoint() -> None:
+    response = Mock(status_code=201, text="created")
+    response.json.return_value = {
+        "id": "123",
+        "social_id": "urn:li:activity:123",
+        "share_url": "https://www.linkedin.com/posts/example",
+    }
+    mock_client = _mock_async_http_client(response)
+
+    with patch(
+        "services.integrations.linkedin.unipile_client.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        client = UnipileClient(api_key="test-key", dsn="api.example.com")
+        data = await client.create_post("acct-1", "Hello LinkedIn")
+
+    assert data["social_id"] == "urn:li:activity:123"
+    mock_client.post.assert_awaited_once()
+    url = mock_client.post.await_args.args[0]
+    assert url.endswith("/api/v1/posts")
+    assert mock_client.post.await_args.kwargs["files"] == {
+        "account_id": (None, "acct-1"),
+        "text": (None, "Hello LinkedIn"),
+    }
+    assert "json" not in mock_client.post.await_args.kwargs
+
+
+@pytest.mark.anyio
+async def test_unipile_client_create_post_raises_on_error() -> None:
+    response = Mock(status_code=403, text="Forbidden")
+    mock_client = _mock_async_http_client(response)
+
+    with patch(
+        "services.integrations.linkedin.unipile_client.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        client = UnipileClient(api_key="test-key", dsn="api.example.com")
+        with pytest.raises(UnipileAPIError) as exc_info:
+            await client.create_post("acct-1", "Hello LinkedIn")
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_unipile_provider_create_post_publishes_text_only() -> None:
+    creds = SimpleNamespace(provider_mode="unipile", unipile_account_id="acct-1")
+    provider = UnipileProvider(
+        oauth_service=SimpleNamespace(resolve_credentials=lambda user_id: creds)
+    )
+    provider._client.create_post = AsyncMock(
+        return_value={
+            "id": "123",
+            "social_id": "urn:li:activity:123",
+            "share_url": "https://www.linkedin.com/posts/example",
+        }
+    )
+
+    with patch(
+        "services.integrations.linkedin.unipile_provider.run_publish_preflight",
+        new_callable=AsyncMock,
+    ):
+        result = await provider.create_post(
+            "user_1",
+            CreatePostRequest(
+                account_id="acct-1",
+                content="Hello LinkedIn",
+            ),
+        )
+
+    assert result.success is True
+    assert result.post_urn == "urn:li:activity:123"
+    provider._client.create_post.assert_awaited_once_with("acct-1", "Hello LinkedIn")
+
+
+@pytest.mark.anyio
+async def test_unipile_provider_create_post_rejects_empty_content() -> None:
+    creds = SimpleNamespace(provider_mode="unipile", unipile_account_id="acct-1")
+    provider = UnipileProvider(
+        oauth_service=SimpleNamespace(resolve_credentials=lambda user_id: creds)
+    )
+    provider._client.create_post = AsyncMock()
+
+    with pytest.raises(ValueError, match="empty"):
+        await provider.create_post(
+            "user_1",
+            CreatePostRequest(account_id="acct-1", content="   "),
+        )
+
+    provider._client.create_post.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_unipile_provider_create_post_rejects_account_mismatch() -> None:
+    creds = SimpleNamespace(provider_mode="unipile", unipile_account_id="acct-1")
+    provider = UnipileProvider(
+        oauth_service=SimpleNamespace(resolve_credentials=lambda user_id: creds)
+    )
+    provider._client.create_post = AsyncMock()
+
+    with pytest.raises(ValueError, match="does not match"):
+        await provider.create_post(
+            "user_1",
+            CreatePostRequest(account_id="other-acct", content="Hello"),
+        )
+
+    provider._client.create_post.assert_not_called()

--- a/frontend/src/api/linkedinSocial.ts
+++ b/frontend/src/api/linkedinSocial.ts
@@ -258,6 +258,20 @@ export interface LinkedInProfileCompleteResponse {
   ai_profile_intelligence_meta?: LinkedInProfileIntelligenceMeta | null;
 }
 
+export interface LinkedInPublishPostRequest {
+  content: string;
+  account_id?: string;
+}
+
+export interface LinkedInPublishPostResponse {
+  success: boolean;
+  post_id?: string | null;
+  post_urn?: string | null;
+  provider: string;
+  message: string;
+  debug_id: string;
+}
+
 const BASE = '/api/linkedin-social';
 
 export async function getLinkedInConnectionStatus(): Promise<LinkedInConnectionStatus> {
@@ -282,6 +296,14 @@ export async function syncLinkedInAccounts(): Promise<{
 
 export async function disconnectLinkedIn(): Promise<LinkedInDisconnectResponse> {
   const response = await apiClient.post(`${BASE}/disconnect`);
+  return response.data;
+}
+
+/** Publish the LinkedIn Writer draft as a text-only post to the personal profile. */
+export async function publishLinkedInPost(
+  payload: LinkedInPublishPostRequest
+): Promise<LinkedInPublishPostResponse> {
+  const response = await apiClient.post(`${BASE}/posts/publish`, payload);
   return response.data;
 }
 

--- a/frontend/src/components/LinkedInWriter/components/PublishLinkedInPanel.tsx
+++ b/frontend/src/components/LinkedInWriter/components/PublishLinkedInPanel.tsx
@@ -1,20 +1,18 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import {
+  Alert,
   Box,
   Button,
-  Checkbox,
-  FormControlLabel,
-  TextField,
-  Tooltip,
-  Typography,
   Chip,
+  CircularProgress,
+  Typography,
 } from '@mui/material';
 import { LinkedIn as LinkedInIcon } from '@mui/icons-material';
 import { useLinkedInSocialConnection } from '../../../hooks/useLinkedInSocialConnection';
 import {
-  applyLinkInFirstComment,
-  buildPublishPayload,
-} from '../utils/firstCommentUtils';
+  getLinkedInSocialErrorMessage,
+  publishLinkedInPost,
+} from '../../../api/linkedinSocial';
 
 interface PublishLinkedInPanelProps {
   draft: string;
@@ -26,31 +24,42 @@ const PublishLinkedInPanel: React.FC<PublishLinkedInPanelProps> = ({ draft }) =>
     provider,
     selectedAccountId,
     selectedTarget,
-    selectedOrgId,
     isLoading,
   } = useLinkedInSocialConnection();
 
-  const [firstComment, setFirstComment] = useState('');
-  const [moveLinksEnabled, setMoveLinksEnabled] = useState(true);
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!moveLinksEnabled) return;
-    setFirstComment((prev) => {
-      if (prev.trim()) return prev;
-      const applied = applyLinkInFirstComment(draft, '', true);
-      return applied.firstComment;
-    });
-  }, [draft, moveLinksEnabled]);
+  const trimmedDraft = draft.trim();
+  const isOrgTarget = selectedTarget === 'organization';
+  const canPublish =
+    connected && !!trimmedDraft && !isOrgTarget && !isPublishing && !isLoading;
 
-  const previewPayload = useMemo(
-    () => buildPublishPayload(draft, firstComment, moveLinksEnabled),
-    [draft, firstComment, moveLinksEnabled]
-  );
-
-  const canPublish = connected && !!previewPayload.content.trim();
   const connectionLabel = connected
     ? `Connected via ${provider}`
     : 'Not connected — connect LinkedIn to publish';
+
+  const handlePublish = async () => {
+    if (!canPublish) return;
+
+    setIsPublishing(true);
+    setSuccessMessage(null);
+    setErrorMessage(null);
+
+    try {
+      const result = await publishLinkedInPost({
+        content: trimmedDraft,
+        account_id: selectedAccountId || undefined,
+      });
+      setSuccessMessage(result.message || 'Published to LinkedIn.');
+    } catch (err) {
+      console.error('[LinkedInPublish] publish failed:', err);
+      setErrorMessage(getLinkedInSocialErrorMessage(err));
+    } finally {
+      setIsPublishing(false);
+    }
+  };
 
   return (
     <Box
@@ -82,49 +91,42 @@ const PublishLinkedInPanel: React.FC<PublishLinkedInPanelProps> = ({ draft }) =>
           <>
             {' '}
             · Post as {selectedTarget === 'organization' ? 'company page' : 'profile'}
-            {selectedTarget === 'organization' && selectedOrgId ? ` (${selectedOrgId})` : ''}
           </>
         )}
       </Typography>
 
-      <FormControlLabel
-        control={
-          <Checkbox
-            size="small"
-            checked={moveLinksEnabled}
-            onChange={(e) => setMoveLinksEnabled(e.target.checked)}
-          />
-        }
-        label={
-          <Typography variant="body2" sx={{ color: '#334155' }}>
-            Move links from post to first comment (recommended for reach)
-          </Typography>
-        }
-        sx={{ mb: 1 }}
-      />
+      <Typography variant="caption" sx={{ color: '#64748b', display: 'block', mb: 1.5 }}>
+        Publishes your full draft text to your LinkedIn personal profile. First comment and
+        media support coming soon.
+      </Typography>
 
-      <TextField
-        fullWidth
-        size="small"
-        label="Link to include in first comment"
-        placeholder="https://example.com/your-article"
-        value={firstComment}
-        onChange={(e) => setFirstComment(e.target.value)}
-        helperText="Zernio posts links in the first comment to avoid LinkedIn reach penalties on link posts."
-        sx={{ mb: 1.5, bgcolor: '#fff' }}
-      />
+      {isOrgTarget && (
+        <Alert severity="info" sx={{ mb: 1.5 }}>
+          Switch to personal profile to publish. Company page posting is not available yet.
+        </Alert>
+      )}
 
-      <Tooltip title="Publishing ships in Phase 2 — payload is prepared with first_comment">
-        <span>
-          <Button
-            variant="contained"
-            disabled={!canPublish}
-            sx={{ bgcolor: '#0A66C2', '&:hover': { bgcolor: '#004182' } }}
-          >
-            Publish to LinkedIn
-          </Button>
-        </span>
-      </Tooltip>
+      {successMessage && (
+        <Alert severity="success" sx={{ mb: 1.5 }}>
+          {successMessage}
+        </Alert>
+      )}
+
+      {errorMessage && (
+        <Alert severity="error" sx={{ mb: 1.5 }}>
+          {errorMessage}
+        </Alert>
+      )}
+
+      <Button
+        variant="contained"
+        disabled={!canPublish}
+        onClick={handlePublish}
+        startIcon={isPublishing ? <CircularProgress size={16} color="inherit" /> : undefined}
+        sx={{ bgcolor: '#0A66C2', '&:hover': { bgcolor: '#004182' } }}
+      >
+        {isPublishing ? 'Publishing...' : 'Publish to LinkedIn'}
+      </Button>
     </Box>
   );
 };


### PR DESCRIPTION
This PR introduces a direct "Publish" feature for text-based content within the LinkedIn Writer module. This allows users to post generated content directly to LinkedIn, improving the end-to-end workflow within ALwrity.

### Key Changes
**Backend**: Added new API routes and integrated the Unipile client/provider to handle LinkedIn text publishing.

**Frontend**: Updated LinkedInWriter components to include a PublishLinkedInPanel, allowing users to trigger the publish action directly from the editor.

**Testing**: Included new unit and integration tests (test_linkedin_publish_route.py, test_linkedin_unipile_publish.py) to verify the publishing flow and error handling.

### Testing Performed
- Verified that text content from the editor is correctly formatted and sent to the LinkedIn API.
- Confirmed the UI reflects the publish status correctly within the LinkedIn Writer panel and post is successfully published on LinkedIn personal profile.
- Ran internal integration tests to ensure the Unipile provider communication is stable.