### PR TITLE
LinkedIn Fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,6 +250,9 @@ gsc_credentials.json
 !backend/tests/
 !backend/tests/**
 !backend/tests/**/test_*.py
+# Re-ignore bytecode caches un-negated by the rules above
+backend/tests/**/__pycache__/
+backend/tests/**/*.pyc
 
 # Documentation build
 docs/_build/

--- a/backend/alwrity_utils/router_manager.py
+++ b/backend/alwrity_utils/router_manager.py
@@ -29,6 +29,7 @@ CORE_ROUTER_REGISTRY = [
     {"name": "facebook_writer", "module": "api.facebook_writer.routers", "attr": "facebook_router", "features": {"all", "core", "facebook"}},
     {"name": "linkedin", "module": "routers.linkedin", "attr": "router", "features": {"all", "core", "linkedin"}},
     {"name": "linkedin_social", "module": "api.linkedin_social_routes", "attr": "router", "features": {"all", "core", "linkedin"}},
+    {"name": "linkedin_posts", "module": "api.linkedin_posts_routes", "attr": "router", "features": {"all", "core", "linkedin"}},
     {"name": "unipile_webhook", "module": "api.unipile_webhook_routes", "attr": "router", "features": {"all", "core", "linkedin"}},
     {"name": "linkedin_image", "module": "api.linkedin_image_generation", "attr": "router", "features": {"all", "core", "linkedin"}},
     {"name": "linkedin_video", "module": "api.linkedin_video_generation", "attr": "router", "features": {"all", "core", "linkedin"}},

--- a/backend/api/linkedin_posts_routes.py
+++ b/backend/api/linkedin_posts_routes.py
@@ -1,0 +1,151 @@
+"""
+LinkedIn posts/articles fetch API routes.
+
+Separate from content generation (routers/linkedin.py) and profile routes.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from loguru import logger
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from middleware.auth_middleware import get_current_user
+from services.database import get_db
+from services.integrations.linkedin.linkedin_posts_service import (
+    fetch_single_post,
+    fetch_user_posts,
+)
+from services.integrations.linkedin.types import LinkedInNotConnectedError
+from services.integrations.linkedin.unipile_client import UnipileAPIError
+
+router = APIRouter(prefix="/api/linkedin-social", tags=["LinkedIn Social"])
+
+
+class LinkedInPostItemResponse(BaseModel):
+    unipile_post_id: str
+    social_id: str
+    content_kind: str
+    title: str
+    text: str
+    share_url: str
+    parsed_datetime: str
+    is_repost: bool
+    reaction_counter: int
+    comment_counter: int
+    repost_counter: int
+    impressions_counter: int
+    author_name: str
+    author_public_identifier: str
+    article_subtitle: str = ""
+    article_cover_url: str = ""
+
+
+class LinkedInPostsListResponse(BaseModel):
+    user_id: str
+    account_id: str
+    identifier: str
+    count: int
+    cursor: Optional[str] = None
+    persisted_asset_ids: list[int] = Field(default_factory=list)
+    skipped_social_ids: list[str] = Field(default_factory=list)
+    posts: list[LinkedInPostItemResponse]
+
+
+def _raise_posts_http_error(exc: Exception, *, user_id: str) -> None:
+    if isinstance(exc, LinkedInNotConnectedError):
+        raise HTTPException(
+            status_code=401,
+            detail="LinkedIn account not connected",
+        ) from exc
+
+    if isinstance(exc, UnipileAPIError):
+        status = exc.status_code
+        message = str(exc).lower()
+        if status == 401 or "disconnected" in message or "reconnect" in message:
+            raise HTTPException(status_code=401, detail="Reconnect required") from exc
+        if status == 403:
+            raise HTTPException(
+                status_code=502,
+                detail="Unable to fetch LinkedIn posts",
+            ) from exc
+        raise HTTPException(
+            status_code=502,
+            detail="Unable to fetch LinkedIn posts",
+        ) from exc
+
+    if isinstance(exc, ValueError):
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    logger.exception(
+        "[LinkedInPosts] unexpected error user_id={}: {}",
+        user_id,
+        exc,
+    )
+    raise HTTPException(
+        status_code=500,
+        detail="Unable to fetch LinkedIn posts",
+    ) from exc
+
+
+def _result_to_response(result: Any) -> LinkedInPostsListResponse:
+    payload = result.to_dict()
+    return LinkedInPostsListResponse(**payload)
+
+
+@router.get("/posts", response_model=LinkedInPostsListResponse)
+async def get_linkedin_posts(
+    limit: int = Query(20, ge=1, le=100),
+    cursor: Optional[str] = Query(None),
+    fetch_all: bool = Query(False),
+    include_article_body: bool = Query(True),
+    persist: bool = Query(False),
+    identifier: Optional[str] = Query(
+        None,
+        description="LinkedIn provider id; defaults to connected user",
+    ),
+    current_user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> LinkedInPostsListResponse:
+    """Fetch LinkedIn posts/articles for the connected user via Unipile."""
+    user_id = current_user.get("id") or current_user.get("clerk_user_id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    try:
+        result = await fetch_user_posts(
+            user_id,
+            identifier=identifier,
+            limit=limit,
+            cursor=cursor,
+            fetch_all=fetch_all,
+            include_article_body=include_article_body,
+            persist=persist,
+            db=db if persist else None,
+        )
+        return _result_to_response(result)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _raise_posts_http_error(exc, user_id=user_id)
+
+
+@router.get("/posts/{post_id}")
+async def get_linkedin_post_detail(
+    post_id: str,
+    current_user: dict = Depends(get_current_user),
+) -> dict[str, Any]:
+    """Fetch a single LinkedIn post by Unipile post id."""
+    user_id = current_user.get("id") or current_user.get("clerk_user_id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    try:
+        return await fetch_single_post(user_id, post_id)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _raise_posts_http_error(exc, user_id=user_id)

--- a/backend/scripts/linkedin_fetch_posts.py
+++ b/backend/scripts/linkedin_fetch_posts.py
@@ -1,0 +1,190 @@
+"""
+LinkedIn posts acquire CLI — fetch, normalize, optional persist to asset library.
+
+Usage:
+    python backend/scripts/linkedin_fetch_posts.py --from-fixture docs/linkedin/fixtures/sample_post_list_raw.json --print-normalized
+    python backend/scripts/linkedin_fetch_posts.py --user-id USER_ID --limit 10 --dry-run
+    python backend/scripts/linkedin_fetch_posts.py --user-id USER_ID --persist
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(backend_dir))
+
+from dotenv import load_dotenv
+
+load_dotenv(backend_dir / ".env")
+
+# Avoid importing backend/services/__init__.py (heavy optional deps).
+import types
+
+if "services" not in sys.modules:
+    _services_pkg = types.ModuleType("services")
+    _services_pkg.__path__ = [str(backend_dir / "services")]
+    sys.modules["services"] = _services_pkg
+
+_integrations_stub = types.ModuleType("services.integrations")
+_integrations_stub.__path__ = [str(backend_dir / "services" / "integrations")]
+sys.modules["services.integrations"] = _integrations_stub
+
+from loguru import logger
+
+from services.integrations.linkedin.linkedin_posts_normalizer import (
+    normalize_unipile_posts,
+)
+from services.integrations.linkedin.linkedin_posts_service import fetch_user_posts
+from services.integrations.linkedin.linkedin_posts_storage import persist_fetched_posts
+from services.integrations.linkedin.types import LinkedInNotConnectedError
+from services.integrations.linkedin.unipile_client import UnipileAPIError
+from services.database import get_session_for_user
+
+
+def _load_fixture(path: Path) -> list[dict[str, Any]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, dict):
+        items = data.get("items")
+        if isinstance(items, list):
+            return [item for item in items if isinstance(item, dict)]
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    raise ValueError(f"Fixture at {path} is not a PostList or list of posts")
+
+
+def _print_normalized(items: list[dict[str, Any]]) -> None:
+    normalized = normalize_unipile_posts(items)
+    payload = {
+        "count": len(normalized),
+        "posts": [
+            {
+                "unipile_post_id": p.unipile_post_id,
+                "social_id": p.social_id,
+                "content_kind": p.content_kind,
+                "title": p.title,
+                "text": p.text,
+                "share_url": p.share_url,
+                "parsed_datetime": p.parsed_datetime,
+                "is_repost": p.is_repost,
+                "reaction_counter": p.reaction_counter,
+            }
+            for p in normalized
+        ],
+    }
+    print(json.dumps(payload, indent=2))
+
+
+async def _run_live(args: argparse.Namespace) -> int:
+    db = None
+    if args.persist:
+        db = get_session_for_user(args.user_id)
+        if db is None:
+            logger.error("Could not open database session for user {}", args.user_id)
+            return 1
+
+    try:
+        result = await fetch_user_posts(
+            args.user_id,
+            limit=args.limit,
+            cursor=args.cursor,
+            fetch_all=args.fetch_all,
+            include_article_body=not args.skip_article_body,
+            persist=args.persist and not args.dry_run,
+            db=db,
+        )
+        print(json.dumps(result.to_dict(), indent=2))
+        return 0
+    except LinkedInNotConnectedError as exc:
+        logger.error("Not connected: {}", exc)
+        return 2
+    except UnipileAPIError as exc:
+        logger.error("Unipile error: {}", exc)
+        return 3
+    except Exception as exc:
+        logger.exception("Fetch failed: {}", exc)
+        return 1
+    finally:
+        if db is not None:
+            db.close()
+
+
+async def _run_fixture_persist(args: argparse.Namespace) -> int:
+    items = _load_fixture(Path(args.from_fixture))
+    normalized = normalize_unipile_posts(items)
+    db = get_session_for_user(args.user_id)
+    if db is None:
+        logger.error("Could not open database session for user {}", args.user_id)
+        return 1
+    try:
+        asset_ids, skipped = persist_fetched_posts(db, args.user_id, normalized)
+        db.commit()
+        print(
+            json.dumps(
+                {
+                    "persisted_asset_ids": asset_ids,
+                    "skipped_social_ids": skipped,
+                    "count": len(normalized),
+                },
+                indent=2,
+            )
+        )
+        return 0
+    finally:
+        db.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Fetch LinkedIn posts via Unipile")
+    parser.add_argument("--user-id", help="ALwrity Clerk user id")
+    parser.add_argument("--from-fixture", help="Path to PostList JSON fixture")
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--cursor", default=None)
+    parser.add_argument("--fetch-all", action="store_true")
+    parser.add_argument("--dry-run", action="store_true", help="Fetch without persisting")
+    parser.add_argument("--persist", action="store_true", help="Save to asset library")
+    parser.add_argument(
+        "--skip-article-body",
+        action="store_true",
+        help="Skip per-article detail fetch",
+    )
+    parser.add_argument(
+        "--print-normalized",
+        action="store_true",
+        help="Normalize fixture and print (offline mode)",
+    )
+
+    args = parser.parse_args()
+
+    if args.from_fixture:
+        fixture_path = Path(args.from_fixture)
+        if not fixture_path.is_file():
+            logger.error("Fixture not found: {}", fixture_path)
+            return 1
+        items = _load_fixture(fixture_path)
+        if args.print_normalized or not args.persist:
+            _print_normalized(items)
+            return 0
+        if not args.user_id:
+            logger.error("--user-id is required with --persist")
+            return 1
+        return asyncio.run(_run_fixture_persist(args))
+
+    if not args.user_id:
+        logger.error("--user-id is required for live fetch")
+        return 1
+
+    if args.persist and args.dry_run:
+        logger.error("Use either --persist or --dry-run, not both")
+        return 1
+
+    return asyncio.run(_run_live(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/services/integrations/linkedin/linkedin_posts_client.py
+++ b/backend/services/integrations/linkedin/linkedin_posts_client.py
@@ -1,0 +1,160 @@
+"""
+Unipile HTTP client extensions for LinkedIn posts/articles fetch.
+
+Subclasses ``UnipileClient`` without modifying the base module.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+from urllib.parse import quote
+
+import httpx
+from loguru import logger
+
+from services.integrations.linkedin.unipile_client import (
+    UnipileAPIError,
+    UnipileClient,
+    _auth_headers,
+    _raise_for_error,
+)
+
+
+def _normalize_post_list(data: Any) -> tuple[list[dict[str, Any]], Optional[str]]:
+    """Parse PostList response into items and next cursor."""
+    if not isinstance(data, dict):
+        return [], None
+
+    items_raw = data.get("items")
+    items: list[dict[str, Any]] = []
+    if isinstance(items_raw, list):
+        items = [item for item in items_raw if isinstance(item, dict)]
+
+    cursor = data.get("cursor")
+    if isinstance(cursor, str) and cursor.strip():
+        return items, cursor.strip()
+    return items, None
+
+
+class LinkedInPostsClient(UnipileClient):
+    """Unipile client with LinkedIn posts list/detail endpoints."""
+
+    async def list_user_posts(
+        self,
+        account_id: str,
+        identifier: str,
+        *,
+        limit: int = 20,
+        cursor: Optional[str] = None,
+        is_company: Optional[bool] = None,
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+        """
+        List posts for a LinkedIn user or company.
+
+        Uses ``GET /api/v1/users/{identifier}/posts``.
+        """
+        if not self._api_key:
+            raise ValueError("Unipile API key is required")
+        if not identifier or not identifier.strip():
+            raise UnipileAPIError("Post list identifier is required")
+
+        encoded_identifier = quote(identifier.strip(), safe="")
+        url = self._get_full_url(f"/api/v1/users/{encoded_identifier}/posts")
+        params: dict[str, Any] = {
+            "account_id": account_id,
+            "limit": max(1, min(limit, 100)),
+        }
+        if cursor:
+            params["cursor"] = cursor
+        if is_company is not None:
+            params["is_company"] = is_company
+
+        logger.debug(
+            "[LinkedInPostsClient] list_user_posts account_id={} identifier={} limit={}",
+            account_id,
+            identifier,
+            limit,
+        )
+
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(
+                url, params=params, headers=_auth_headers(self._api_key)
+            )
+            _raise_for_error(response)
+            data = response.json()
+
+        items, next_cursor = _normalize_post_list(data)
+        logger.info(
+            "[LinkedInPostsClient] list_user_posts returned {} items cursor={!r}",
+            len(items),
+            next_cursor,
+        )
+        return items, next_cursor
+
+    async def get_post(
+        self, account_id: str, post_id: str
+    ) -> dict[str, Any]:
+        """
+        Retrieve a single post by Unipile post id.
+
+        Uses ``GET /api/v1/posts/{post_id}``.
+        """
+        if not self._api_key:
+            raise ValueError("Unipile API key is required")
+        if not post_id or not post_id.strip():
+            raise UnipileAPIError("Post id is required")
+
+        encoded_post_id = quote(post_id.strip(), safe="")
+        url = self._get_full_url(f"/api/v1/posts/{encoded_post_id}")
+        params = {"account_id": account_id}
+
+        logger.debug(
+            "[LinkedInPostsClient] get_post account_id={} post_id={}",
+            account_id,
+            post_id,
+        )
+
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(
+                url, params=params, headers=_auth_headers(self._api_key)
+            )
+            _raise_for_error(response)
+            data = response.json()
+
+        if not isinstance(data, dict):
+            raise UnipileAPIError(
+                f"Unexpected post detail response type: {type(data).__name__}"
+            )
+        return data
+
+    async def list_all_user_posts(
+        self,
+        account_id: str,
+        identifier: str,
+        *,
+        limit_per_page: int = 100,
+        max_pages: Optional[int] = None,
+        is_company: Optional[bool] = None,
+    ) -> list[dict[str, Any]]:
+        """Follow cursors until exhausted or ``max_pages`` reached."""
+        all_items: list[dict[str, Any]] = []
+        cursor: Optional[str] = None
+        pages = 0
+
+        while True:
+            items, cursor = await self.list_user_posts(
+                account_id,
+                identifier,
+                limit=limit_per_page,
+                cursor=cursor,
+                is_company=is_company,
+            )
+            all_items.extend(items)
+            pages += 1
+
+            if not cursor:
+                break
+            if max_pages is not None and pages >= max_pages:
+                break
+
+        return all_items

--- a/backend/services/integrations/linkedin/linkedin_posts_normalizer.py
+++ b/backend/services/integrations/linkedin/linkedin_posts_normalizer.py
@@ -1,0 +1,106 @@
+"""
+Pure normalization of Unipile Post payloads to ALwrity shapes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from services.integrations.linkedin.field_coercion import (
+    clean_str,
+    coerce_bool,
+    coerce_int,
+)
+from services.integrations.linkedin.linkedin_posts_types import (
+    NormalizedLinkedInPost,
+    PostContentKind,
+)
+
+
+def _author_field(raw: dict[str, Any], key: str) -> str:
+    author = raw.get("author")
+    if isinstance(author, dict):
+        return clean_str(author.get(key))
+    written_by = raw.get("written_by")
+    if isinstance(written_by, dict):
+        return clean_str(written_by.get(key))
+    return ""
+
+
+def _detect_content_kind(raw: dict[str, Any]) -> PostContentKind:
+    if coerce_bool(raw.get("is_repost")):
+        return "repost"
+    article = raw.get("article")
+    if isinstance(article, dict) and (
+        clean_str(article.get("title")) or clean_str(article.get("subtitle"))
+    ):
+        return "article"
+    return "post"
+
+
+def _title_from_raw(raw: dict[str, Any], content_kind: PostContentKind) -> str:
+    if content_kind == "article":
+        article = raw.get("article")
+        if isinstance(article, dict):
+            title = clean_str(article.get("title"))
+            if title:
+                return title
+    title = clean_str(raw.get("title"))
+    if title:
+        return title
+    text = clean_str(raw.get("text"))
+    if text:
+        first_line = text.splitlines()[0].strip()
+        return first_line[:120] if first_line else "LinkedIn Post"
+    return "LinkedIn Post"
+
+
+def normalize_unipile_post(raw: dict[str, Any]) -> NormalizedLinkedInPost:
+    """
+    Map a single Unipile Post dict to ``NormalizedLinkedInPost``.
+
+    Args:
+        raw: Item from ``PostList.items`` or ``GET /posts/{id}``
+
+    Returns:
+        Normalized post record
+    """
+    if not isinstance(raw, dict):
+        raise TypeError(f"Expected dict post payload, got {type(raw).__name__}")
+
+    content_kind = _detect_content_kind(raw)
+    article = raw.get("article") if isinstance(raw.get("article"), dict) else {}
+    unipile_post_id = clean_str(raw.get("id"))
+    social_id = clean_str(raw.get("social_id")) or unipile_post_id
+
+    return NormalizedLinkedInPost(
+        unipile_post_id=unipile_post_id,
+        social_id=social_id,
+        content_kind=content_kind,
+        title=_title_from_raw(raw, content_kind),
+        text=clean_str(raw.get("text")),
+        share_url=clean_str(raw.get("share_url")),
+        parsed_datetime=clean_str(raw.get("parsed_datetime") or raw.get("date")),
+        is_repost=coerce_bool(raw.get("is_repost")),
+        reaction_counter=coerce_int(raw.get("reaction_counter")),
+        comment_counter=coerce_int(raw.get("comment_counter")),
+        repost_counter=coerce_int(raw.get("repost_counter")),
+        impressions_counter=coerce_int(raw.get("impressions_counter")),
+        author_name=_author_field(raw, "name"),
+        author_public_identifier=_author_field(raw, "public_identifier"),
+        article_subtitle=clean_str(article.get("subtitle")),
+        article_cover_url=clean_str(
+            article.get("cover_url") or article.get("thumbnail_url")
+        ),
+        raw=raw,
+    )
+
+
+def normalize_unipile_posts(items: list[Any]) -> list[NormalizedLinkedInPost]:
+    """Normalize a list of Unipile post dicts, skipping invalid entries."""
+    normalized: list[NormalizedLinkedInPost] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        normalized.append(normalize_unipile_post(item))
+    return normalized

--- a/backend/services/integrations/linkedin/linkedin_posts_service.py
+++ b/backend/services/integrations/linkedin/linkedin_posts_service.py
@@ -1,0 +1,228 @@
+"""
+LinkedIn posts/articles acquisition — fetch, normalize, optional persist.
+
+Composes existing Unipile OAuth/client code without modifying those modules.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from services.integrations.linkedin.linkedin_posts_client import LinkedInPostsClient
+from services.integrations.linkedin.linkedin_posts_normalizer import (
+    normalize_unipile_post,
+    normalize_unipile_posts,
+)
+from services.integrations.linkedin.linkedin_posts_storage import persist_fetched_posts
+from services.integrations.linkedin.linkedin_posts_types import FetchPostsResult
+from services.integrations.linkedin.types import LinkedInNotConnectedError
+from services.integrations.linkedin.unipile_client import (
+    UnipileAPIError,
+    profile_identifier_from_owner,
+)
+from services.integrations.linkedin_oauth import LinkedInOAuthService
+
+
+async def resolve_post_list_identifier(
+    client: LinkedInPostsClient,
+    account_id: str,
+    identifier: Optional[str] = None,
+) -> str:
+    """Resolve LinkedIn provider id for posts list (defaults to connected user)."""
+    if identifier and identifier.strip():
+        return identifier.strip()
+
+    owner = await client.get_own_profile(account_id)
+    if not isinstance(owner, dict):
+        raise UnipileAPIError(
+            f"Unexpected /users/me response type: {type(owner).__name__}"
+        )
+    resolved = profile_identifier_from_owner(owner)
+    if not resolved:
+        raise UnipileAPIError(
+            f"AccountOwnerProfile missing identifier for account_id={account_id}"
+        )
+    return resolved
+
+
+async def _maybe_enrich_article(
+    client: LinkedInPostsClient,
+    account_id: str,
+    raw: dict[str, Any],
+    *,
+    include_article_body: bool,
+) -> dict[str, Any]:
+    if not include_article_body:
+        return raw
+    article = raw.get("article")
+    if not isinstance(article, dict):
+        return raw
+    post_id = raw.get("id")
+    if not isinstance(post_id, str) or not post_id.strip():
+        return raw
+
+    try:
+        detail = await client.get_post(account_id, post_id)
+        if isinstance(detail, dict):
+            return detail
+    except UnipileAPIError as exc:
+        logger.warning(
+            "[LinkedInPosts] article detail fetch failed post_id={}: {}",
+            post_id,
+            exc,
+        )
+    return raw
+
+
+async def fetch_user_posts(
+    user_id: str,
+    *,
+    identifier: Optional[str] = None,
+    limit: int = 20,
+    cursor: Optional[str] = None,
+    fetch_all: bool = False,
+    include_article_body: bool = True,
+    persist: bool = False,
+    db: Optional[Session] = None,
+    client: Optional[LinkedInPostsClient] = None,
+    oauth: Optional[LinkedInOAuthService] = None,
+    persist_fn: Optional[Callable] = None,
+) -> FetchPostsResult:
+    """
+    Fetch LinkedIn posts for a connected user via Unipile.
+
+    Args:
+        user_id: ALwrity Clerk user id
+        identifier: LinkedIn provider id; resolved from /users/me when omitted
+        limit: Page size (1–100) when not using fetch_all
+        cursor: Pagination cursor for a single page fetch
+        fetch_all: Follow all cursors (ignores incoming cursor)
+        include_article_body: Fetch full post detail for article items
+        persist: Save to asset library via save_and_track_text_content()
+        db: SQLAlchemy session (required when persist=True)
+        client: Injectable Unipile posts client (for tests)
+        oauth: Injectable OAuth service (for tests)
+        persist_fn: Injectable save function (for tests)
+    """
+    logger.info(
+        "[LinkedInPosts] fetch_user_posts user_id={} limit={} fetch_all={} persist={}",
+        user_id,
+        limit,
+        fetch_all,
+        persist,
+    )
+
+    oauth_service = oauth or LinkedInOAuthService()
+    posts_client = client or LinkedInPostsClient()
+
+    creds = oauth_service.resolve_credentials(user_id)
+    account_id = creds.unipile_account_id
+    if not account_id:
+        raise LinkedInNotConnectedError(
+            "No Unipile LinkedIn account connected. "
+            "Connect via hosted OAuth before fetching posts."
+        )
+
+    resolved_identifier = await resolve_post_list_identifier(
+        posts_client, account_id, identifier
+    )
+
+    raw_items: list[dict[str, Any]] = []
+    next_cursor: Optional[str] = None
+
+    if fetch_all:
+        raw_items = await posts_client.list_all_user_posts(
+            account_id, resolved_identifier, limit_per_page=min(limit, 100)
+        )
+    else:
+        raw_items, next_cursor = await posts_client.list_user_posts(
+            account_id,
+            resolved_identifier,
+            limit=limit,
+            cursor=cursor,
+        )
+
+    enriched_items: list[dict[str, Any]] = []
+    for item in raw_items:
+        enriched = await _maybe_enrich_article(
+            posts_client,
+            account_id,
+            item,
+            include_article_body=include_article_body,
+        )
+        enriched_items.append(enriched)
+
+    normalized = normalize_unipile_posts(enriched_items)
+
+    result = FetchPostsResult(
+        user_id=user_id,
+        account_id=account_id,
+        identifier=resolved_identifier,
+        posts=normalized,
+        cursor=next_cursor,
+    )
+
+    if persist:
+        if db is None:
+            raise ValueError("db session is required when persist=True")
+        kwargs: dict[str, Any] = {}
+        if persist_fn is not None:
+            kwargs["save_fn"] = persist_fn
+        asset_ids, skipped = persist_fetched_posts(db, user_id, normalized, **kwargs)
+        result.persisted_asset_ids = asset_ids
+        result.skipped_social_ids = skipped
+
+    logger.info(
+        "[LinkedInPosts] fetch complete user_id={} count={} persisted={}",
+        user_id,
+        len(normalized),
+        len(result.persisted_asset_ids),
+    )
+    return result
+
+
+async def fetch_single_post(
+    user_id: str,
+    post_id: str,
+    *,
+    client: Optional[LinkedInPostsClient] = None,
+    oauth: Optional[LinkedInOAuthService] = None,
+) -> dict[str, Any]:
+    """Fetch and normalize a single post by Unipile post id."""
+    oauth_service = oauth or LinkedInOAuthService()
+    posts_client = client or LinkedInPostsClient()
+
+    creds = oauth_service.resolve_credentials(user_id)
+    account_id = creds.unipile_account_id
+    if not account_id:
+        raise LinkedInNotConnectedError(
+            "No Unipile LinkedIn account connected."
+        )
+
+    raw = await posts_client.get_post(account_id, post_id)
+    normalized = normalize_unipile_post(raw)
+    return {
+        "account_id": account_id,
+        "post": {
+            "unipile_post_id": normalized.unipile_post_id,
+            "social_id": normalized.social_id,
+            "content_kind": normalized.content_kind,
+            "title": normalized.title,
+            "text": normalized.text,
+            "share_url": normalized.share_url,
+            "parsed_datetime": normalized.parsed_datetime,
+            "is_repost": normalized.is_repost,
+            "reaction_counter": normalized.reaction_counter,
+            "comment_counter": normalized.comment_counter,
+            "repost_counter": normalized.repost_counter,
+            "impressions_counter": normalized.impressions_counter,
+            "author_name": normalized.author_name,
+            "author_public_identifier": normalized.author_public_identifier,
+            "article_subtitle": normalized.article_subtitle,
+            "article_cover_url": normalized.article_cover_url,
+        },
+        "raw": raw,
+    }

--- a/backend/services/integrations/linkedin/linkedin_posts_storage.py
+++ b/backend/services/integrations/linkedin/linkedin_posts_storage.py
@@ -1,0 +1,165 @@
+"""
+Persist fetched LinkedIn posts/articles via save_and_track_text_content().
+
+Mirrors the generated-content pattern in backend/routers/linkedin.py.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from models.content_asset_models import AssetSource
+from services.content_asset_service import ContentAssetService
+from services.integrations.linkedin.linkedin_posts_types import NormalizedLinkedInPost
+from utils.text_asset_tracker import save_and_track_text_content
+
+CONTENT_ORIGIN = "unipile_fetch"
+SOURCE_MODULE = "linkedin_writer"
+
+
+def _preview_text(text: str, *, max_len: int = 500) -> str:
+    cleaned = (text or "").strip()
+    if len(cleaned) <= max_len:
+        return cleaned
+    return cleaned[: max_len - 3] + "..."
+
+
+def _build_post_content(post: NormalizedLinkedInPost) -> str:
+    if post.content_kind == "article":
+        parts = [f"# {post.title}"]
+        if post.article_subtitle:
+            parts.append(post.article_subtitle)
+        if post.text:
+            parts.append(post.text)
+        if post.share_url:
+            parts.append(f"\nSource: {post.share_url}")
+        return "\n\n".join(parts)
+    return post.text or post.title
+
+
+def _asset_metadata(post: NormalizedLinkedInPost) -> dict[str, Any]:
+    return {
+        "content_origin": CONTENT_ORIGIN,
+        "content_kind": post.content_kind,
+        "social_id": post.social_id,
+        "unipile_post_id": post.unipile_post_id,
+        "share_url": post.share_url,
+        "parsed_datetime": post.parsed_datetime,
+        "reaction_counter": post.reaction_counter,
+        "comment_counter": post.comment_counter,
+        "repost_counter": post.repost_counter,
+        "impressions_counter": post.impressions_counter,
+        "is_repost": post.is_repost,
+        "author_name": post.author_name,
+        "author_public_identifier": post.author_public_identifier,
+    }
+
+
+def find_asset_id_by_social_id(
+    db: Session, user_id: str, social_id: str
+) -> Optional[int]:
+    """Return existing asset id when the same LinkedIn post was already saved."""
+    if not social_id:
+        return None
+
+    service = ContentAssetService(db)
+    assets, _ = service.get_user_assets(
+        user_id=user_id,
+        source_module=AssetSource.LINKEDIN_WRITER,
+        limit=500,
+    )
+    for asset in assets:
+        meta = asset.asset_metadata or {}
+        if meta.get("content_origin") == CONTENT_ORIGIN and meta.get("social_id") == social_id:
+            return asset.id
+    return None
+
+
+def persist_fetched_post(
+    db: Session,
+    user_id: str,
+    post: NormalizedLinkedInPost,
+    *,
+    save_fn: Callable[..., Optional[int]] = save_and_track_text_content,
+) -> Optional[int]:
+    """
+    Save one fetched post/article to the asset library.
+
+    Uses the same ``save_and_track_text_content()`` path as generated LinkedIn
+    posts and articles in ``backend/routers/linkedin.py``.
+    """
+    existing_id = find_asset_id_by_social_id(db, user_id, post.social_id)
+    if existing_id is not None:
+        logger.info(
+            "[LinkedInPostsStorage] skip duplicate social_id={} asset_id={}",
+            post.social_id,
+            existing_id,
+        )
+        return existing_id
+
+    content = _build_post_content(post)
+    if not content.strip():
+        logger.warning(
+            "[LinkedInPostsStorage] skip empty content social_id={}",
+            post.social_id,
+        )
+        return None
+
+    metadata = _asset_metadata(post)
+    preview = _preview_text(content)
+
+    if post.content_kind == "article":
+        return save_fn(
+            db=db,
+            user_id=user_id,
+            content=content,
+            source_module=SOURCE_MODULE,
+            title=f"LinkedIn Article: {post.title[:80]}",
+            description=preview,
+            tags=["linkedin", "article", "fetched"],
+            asset_metadata=metadata,
+            subdirectory="articles",
+            file_extension=".md",
+        )
+
+    return save_fn(
+        db=db,
+        user_id=user_id,
+        content=content,
+        source_module=SOURCE_MODULE,
+        title=f"LinkedIn Post: {post.title[:80]}",
+        description=preview,
+        tags=["linkedin", "post", "fetched"],
+        asset_metadata=metadata,
+        subdirectory="posts",
+    )
+
+
+def persist_fetched_posts(
+    db: Session,
+    user_id: str,
+    posts: list[NormalizedLinkedInPost],
+    *,
+    save_fn: Callable[..., Optional[int]] = save_and_track_text_content,
+) -> tuple[list[int], list[str]]:
+    """
+    Persist multiple posts; returns (new_or_existing asset ids, skipped social ids).
+
+    Skipped social ids are duplicates that already existed before this call.
+    """
+    asset_ids: list[int] = []
+    skipped: list[str] = []
+
+    for post in posts:
+        prior_id = find_asset_id_by_social_id(db, user_id, post.social_id)
+        asset_id = persist_fetched_post(db, user_id, post, save_fn=save_fn)
+        if asset_id is None:
+            continue
+        asset_ids.append(asset_id)
+        if prior_id is not None:
+            skipped.append(post.social_id)
+
+    return asset_ids, skipped

--- a/backend/services/integrations/linkedin/linkedin_posts_types.py
+++ b/backend/services/integrations/linkedin/linkedin_posts_types.py
@@ -1,0 +1,78 @@
+"""
+Typed shapes for LinkedIn posts/articles fetched via Unipile.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Optional
+
+PostContentKind = Literal["post", "article", "repost"]
+
+
+@dataclass(frozen=True)
+class NormalizedLinkedInPost:
+    """Normalized LinkedIn post or article from Unipile."""
+
+    unipile_post_id: str
+    social_id: str
+    content_kind: PostContentKind
+    title: str
+    text: str
+    share_url: str
+    parsed_datetime: str
+    is_repost: bool
+    reaction_counter: int
+    comment_counter: int
+    repost_counter: int
+    impressions_counter: int
+    author_name: str
+    author_public_identifier: str
+    article_subtitle: str = ""
+    article_cover_url: str = ""
+    raw: dict[str, Any] = field(default_factory=dict, compare=False)
+
+
+@dataclass
+class FetchPostsResult:
+    """Result of a posts fetch operation."""
+
+    user_id: str
+    account_id: str
+    identifier: str
+    posts: list[NormalizedLinkedInPost]
+    cursor: Optional[str] = None
+    persisted_asset_ids: list[int] = field(default_factory=list)
+    skipped_social_ids: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "user_id": self.user_id,
+            "account_id": self.account_id,
+            "identifier": self.identifier,
+            "cursor": self.cursor,
+            "count": len(self.posts),
+            "persisted_asset_ids": self.persisted_asset_ids,
+            "skipped_social_ids": self.skipped_social_ids,
+            "posts": [
+                {
+                    "unipile_post_id": p.unipile_post_id,
+                    "social_id": p.social_id,
+                    "content_kind": p.content_kind,
+                    "title": p.title,
+                    "text": p.text,
+                    "share_url": p.share_url,
+                    "parsed_datetime": p.parsed_datetime,
+                    "is_repost": p.is_repost,
+                    "reaction_counter": p.reaction_counter,
+                    "comment_counter": p.comment_counter,
+                    "repost_counter": p.repost_counter,
+                    "impressions_counter": p.impressions_counter,
+                    "author_name": p.author_name,
+                    "author_public_identifier": p.author_public_identifier,
+                    "article_subtitle": p.article_subtitle,
+                    "article_cover_url": p.article_cover_url,
+                }
+                for p in self.posts
+            ],
+        }

--- a/backend/tests/api/test_linkedin_posts_route.py
+++ b/backend/tests/api/test_linkedin_posts_route.py
@@ -1,0 +1,115 @@
+"""Tests for GET /api/linkedin-social/posts route."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+
+def _load_linkedin_posts_routes():
+    module_name = "_linkedin_posts_routes_under_test"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    routes_path = _BACKEND_ROOT / "api" / "linkedin_posts_routes.py"
+    spec = importlib.util.spec_from_file_location(module_name, routes_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load route module from {routes_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_routes = _load_linkedin_posts_routes()
+get_linkedin_posts = _routes.get_linkedin_posts
+
+
+def _mock_fetch_result() -> object:
+    from services.integrations.linkedin.linkedin_posts_types import (
+        FetchPostsResult,
+        NormalizedLinkedInPost,
+    )
+
+    return FetchPostsResult(
+        user_id="user-route-test",
+        account_id="acc_route",
+        identifier="ACoTEST",
+        posts=[
+            NormalizedLinkedInPost(
+                unipile_post_id="post_1",
+                social_id="urn:li:activity:1",
+                content_kind="post",
+                title="Hello",
+                text="Hello world",
+                share_url="https://linkedin.com/post/1",
+                parsed_datetime="2025-01-01T00:00:00Z",
+                is_repost=False,
+                reaction_counter=1,
+                comment_counter=0,
+                repost_counter=0,
+                impressions_counter=10,
+                author_name="Jane",
+                author_public_identifier="jane",
+            )
+        ],
+        cursor=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_linkedin_posts_returns_normalized_payload():
+    current_user = {"id": "user-route-test"}
+    mock_db = object()
+
+    with patch.object(
+        _routes,
+        "fetch_user_posts",
+        new=AsyncMock(return_value=_mock_fetch_result()),
+    ):
+        response = await get_linkedin_posts(
+            limit=20,
+            cursor=None,
+            fetch_all=False,
+            include_article_body=True,
+            persist=False,
+            identifier=None,
+            current_user=current_user,
+            db=mock_db,
+        )
+
+    assert response.user_id == "user-route-test"
+    assert response.count == 1
+    assert response.posts[0].title == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_get_linkedin_posts_maps_not_connected_to_401():
+    from services.integrations.linkedin.types import LinkedInNotConnectedError
+
+    with patch.object(
+        _routes,
+        "fetch_user_posts",
+        new=AsyncMock(side_effect=LinkedInNotConnectedError("not connected")),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_linkedin_posts(
+                limit=20,
+                cursor=None,
+                fetch_all=False,
+                include_article_body=True,
+                persist=False,
+                identifier=None,
+                current_user={"id": "user-route-test"},
+                db=object(),
+            )
+
+    assert exc_info.value.status_code == 401

--- a/backend/tests/services/integrations/conftest.py
+++ b/backend/tests/services/integrations/conftest.py
@@ -1,0 +1,22 @@
+"""
+Isolate LinkedIn integration unit tests from heavy ``services.integrations`` imports.
+
+``services.integrations.__init__`` eagerly imports WordPress (PIL, etc.).
+Stub the package so ``services.integrations.linkedin.*`` submodules load directly.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+
+def pytest_configure(config) -> None:
+    backend_root = Path(__file__).resolve().parents[3]
+    integrations_dir = backend_root / "services" / "integrations"
+
+    stub = types.ModuleType("services.integrations")
+    stub.__path__ = [str(integrations_dir)]
+    stub.__package__ = "services.integrations"
+    sys.modules["services.integrations"] = stub

--- a/backend/tests/services/integrations/linkedin/test_linkedin_posts_normalizer.py
+++ b/backend/tests/services/integrations/linkedin/test_linkedin_posts_normalizer.py
@@ -1,0 +1,52 @@
+"""Tests for LinkedIn posts normalizer (pure, no mocks)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from services.integrations.linkedin.linkedin_posts_normalizer import (
+    normalize_unipile_post,
+    normalize_unipile_posts,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_FIXTURE_PATH = _REPO_ROOT / "docs" / "linkedin" / "fixtures" / "sample_post_list_raw.json"
+
+
+@pytest.fixture
+def fixture_items() -> list[dict]:
+    data = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+    return data["items"]
+
+
+def test_normalize_short_post(fixture_items):
+    post = normalize_unipile_post(fixture_items[0])
+    assert post.content_kind == "post"
+    assert post.social_id == "urn:li:activity:7000000000000000001"
+    assert "product launch" in post.text
+    assert post.reaction_counter == 42
+    assert post.author_name == "Jane Doe"
+
+
+def test_normalize_article_post(fixture_items):
+    post = normalize_unipile_post(fixture_items[1])
+    assert post.content_kind == "article"
+    assert post.title == "How We Scaled APIs"
+    assert post.article_subtitle == "Lessons from 8 years of backend engineering"
+    assert post.impressions_counter == 5400
+
+
+def test_normalize_repost(fixture_items):
+    post = normalize_unipile_post(fixture_items[2])
+    assert post.content_kind == "repost"
+    assert post.is_repost is True
+
+
+def test_normalize_list_skips_invalid_entries():
+    items = [{"id": "a", "social_id": "s1", "text": "hello"}]
+    normalized = normalize_unipile_posts(items + ["bad", None])
+    assert len(normalized) == 1
+    assert normalized[0].unipile_post_id == "a"

--- a/backend/tests/services/integrations/linkedin/test_linkedin_posts_service.py
+++ b/backend/tests/services/integrations/linkedin/test_linkedin_posts_service.py
@@ -1,0 +1,121 @@
+"""Tests for LinkedIn posts fetch orchestrator with injected fakes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+
+from services.integrations.linkedin.linkedin_posts_service import fetch_user_posts
+from services.integrations.linkedin.types import LinkedInCredentials, LinkedInNotConnectedError
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_FIXTURE_PATH = _REPO_ROOT / "docs" / "linkedin" / "fixtures" / "sample_post_list_raw.json"
+
+
+class FakeOAuth:
+    def resolve_credentials(self, user_id: str) -> LinkedInCredentials:
+        return LinkedInCredentials(
+            provider_mode="unipile",
+            unipile_account_id="acc_test_123",
+        )
+
+
+class FakePostsClient:
+    def __init__(self, items: list[dict[str, Any]], *, cursor: Optional[str] = "c1"):
+        self._items = items
+        self._cursor = cursor
+        self.get_own_profile_calls = 0
+        self.get_post_calls = 0
+
+    async def get_own_profile(self, account_id: str) -> dict[str, Any]:
+        self.get_own_profile_calls += 1
+        return {
+            "object": "AccountOwnerProfile",
+            "provider_id": "ACoAABCD1234",
+            "public_identifier": "jane-doe",
+        }
+
+    async def list_user_posts(
+        self,
+        account_id: str,
+        identifier: str,
+        *,
+        limit: int = 20,
+        cursor: Optional[str] = None,
+        is_company: Optional[bool] = None,
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+        return self._items[:limit], self._cursor
+
+    async def get_post(self, account_id: str, post_id: str) -> dict[str, Any]:
+        self.get_post_calls += 1
+        for item in self._items:
+            if item.get("id") == post_id:
+                enriched = dict(item)
+                enriched["text"] = enriched.get("text", "") + "\n\nFull article body."
+                return enriched
+        raise RuntimeError(f"post not found: {post_id}")
+
+
+@pytest.fixture
+def fixture_items() -> list[dict[str, Any]]:
+    data = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+    return data["items"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_user_posts_resolves_identifier_and_normalizes(fixture_items):
+    client = FakePostsClient(fixture_items, cursor=None)
+    result = await fetch_user_posts(
+        "user-test-1",
+        client=client,
+        oauth=FakeOAuth(),
+        limit=10,
+    )
+
+    assert result.account_id == "acc_test_123"
+    assert result.identifier == "jane-doe"
+    assert len(result.posts) == 3
+    assert result.posts[1].content_kind == "article"
+    assert client.get_own_profile_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_user_posts_enriches_articles(fixture_items):
+    client = FakePostsClient(fixture_items, cursor=None)
+    result = await fetch_user_posts(
+        "user-test-1",
+        client=client,
+        oauth=FakeOAuth(),
+        include_article_body=True,
+    )
+    assert client.get_post_calls == 1
+    assert "Full article body." in result.posts[1].text
+
+
+@pytest.mark.asyncio
+async def test_fetch_user_posts_skips_article_enrichment_when_disabled(fixture_items):
+    client = FakePostsClient(fixture_items, cursor=None)
+    await fetch_user_posts(
+        "user-test-1",
+        client=client,
+        oauth=FakeOAuth(),
+        include_article_body=False,
+    )
+    assert client.get_post_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_fetch_user_posts_not_connected():
+    class EmptyOAuth:
+        def resolve_credentials(self, user_id: str) -> LinkedInCredentials:
+            return LinkedInCredentials(provider_mode="unipile")
+
+    with pytest.raises(LinkedInNotConnectedError):
+        await fetch_user_posts(
+            "user-test-1",
+            client=FakePostsClient([]),
+            oauth=EmptyOAuth(),
+        )

--- a/backend/tests/services/integrations/linkedin/test_linkedin_posts_storage.py
+++ b/backend/tests/services/integrations/linkedin/test_linkedin_posts_storage.py
@@ -1,0 +1,122 @@
+"""Tests for LinkedIn posts asset-library persistence."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.integrations.linkedin import linkedin_posts_storage as storage_module
+from services.integrations.linkedin.linkedin_posts_normalizer import normalize_unipile_post
+from services.integrations.linkedin.linkedin_posts_storage import (
+    CONTENT_ORIGIN,
+    find_asset_id_by_social_id,
+    persist_fetched_post,
+    persist_fetched_posts,
+)
+
+
+def _sample_post(**overrides):
+    raw = {
+        "id": "post_001",
+        "social_id": "urn:li:activity:111",
+        "text": "Hello LinkedIn world",
+        "parsed_datetime": "2025-01-01T00:00:00Z",
+        "reaction_counter": 1,
+        "comment_counter": 0,
+        "repost_counter": 0,
+        "impressions_counter": 10,
+        "is_repost": False,
+        "author": {"name": "Jane", "public_identifier": "jane"},
+        **overrides,
+    }
+    return normalize_unipile_post(raw)
+
+
+def test_persist_post_uses_linkedin_writer_pattern():
+    saved: list[dict] = []
+
+    def fake_save(**kwargs):
+        saved.append(kwargs)
+        return 101
+
+    post = _sample_post()
+    asset_id = persist_fetched_post(
+        db=MagicMock(),
+        user_id="user-1",
+        post=post,
+        save_fn=fake_save,
+    )
+
+    assert asset_id == 101
+    assert len(saved) == 1
+    call = saved[0]
+    assert call["source_module"] == "linkedin_writer"
+    assert call["subdirectory"] == "posts"
+    assert call["tags"] == ["linkedin", "post", "fetched"]
+    assert call["asset_metadata"]["content_origin"] == CONTENT_ORIGIN
+    assert call["asset_metadata"]["social_id"] == "urn:li:activity:111"
+    assert call["title"].startswith("LinkedIn Post:")
+
+
+def test_persist_article_uses_md_and_articles_subdirectory():
+    saved: list[dict] = []
+
+    def fake_save(**kwargs):
+        saved.append(kwargs)
+        return 202
+
+    post = _sample_post(
+        article={"title": "My Article", "subtitle": "Subtitle"},
+        text="Intro paragraph",
+    )
+    asset_id = persist_fetched_post(
+        db=MagicMock(),
+        user_id="user-1",
+        post=post,
+        save_fn=fake_save,
+    )
+
+    assert asset_id == 202
+    call = saved[0]
+    assert call["subdirectory"] == "articles"
+    assert call["file_extension"] == ".md"
+    assert call["tags"] == ["linkedin", "article", "fetched"]
+    assert call["content"].startswith("# My Article")
+
+
+def test_find_asset_id_by_social_id_matches_content_origin(monkeypatch):
+    asset = MagicMock()
+    asset.id = 55
+    asset.asset_metadata = {
+        "content_origin": CONTENT_ORIGIN,
+        "social_id": "urn:li:activity:dup",
+    }
+
+    service = MagicMock()
+    service.get_user_assets.return_value = ([asset], 1)
+
+    monkeypatch.setattr(storage_module, "ContentAssetService", lambda _db: service)
+    found = find_asset_id_by_social_id(MagicMock(), "user-1", "urn:li:activity:dup")
+
+    assert found == 55
+
+
+def test_persist_fetched_posts_skips_duplicate_social_id(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_save(**_kwargs):
+        calls["count"] += 1
+        return 1
+
+    post = _sample_post()
+    db = MagicMock()
+
+    monkeypatch.setattr(storage_module, "find_asset_id_by_social_id", lambda *_a, **_k: 99)
+    asset_ids, skipped = persist_fetched_posts(
+        db, "user-1", [post], save_fn=fake_save
+    )
+
+    assert asset_ids == [99]
+    assert skipped == ["urn:li:activity:111"]
+    assert calls["count"] == 0

--- a/docs/linkedin/fixtures/sample_post_list_raw.json
+++ b/docs/linkedin/fixtures/sample_post_list_raw.json
@@ -1,0 +1,70 @@
+{
+  "object": "PostList",
+  "items": [
+    {
+      "provider": "LINKEDIN",
+      "id": "post_short_001",
+      "social_id": "urn:li:activity:7000000000000000001",
+      "share_url": "https://www.linkedin.com/feed/update/urn:li:activity:7000000000000000001",
+      "title": "",
+      "text": "Excited to share our latest product launch!\n\n#innovation #saas",
+      "parsed_datetime": "2025-11-15T10:30:00.000Z",
+      "reaction_counter": 42,
+      "comment_counter": 7,
+      "repost_counter": 3,
+      "impressions_counter": 1200,
+      "is_repost": false,
+      "author": {
+        "public_identifier": "jane-doe",
+        "id": "ACoAABCD1234",
+        "name": "Jane Doe",
+        "is_company": false
+      }
+    },
+    {
+      "provider": "LINKEDIN",
+      "id": "post_article_002",
+      "social_id": "urn:li:activity:7000000000000000002",
+      "share_url": "https://www.linkedin.com/pulse/how-we-scaled-apis-jane-doe",
+      "title": "",
+      "text": "A deep dive into scaling APIs for millions of users.",
+      "parsed_datetime": "2025-10-01T08:00:00.000Z",
+      "reaction_counter": 128,
+      "comment_counter": 19,
+      "repost_counter": 12,
+      "impressions_counter": 5400,
+      "is_repost": false,
+      "article": {
+        "title": "How We Scaled APIs",
+        "subtitle": "Lessons from 8 years of backend engineering",
+        "cover_url": "https://media.licdn.com/example/cover.jpg"
+      },
+      "author": {
+        "public_identifier": "jane-doe",
+        "id": "ACoAABCD1234",
+        "name": "Jane Doe",
+        "is_company": false
+      }
+    },
+    {
+      "provider": "LINKEDIN",
+      "id": "post_repost_003",
+      "social_id": "urn:li:activity:7000000000000000003",
+      "share_url": "https://www.linkedin.com/feed/update/urn:li:activity:7000000000000000003",
+      "text": "",
+      "parsed_datetime": "2025-09-20T14:00:00.000Z",
+      "reaction_counter": 5,
+      "comment_counter": 0,
+      "repost_counter": 0,
+      "impressions_counter": 200,
+      "is_repost": true,
+      "author": {
+        "public_identifier": "jane-doe",
+        "id": "ACoAABCD1234",
+        "name": "Jane Doe",
+        "is_company": false
+      }
+    }
+  ],
+  "cursor": "next_page_cursor_abc"
+}


### PR DESCRIPTION

Adds a self-contained backend module to fetch a connected LinkedIn user’s posts and articles via Unipile, with optional persistence to the Content Asset Library using the same `save_and_track_text_content()` path as generated LinkedIn content.

## Changes

- **Unipile posts client** — `LinkedInPostsClient` extends existing `UnipileClient` with `list_user_posts`, `get_post`, and cursor pagination (no changes to `unipile_client.py`).
- **Orchestration** — `fetch_user_posts()` resolves credentials, fetches/normalizes posts, optionally enriches article bodies, and supports injectable client/OAuth for tests.
- **Persistence** — Saves fetched posts/articles to asset library (`source_module=linkedin_writer`, `content_origin=unipile_fetch`, dedup by `social_id`).
- **API** — `GET /api/linkedin-social/posts` and `GET /api/linkedin-social/posts/{post_id}`.
- **CLI** — `backend/scripts/linkedin_fetch_posts.py` (live fetch, `--from-fixture`, `--persist`).
- **Tests** — Normalizer, service, storage, and route tests (14 passing); integration test conftest stubs heavy `services.integrations` imports.

## Test plan

- [ ] `pytest backend/tests/services/integrations/linkedin/test_linkedin_posts_*.py backend/tests/api/test_linkedin_posts_route.py`
- [ ] `python backend/scripts/linkedin_fetch_posts.py --from-fixture docs/linkedin/fixtures/sample_post_list_raw.json --print-normalized`
- [ ] With Unipile connected: `GET /api/linkedin-social/posts?limit=10`
- [ ] With `persist=true`: verify entries appear in asset library with `content_origin=unipile_fetch`
- [ ] Live: `python backend/scripts/linkedin_fetch_posts.py --user-id USER_ID --limit 10 --dry-run` 
- [ ] Live: `python backend/scripts/linkedin_fetch_posts.py --user-id USER_ID --persist`