### PR TITLE
feat(landing): nav auto-hide, cross-page scroll, and hero copy updates

### DIFF
--- a/frontend/src/components/App/TokenInstaller.tsx
+++ b/frontend/src/components/App/TokenInstaller.tsx
@@ -1,25 +1,28 @@
 import { useEffect } from 'react';
-import { useAuth } from '@clerk/clerk-react';
+import { useAuth, useUser } from '@clerk/clerk-react';
 import { setAuthTokenGetter, setClerkSignOut } from '../../api/client';
 import { setMediaAuthTokenGetter } from '../../utils/fetchMediaBlobUrl';
 import { setBillingAuthTokenGetter } from '../../services/billingService';
 import { hallucinationDetectorService } from '../../services/hallucinationDetectorService';
 import { writingAssistantService } from '../../services/writingAssistantService';
+import { persistReturningUserProfile } from '../../utils/returningUserStorage';
 
 const TokenInstaller: React.FC = () => {
   const { getToken, userId, isSignedIn, signOut } = useAuth();
+  const { user } = useUser();
   
   useEffect(() => {
     if (isSignedIn && userId) {
       console.log('TokenInstaller: Storing user_id in localStorage:', userId);
       localStorage.setItem('user_id', userId);
+      persistReturningUserProfile(user?.firstName ?? user?.fullName?.split(' ')[0]);
       
       window.dispatchEvent(new CustomEvent('user-authenticated', { detail: { userId } }));
     } else if (!isSignedIn) {
       console.log('TokenInstaller: Clearing user_id from localStorage');
       localStorage.removeItem('user_id');
     }
-  }, [isSignedIn, userId]);
+  }, [isSignedIn, userId, user?.firstName, user?.fullName]);
   
   useEffect(() => {
     const tokenGetter = async () => {

--- a/frontend/src/components/Landing/HeroSection.tsx
+++ b/frontend/src/components/Landing/HeroSection.tsx
@@ -380,7 +380,7 @@ const HeroSection: React.FC = () => {
                       textShadow: '0 2px 6px rgba(0, 0, 0, 0.7)',
                     }}
                   >
-                    Bring Your Own Keys • No vendor lock-in • Enterprise security
+                    AI Marketing OS • No vendor lock-in • Enterprise security
                   </Typography>
 
                   <Grid

--- a/frontend/src/components/Landing/Landing.tsx
+++ b/frontend/src/components/Landing/Landing.tsx
@@ -1,5 +1,5 @@
-import React, { Suspense, lazy } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { Suspense, lazy, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useClerk } from '@clerk/clerk-react';
 import usePerformanceMonitor from '../../hooks/usePerformanceMonitor';
 import {
@@ -39,6 +39,7 @@ import {
   landingSectionHeaderGap,
   landingCardHoverSx,
 } from './landingStyles';
+import { parseLandingHash, scrollToLandingSectionWithRetry, isLandingMarketingPath } from '../../utils/landingNavigation';
 
 const PRICING_TEASER_PLANS = [
   {
@@ -77,13 +78,13 @@ const PRICING_TEASER_PLANS = [
       'Higher AI usage limits',
       'Team collaboration features',
       'Scheduler & remarketing',
-      'BYOK for all providers',
+      'Fact-checked AI content with source verification',
     ],
   },
   {
     name: 'Enterprise',
-    price: 'Custom',
-    period: '',
+    price: '$199',
+    period: '/mo',
     highlight: false,
     features: [
       'Dedicated account manager',
@@ -133,10 +134,18 @@ const IntroducingAlwrity = lazy(() => import('./IntroducingAlwrity'));
 const Landing: React.FC = () => {
   const theme = useTheme();
   const navigate = useNavigate();
+  const location = useLocation();
   const { openSignIn } = useClerk();
   
   // Monitor performance
   usePerformanceMonitor('Landing');
+
+  useEffect(() => {
+    if (!isLandingMarketingPath(location.pathname)) return undefined;
+    const section = parseLandingHash(location.hash);
+    if (!section) return undefined;
+    return scrollToLandingSectionWithRetry(section);
+  }, [location.pathname, location.hash]);
 
   // Optimized Framer Motion variants for better performance
 

--- a/frontend/src/components/Landing/LandingFooter.tsx
+++ b/frontend/src/components/Landing/LandingFooter.tsx
@@ -3,172 +3,122 @@ import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 
 import {
-
   Box,
-
   Container,
-
   Divider,
-
   Link,
-
   Stack,
-
   Typography,
-
   useTheme,
-
   alpha,
-
 } from '@mui/material';
 
 import BrandMark from './BrandMark';
 
+interface LandingFooterProps {
+  surface?: 'dark' | 'light';
+}
 
-
-const LandingFooter: React.FC = () => {
-
+const LandingFooter: React.FC<LandingFooterProps> = ({ surface = 'dark' }) => {
   const theme = useTheme();
-
   const year = new Date().getFullYear();
+  const isLight = surface === 'light';
 
+  const linkSx = isLight
+    ? {
+        color: '#64748b',
+        textDecoration: 'none',
+        fontSize: '0.9rem',
+        '&:hover': { color: '#6366f1' },
+      }
+    : {
+        color: alpha('#fff', 0.75),
+        textDecoration: 'none',
+        fontSize: '0.9rem',
+        '&:hover': { color: theme.palette.primary.light },
+      };
 
-
-  const linkSx = {
-
-    color: alpha('#fff', 0.75),
-
-    textDecoration: 'none',
-
-    fontSize: '0.9rem',
-
-    '&:hover': { color: theme.palette.primary.light },
-
-  };
-
-
+  const mutedText = isLight ? '#64748b' : alpha('#fff', 0.45);
+  const footerLinkMuted = isLight ? '#475569' : alpha('#fff', 0.55);
 
   return (
-
     <Box
-
       component="footer"
-
       sx={{
-
         py: 6,
-
-        background: `linear-gradient(180deg, ${alpha('#0a0a0a', 0.95)} 0%, #000 100%)`,
-
-        borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.15)}`,
-
+        background: isLight
+          ? '#F8FAFC'
+          : `linear-gradient(180deg, ${alpha('#0a0a0a', 0.95)} 0%, #000 100%)`,
+        borderTop: isLight
+          ? '1px solid #E5E7EB'
+          : `1px solid ${alpha(theme.palette.primary.main, 0.15)}`,
       }}
-
     >
-
       <Container maxWidth="lg">
-
         <Stack
-
           direction={{ xs: 'column', md: 'row' }}
-
           justifyContent="space-between"
-
           alignItems={{ xs: 'flex-start', md: 'center' }}
-
           spacing={3}
-
         >
-
           <Stack spacing={1}>
-
-            <BrandMark showSubtitle showTagline logoSize={40} />
-
-            <Typography variant="caption" color={alpha('#fff', 0.45)}>
-
+            <BrandMark
+              showSubtitle
+              showTagline
+              logoSize={40}
+              variant={isLight ? 'dark' : 'light'}
+            />
+            <Typography variant="caption" sx={{ color: mutedText }}>
               © {year} ALwrity. Open-source &amp; community-driven.
-
             </Typography>
-
           </Stack>
-
-
 
           <Stack direction={{ xs: 'column', sm: 'row' }} spacing={{ xs: 2, sm: 3 }} flexWrap="wrap">
-
             <Link component={RouterLink} to="/privacy" sx={linkSx}>
-
               Privacy Policy
-
             </Link>
-
             <Link component={RouterLink} to="/code-of-conduct" sx={linkSx}>
-
               Code of Conduct
-
             </Link>
-
             <Link component={RouterLink} to="/terms" sx={linkSx}>
-
               Terms of Service
-
             </Link>
-
           </Stack>
-
         </Stack>
 
+        <Divider
+          sx={{
+            my: 3,
+            borderColor: isLight ? '#E5E7EB' : alpha('#fff', 0.08),
+          }}
+        />
 
-
-        <Divider sx={{ my: 3, borderColor: alpha('#fff', 0.08) }} />
-
-
-
-        <Typography variant="caption" color={alpha('#fff', 0.4)} display="block" textAlign="center">
-
+        <Typography
+          variant="caption"
+          sx={{ color: mutedText }}
+          display="block"
+          textAlign="center"
+        >
           © {year} ALwrity. See our{' '}
-
-          <Link component={RouterLink} to="/privacy" sx={{ color: alpha('#fff', 0.55) }}>
-
+          <Link component={RouterLink} to="/privacy" sx={{ color: footerLinkMuted }}>
             Privacy Policy
-
           </Link>
-
           ,{' '}
-
-          <Link component={RouterLink} to="/code-of-conduct" sx={{ color: alpha('#fff', 0.55) }}>
-
+          <Link component={RouterLink} to="/code-of-conduct" sx={{ color: footerLinkMuted }}>
             Code of Conduct
-
           </Link>
-
           , and{' '}
-
-          <Link component={RouterLink} to="/terms" sx={{ color: alpha('#fff', 0.55) }}>
-
+          <Link component={RouterLink} to="/terms" sx={{ color: footerLinkMuted }}>
             Terms of Service
-
           </Link>
-
           . Inquiries:{' '}
-
-          <Link href="mailto:info@alwrity.com" sx={{ color: alpha('#fff', 0.55) }}>
-
+          <Link href="mailto:info@alwrity.com" sx={{ color: footerLinkMuted }}>
             info@alwrity.com
-
           </Link>
-
         </Typography>
-
       </Container>
-
     </Box>
-
   );
-
 };
 
-
-
 export default LandingFooter;
-

--- a/frontend/src/components/Landing/LandingNav.tsx
+++ b/frontend/src/components/Landing/LandingNav.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Link as RouterLink, useNavigate } from 'react-router-dom';
+import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
 import {
   AppBar,
   Box,
@@ -17,24 +17,39 @@ import {
 import MenuIcon from '@mui/icons-material/Menu';
 import CloseIcon from '@mui/icons-material/Close';
 import BrandMark from './BrandMark';
+import NavAuthButton from './NavAuthButton';
+import {
+  landingPathForSection,
+  scrollToLandingSection,
+  isLandingMarketingPath,
+  LANDING_MARKETING_PATH,
+  type LandingSectionId,
+} from '../../utils/landingNavigation';
 
 type NavItem =
-  | { label: string; id: string; href?: never; newTab?: never }
-  | { label: string; href: string; newTab?: boolean; id?: never };
+  | { label: string; section: LandingSectionId }
+  | { label: string; href: string; newTab?: boolean };
+
+interface LandingNavProps {
+  /** Dark = transparent over hero (landing). Light = solid bar for white pages (pricing, etc.). */
+  surface?: 'dark' | 'light';
+}
 
 const NAV_ITEMS: NavItem[] = [
-  { label: 'Home', id: 'hero' },
-  { label: 'Lifecycle', id: 'lifecycle' },
-  { label: 'Features', id: 'features' },
-  { label: 'Pricing', href: '/pricing', newTab: true },
+  { label: 'Home', section: 'hero' },
+  { label: 'Lifecycle', section: 'lifecycle' },
+  { label: 'Features', section: 'features' },
+  { label: 'Pricing', href: '/pricing' },
 ];
 
 const NAV_HIDE_DELAY_MS = 3500;
 const TOP_REVEAL_ZONE_PX = 72;
 
-const LandingNav: React.FC = () => {
+const LandingNav: React.FC<LandingNavProps> = ({ surface = 'dark' }) => {
   const theme = useTheme();
   const navigate = useNavigate();
+  const location = useLocation();
+  const isLightSurface = surface === 'light';
   const [mobileOpen, setMobileOpen] = useState(false);
   const [navVisible, setNavVisible] = useState(true);
   const [elevated, setElevated] = useState(false);
@@ -70,9 +85,13 @@ const LandingNav: React.FC = () => {
   );
 
   useEffect(() => {
+    document.documentElement.style.setProperty('--sticky-top-offset', navVisible ? '64px' : '0px');
+  }, [navVisible]);
+
+  useEffect(() => {
     const onScroll = () => {
       const y = window.scrollY;
-      setElevated(y > 24);
+      setElevated(isLightSurface ? y > 8 : y > 24);
 
       if (y <= 16) {
         revealNav(false);
@@ -103,28 +122,35 @@ const LandingNav: React.FC = () => {
       window.removeEventListener('scroll', onScroll);
       window.removeEventListener('mousemove', onMouseMove);
       clearHideTimer();
+      document.documentElement.style.removeProperty('--sticky-top-offset');
     };
-  }, [clearHideTimer, revealNav]);
+  }, [clearHideTimer, revealNav, isLightSurface]);
 
-  const navLinkSx = {
-    color: 'rgba(255,255,255,0.94)',
-    fontWeight: 600,
-    fontSize: { xs: '1rem', md: '1.05rem' },
-    textDecoration: 'none',
-    cursor: 'pointer',
-    letterSpacing: '0.02em',
-    textShadow: '0 1px 6px rgba(0,0,0,0.45)',
-    '&:hover': { color: theme.palette.primary.light },
-  };
-
-  const scrollTo = (id: string) => {
-    setMobileOpen(false);
-    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
-  };
+  const navLinkSx = isLightSurface
+    ? {
+        color: '#1a1a2e',
+        fontWeight: 600,
+        fontSize: { xs: '1rem', md: '1.05rem' },
+        textDecoration: 'none',
+        cursor: 'pointer',
+        letterSpacing: '0.02em',
+        '&:hover': { color: theme.palette.primary.main },
+      }
+    : {
+        color: 'rgba(255,255,255,0.94)',
+        fontWeight: 600,
+        fontSize: { xs: '1rem', md: '1.05rem' },
+        textDecoration: 'none',
+        cursor: 'pointer',
+        letterSpacing: '0.02em',
+        textShadow: '0 1px 6px rgba(0,0,0,0.45)',
+        '&:hover': { color: theme.palette.primary.light },
+      };
 
   const handleNavClick = (item: NavItem) => {
-    if ('href' in item && item.href) {
-      setMobileOpen(false);
+    setMobileOpen(false);
+
+    if ('href' in item) {
       if (item.newTab) {
         window.open(item.href, '_blank', 'noopener,noreferrer');
         return;
@@ -132,27 +158,34 @@ const LandingNav: React.FC = () => {
       navigate(item.href);
       return;
     }
-    if ('id' in item && item.id) {
-      if (window.location.pathname !== '/') {
-        navigate(`/#${item.id}`);
-        return;
-      }
-      scrollTo(item.id);
+
+    const { section } = item;
+    if (!isLandingMarketingPath(location.pathname)) {
+      navigate(landingPathForSection(section));
+      return;
     }
+
+    scrollToLandingSection(section);
   };
 
   return (
     <>
       <AppBar
         position="fixed"
-        elevation={elevated ? 4 : 0}
+        elevation={isLightSurface ? 0 : elevated ? 4 : 0}
         sx={{
-          background: elevated
-            ? `linear-gradient(135deg, rgba(0,0,0,0.92) 0%, rgba(20,20,30,0.95) 100%)`
-            : 'transparent',
-          backdropFilter: elevated ? 'blur(12px)' : 'none',
-          borderBottom: elevated ? `1px solid ${alpha(theme.palette.primary.main, 0.2)}` : 'none',
-          boxShadow: elevated ? undefined : 'none',
+          background: isLightSurface
+            ? '#FFFFFF'
+            : elevated
+              ? `linear-gradient(135deg, rgba(0,0,0,0.92) 0%, rgba(20,20,30,0.95) 100%)`
+              : 'transparent',
+          backdropFilter: isLightSurface ? 'none' : elevated ? 'blur(12px)' : 'none',
+          borderBottom: isLightSurface
+            ? `1px solid ${alpha('#1a1a2e', 0.08)}`
+            : elevated
+              ? `1px solid ${alpha(theme.palette.primary.main, 0.2)}`
+              : 'none',
+          boxShadow: isLightSurface ? '0 1px 8px rgba(0, 0, 0, 0.06)' : elevated ? undefined : 'none',
           transform: navVisible ? 'translateY(0)' : 'translateY(-110%)',
           transition: 'transform 0.35s cubic-bezier(0.4, 0, 0.2, 1), background 0.3s ease, box-shadow 0.3s ease',
           pointerEvents: navVisible ? 'auto' : 'none',
@@ -162,7 +195,7 @@ const LandingNav: React.FC = () => {
           <Toolbar disableGutters sx={{ py: 0.25, position: 'relative', minHeight: 48, px: 0 }}>
             <Box
               component={RouterLink}
-              to="/"
+              to={LANDING_MARKETING_PATH}
               sx={{
                 position: 'absolute',
                 left: { xs: 12, md: 20 },
@@ -174,7 +207,12 @@ const LandingNav: React.FC = () => {
                 alignItems: 'flex-start',
               }}
             >
-              <BrandMark variant="nav" titleSize="nav" showTagline logoSize={38} />
+              <BrandMark
+                variant={isLightSurface ? 'dark' : 'nav'}
+                titleSize="nav"
+                showTagline
+                logoSize={38}
+              />
             </Box>
 
             <Box
@@ -194,17 +232,32 @@ const LandingNav: React.FC = () => {
               ))}
             </Box>
 
-            <IconButton
-              aria-label="Open navigation menu"
-              onClick={() => setMobileOpen(true)}
+            <Box
               sx={{
-                display: { xs: 'flex', md: 'none' },
-                ml: 'auto',
-                color: '#fff',
+                position: 'absolute',
+                right: { xs: 8, md: 20 },
+                top: '50%',
+                transform: 'translateY(-50%)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5,
+                zIndex: 2,
               }}
             >
-              <MenuIcon />
-            </IconButton>
+              <Box sx={{ display: { xs: 'none', md: 'block' } }}>
+                <NavAuthButton surface={isLightSurface ? 'light' : 'dark'} />
+              </Box>
+              <IconButton
+                aria-label="Open navigation menu"
+                onClick={() => setMobileOpen(true)}
+                sx={{
+                  display: { xs: 'flex', md: 'none' },
+                  color: isLightSurface ? '#1a1a2e' : '#fff',
+                }}
+              >
+                <MenuIcon />
+              </IconButton>
+            </Box>
           </Toolbar>
         </Container>
       </AppBar>
@@ -215,16 +268,29 @@ const LandingNav: React.FC = () => {
         onClose={() => setMobileOpen(false)}
         PaperProps={{
           sx: {
-            width: 280,
-            background: `linear-gradient(180deg, rgba(10,10,20,0.98) 0%, rgba(0,0,0,0.98) 100%)`,
-            color: '#fff',
+            width: 300,
+            background: isLightSurface
+              ? '#FFFFFF'
+              : `linear-gradient(180deg, rgba(10,10,20,0.98) 0%, rgba(0,0,0,0.98) 100%)`,
+            color: isLightSurface ? '#1a1a2e' : '#fff',
           },
         }}
       >
         <Box sx={{ display: 'flex', justifyContent: 'flex-end', p: 1 }}>
-          <IconButton aria-label="Close navigation menu" onClick={() => setMobileOpen(false)} sx={{ color: '#fff' }}>
+          <IconButton
+            aria-label="Close navigation menu"
+            onClick={() => setMobileOpen(false)}
+            sx={{ color: isLightSurface ? '#1a1a2e' : '#fff' }}
+          >
             <CloseIcon />
           </IconButton>
+        </Box>
+        <Box sx={{ px: 2, pb: 2 }}>
+          <NavAuthButton
+            surface={isLightSurface ? 'light' : 'dark'}
+            fullWidth
+            onNavigate={() => setMobileOpen(false)}
+          />
         </Box>
         <List sx={{ px: 1 }}>
           {NAV_ITEMS.map((item) => (
@@ -234,7 +300,11 @@ const LandingNav: React.FC = () => {
               sx={{
                 borderRadius: 2,
                 mb: 0.5,
-                '&:hover': { background: alpha(theme.palette.primary.main, 0.15) },
+                '&:hover': {
+                  background: isLightSurface
+                    ? alpha(theme.palette.primary.main, 0.08)
+                    : alpha(theme.palette.primary.main, 0.15),
+                },
               }}
             >
               <ListItemText

--- a/frontend/src/components/Landing/NavAuthButton.tsx
+++ b/frontend/src/components/Landing/NavAuthButton.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from '@mui/material';
+import { useAuth, useClerk, useUser } from '@clerk/clerk-react';
+import { useNavigate } from 'react-router-dom';
+import {
+  getPostAuthDestination,
+  getStoredFirstName,
+  hasSignedInBefore,
+} from '../../utils/returningUserStorage';
+
+interface NavAuthButtonProps {
+  surface?: 'dark' | 'light';
+  fullWidth?: boolean;
+  onNavigate?: () => void;
+}
+
+const NavAuthButton: React.FC<NavAuthButtonProps> = ({
+  surface = 'dark',
+  fullWidth = false,
+  onNavigate,
+}) => {
+  const navigate = useNavigate();
+  const { isSignedIn, isLoaded } = useAuth();
+  const { user } = useUser();
+  const { openSignIn } = useClerk();
+  const [, setProfileTick] = useState(0);
+
+  useEffect(() => {
+    const refreshProfile = () => setProfileTick((value) => value + 1);
+    window.addEventListener('user-authenticated', refreshProfile);
+    return () => window.removeEventListener('user-authenticated', refreshProfile);
+  }, []);
+
+  const isLight = surface === 'light';
+  const storedFirstName = getStoredFirstName();
+  const returningUser = hasSignedInBefore();
+  const activeFirstName = (isSignedIn ? user?.firstName : storedFirstName)?.trim();
+  const showPersonalizedWelcome = Boolean(activeFirstName) && (isSignedIn || returningUser);
+
+  const label = showPersonalizedWelcome ? `👋 Welcome ${activeFirstName}` : '👋 Welcome';
+
+  const handleClick = () => {
+    onNavigate?.();
+
+    if (isSignedIn) {
+      navigate(getPostAuthDestination());
+      return;
+    }
+
+    openSignIn({ forceRedirectUrl: getPostAuthDestination() });
+  };
+
+  if (!isLoaded) {
+    return null;
+  }
+
+  return (
+    <Button
+      onClick={handleClick}
+      fullWidth={fullWidth}
+      aria-label={showPersonalizedWelcome ? `Welcome back, ${activeFirstName}` : 'Welcome — sign in to ALwrity'}
+      sx={{
+        textTransform: 'none',
+        fontWeight: 700,
+        fontSize: { xs: '0.9rem', md: '0.95rem' },
+        letterSpacing: '0.01em',
+        borderRadius: 2,
+        px: { xs: 1.75, md: 2.25 },
+        py: 0.75,
+        minWidth: { xs: 'auto', md: 148 },
+        whiteSpace: 'nowrap',
+        color: isLight ? '#1a1a2e' : 'rgba(255,255,255,0.96)',
+        border: isLight ? '1px solid rgba(26, 26, 46, 0.12)' : '1px solid rgba(255,255,255,0.28)',
+        bgcolor: isLight ? '#FFFFFF' : 'rgba(255,255,255,0.08)',
+        boxShadow: isLight ? '0 1px 6px rgba(0,0,0,0.06)' : '0 2px 12px rgba(0,0,0,0.25)',
+        '&:hover': {
+          bgcolor: isLight ? '#F8FAFC' : 'rgba(255,255,255,0.14)',
+          borderColor: isLight ? 'rgba(99, 102, 241, 0.35)' : 'rgba(255,255,255,0.45)',
+        },
+      }}
+    >
+      {label}
+    </Button>
+  );
+};
+
+export default NavAuthButton;

--- a/frontend/src/utils/landingNavigation.ts
+++ b/frontend/src/utils/landingNavigation.ts
@@ -1,0 +1,58 @@
+export type LandingSectionId = 'hero' | 'lifecycle' | 'features';
+
+/** Public marketing landing route — always shows Landing (signed-in or not). */
+export const LANDING_MARKETING_PATH = '/home';
+
+const NAV_OFFSET_PX = 72;
+
+export function isLandingMarketingPath(pathname: string): boolean {
+  return pathname === '/' || pathname === LANDING_MARKETING_PATH;
+}
+
+export function landingPathForSection(section: LandingSectionId): string {
+  return section === 'hero' ? LANDING_MARKETING_PATH : `${LANDING_MARKETING_PATH}#${section}`;
+}
+
+export function scrollToLandingSection(section: LandingSectionId): boolean {
+  if (section === 'hero') {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    return true;
+  }
+
+  const el = document.getElementById(section);
+  if (!el) return false;
+
+  const top = el.getBoundingClientRect().top + window.scrollY - NAV_OFFSET_PX;
+  window.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+  return true;
+}
+
+/** Retry scroll for lazy-loaded landing sections (e.g. features). */
+export function scrollToLandingSectionWithRetry(
+  section: LandingSectionId,
+  maxAttempts = 30,
+  intervalMs = 200
+): () => void {
+  if (section === 'hero') {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    return () => undefined;
+  }
+
+  let attempts = 0;
+  const timer = window.setInterval(() => {
+    if (scrollToLandingSection(section) || attempts >= maxAttempts) {
+      window.clearInterval(timer);
+    }
+    attempts += 1;
+  }, intervalMs);
+
+  return () => window.clearInterval(timer);
+}
+
+export function parseLandingHash(hash: string): LandingSectionId | null {
+  const id = hash.replace('#', '').trim();
+  if (id === 'hero' || id === 'lifecycle' || id === 'features') {
+    return id;
+  }
+  return null;
+}

--- a/frontend/src/utils/returningUserStorage.ts
+++ b/frontend/src/utils/returningUserStorage.ts
@@ -1,0 +1,21 @@
+const HAS_SIGNED_IN_KEY = 'alwrity_has_signed_in';
+const FIRST_NAME_KEY = 'alwrity_user_first_name';
+
+export function persistReturningUserProfile(firstName?: string | null): void {
+  if (!firstName?.trim()) return;
+  localStorage.setItem(FIRST_NAME_KEY, firstName.trim());
+  localStorage.setItem(HAS_SIGNED_IN_KEY, 'true');
+}
+
+export function hasSignedInBefore(): boolean {
+  return localStorage.getItem(HAS_SIGNED_IN_KEY) === 'true';
+}
+
+export function getStoredFirstName(): string | null {
+  return localStorage.getItem(FIRST_NAME_KEY);
+}
+
+export function getPostAuthDestination(): string {
+  const onboardingComplete = localStorage.getItem('onboarding_complete') === 'true';
+  return onboardingComplete ? '/dashboard' : '/onboarding';
+}


### PR DESCRIPTION
## Summary

Incremental landing UX polish on top of the merged landing overhaul (PR #722). Focuses on navigation behavior, cross-page section linking, marketing copy, and returning-user welcome — shared infrastructure also used by the pricing page shell.

- **Auto-hiding nav** on scroll down; reappears on slight scroll up or when the pointer enters the top ~72px, then hides again after ~3.5s (landing **and** light-surface pages)
- **surface prop** on `LandingNav` / `LandingFooter` — `dark` (default, landing/legal) vs `light` (white pages)
- **Cross-page section navigation** via `landingNavigation.ts` — Home/Lifecycle/Features from `/pricing` route to `/home#section` with retry scroll for lazy sections
- **Hash deep-linking** on landing — `/#features` and `/home#features` scroll correctly after mount
- **NavAuthButton** — extracted sign-in/welcome CTA with personalized greeting for returning users (`returningUserStorage` + `TokenInstaller`)
- **Copy updates** — hero tagline **AI Marketing OS**; Pro teaser drops BYOK; Enterprise teaser shows **\/mo**
- **Pricing nav link** opens in-app (`/pricing`) instead of a new tab

## Files (8)

| File | Change |
|------|--------|
| `LandingNav.tsx` | Auto-hide, light/dark surface, NavAuthButton, section routing |
| `NavAuthButton.tsx` | New — welcome / sign-in button |
| `landingNavigation.ts` | New — shared scroll + path helpers |
| `returningUserStorage.ts` | New — first-name persistence for welcome |
| `TokenInstaller.tsx` | Persist returning user profile on sign-in |
| `Landing.tsx` | Hash scroll effect, pricing teaser copy |
| `HeroSection.tsx` | AI Marketing OS tagline |
| `LandingFooter.tsx` | Light surface variant (dark default unchanged) |

## Test plan

- [ ] Landing `/` or `/home` — scroll down → nav hides; scroll up slightly → nav returns; move mouse to top → nav returns then auto-hides
- [ ] Click **Features** / **Lifecycle** on landing → smooth scroll to section
- [ ] From `/pricing`, click **Features** → lands on `/home#features` and scrolls to section
- [ ] Hero shows **AI Marketing OS** (not Bring Your Own Keys)
- [ ] Pricing teaser Pro line: fact-checked copy; Enterprise shows **\/mo**
- [ ] Sign in → nav shows **Welcome {firstName}** on return visit (signed out)
- [ ] Legal pages (Privacy/Terms) — nav/footer still dark theme by default

## Relationship to other PRs

- **#761 (pricing)** includes the same landing files for the pricing page shell. **Recommend merging this PR first**, then rebase #761 — the landing diff will drop out and pricing-only changes remain.

## Not included

- Pricing comparison grid / `PricingPageLayout` (see #761)
- `docs/pricing/` spec docs (`docs/` is gitignored in repo)


Made with [Cursor](https://cursor.com)