### PR TITLE
refactor(onboarding): unify connection state, clean up orphaned linkedinConnected, show profile in LinkedIn tab

### DIFF
--- a/backend/api/linkedin_growth_routes.py
+++ b/backend/api/linkedin_growth_routes.py
@@ -1,0 +1,272 @@
+"""
+LinkedIn Growth Engine API routes.
+
+Provides endpoints for trending topics, network suggestions,
+engagement opportunities, preview scoring, and other growth features.
+Sessions 1-8 are added incrementally to this router.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from typing import Optional
+
+from models.linkedin_growth_models import (
+    ConsolidatedGrowthResponse,
+    TrendingTopicsResponse,
+    NetworkSuggestionsResponse,
+    EngagementOpportunitiesResponse,
+    PreviewScoreRequest,
+    PostPreviewScoreResponse,
+    ViralAnalysisResponse,
+    WeeklyStrategyResponse,
+    ContentGapsResponse,
+    BrandScorecardResponse,
+)
+from middleware.auth_middleware import get_current_user
+from services.linkedin.growth import (
+    ConsolidatedGrowthService,
+    TrendingService,
+    NetworkGrowthService,
+    EngagementService,
+    PreviewScoreService,
+    ViralAnalysisService,
+    WeeklyStrategyService,
+    ContentGapService,
+    BrandScorecardService,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/api/linkedin/growth",
+    tags=["LinkedIn Growth Engine"],
+)
+
+
+def _extract_user_id(current_user: Optional[dict]) -> str:
+    if current_user:
+        uid = (
+            current_user.get("clerk_user_id")
+            or current_user.get("id")
+            or current_user.get("sub")
+        )
+        if uid:
+            return str(uid)
+    raise HTTPException(status_code=401, detail="User not authenticated")
+
+
+@router.post(
+    "/trending",
+    response_model=TrendingTopicsResponse,
+    summary="Get trending topics for the user's industry",
+)
+async def get_trending_topics(
+    current_user: Optional[dict] = Depends(get_current_user),
+):
+    """Identify top trending topics in the user's industry using Exa + AI.
+
+    Returns up to 3 trending topics with suggested hooks and data source attribution.
+    """
+    try:
+        user_id = _extract_user_id(current_user)
+        service = TrendingService()
+        return await service.get_trending_topics(user_id=user_id)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("[Growth] get_trending_topics failed: {}", e)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/network-suggestions",
+    response_model=NetworkSuggestionsResponse,
+    summary="Get people to connect with this week",
+)
+async def get_network_suggestions(
+    current_user: Optional[dict] = Depends(get_current_user),
+):
+    """Suggest LinkedIn connections based on the user's profile and industry.
+
+    Returns up to 3 people to connect with, including personalized connection notes.
+    """
+    try:
+        user_id = _extract_user_id(current_user)
+        service = NetworkGrowthService()
+        return await service.get_network_suggestions(user_id=user_id)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("[Growth] get_network_suggestions failed: {}", e)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/engagement-opportunities",
+    response_model=EngagementOpportunitiesResponse,
+    summary="Find posts to engage with and get comment suggestions",
+)
+async def get_engagement_opportunities(
+    current_user: Optional[dict] = Depends(get_current_user),
+):
+    """Identify posts the user should engage with and suggests comments.
+
+    Uses Exa to find recent thought-provoking content in the user's
+    industry and generates thoughtful comment suggestions via AI.
+    """
+    try:
+        user_id = _extract_user_id(current_user)
+        service = EngagementService()
+        return await service.get_engagement_opportunities(user_id=user_id)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("[Growth] get_engagement_opportunities failed: {}", e)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/preview-score",
+    response_model=PostPreviewScoreResponse,
+    summary="Score a LinkedIn post draft across quality dimensions",
+)
+async def get_preview_score(
+    request: PreviewScoreRequest,
+    current_user: Optional[dict] = Depends(get_current_user),
+):
+    """Analyze a post draft and return scores across 6 quality dimensions.
+
+    Scores Hook Strength, Clarity, Engagement Potential, Value Proposition,
+    Call to Action, and Readability — each with actionable feedback.
+    """
+    try:
+        user_id = _extract_user_id(current_user)
+        service = PreviewScoreService()
+        return await service.score_post(request=request, user_id=user_id)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("[Growth] get_preview_score failed: {}", e)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/viral-analysis",
+    response_model=ViralAnalysisResponse,
+    summary="Analyze viral content patterns in your industry",
+)
+async def get_viral_analysis(
+    current_user: Optional[dict] = Depends(get_current_user),
+):
+    """Identify content patterns driving high engagement in the user's industry.
+
+    Searches Exa for high-engagement LinkedIn content and uses AI to extract
+    recurring patterns with examples and engagement multipliers.
+    """
+    try:
+        user_id = _extract_user_id(current_user)
+        service = ViralAnalysisService()
+        return await service.analyze(user_id=user_id)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("[Growth] get_viral_analysis failed: {}", e)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/weekly-strategy",
+    response_model=WeeklyStrategyResponse,
+    summary="Generate a weekly LinkedIn content strategy",
+)
+async def get_weekly_strategy(
+    current_user: Optional[dict] = Depends(get_current_user),
+):
+    """Create a week-long content strategy with daily post ideas.
+
+    Uses your LinkedIn profile and recent industry trends to generate
+    5 daily post ideas (Mon-Fri), a weekly theme, key topics, and focus area.
+    """
+    try:
+        user_id = _extract_user_id(current_user)
+        service = WeeklyStrategyService()
+        return await service.generate(user_id=user_id)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("[Growth] get_weekly_strategy failed: {}", e)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/content-gaps",
+    response_model=ContentGapsResponse,
+    summary="Identify content gaps in the user's LinkedIn strategy",
+)
+async def get_content_gaps(
+    current_user: Optional[dict] = Depends(get_current_user),
+):
+    """Find topics the user should be covering but hasn't.
+
+    Analyzes the user's industry and role against current trends
+    to identify content gaps with suggested post angles.
+    """
+    try:
+        user_id = _extract_user_id(current_user)
+        service = ContentGapService()
+        return await service.analyze(user_id=user_id)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("[Growth] get_content_gaps failed: {}", e)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get(
+    "/brand-scorecard",
+    response_model=BrandScorecardResponse,
+    summary="Evaluate your LinkedIn personal brand strength",
+)
+async def get_brand_scorecard(
+    current_user: Optional[dict] = Depends(get_current_user),
+):
+    """Score your personal brand across 5 dimensions.
+
+    Evaluates Profile Completeness, Content Consistency, Authority Signals,
+    Network Quality, and Brand Clarity based on your LinkedIn profile data.
+    """
+    try:
+        user_id = _extract_user_id(current_user)
+        service = BrandScorecardService()
+        return await service.score(user_id=user_id)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("[Growth] get_brand_scorecard failed: {}", e)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/analyze-all",
+    response_model=ConsolidatedGrowthResponse,
+    summary="Run all growth analyses in a single AI call",
+)
+async def analyze_all_growth(
+    current_user: Optional[dict] = Depends(get_current_user),
+):
+    """Generate all growth insights in one consolidated AI call.
+
+    Returns trending topics, network suggestions, engagement opportunities,
+    viral analysis, weekly strategy, content gaps, and brand scorecard —
+    all from a single LLM prompt to minimize latency and cost.
+    """
+    try:
+        user_id = _extract_user_id(current_user)
+        service = ConsolidatedGrowthService()
+        return await service.analyze_all(user_id=user_id)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("[Growth] analyze_all_growth failed: {}", e)
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/models/linkedin_growth_models.py
+++ b/backend/models/linkedin_growth_models.py
@@ -1,0 +1,317 @@
+from datetime import datetime
+from typing import List, Literal, Optional
+from pydantic import BaseModel, Field
+
+
+class TrendingTopicItem(BaseModel):
+    topic: str = Field(..., description="Short label for the trending topic (2-4 words)")
+    emoji: str = Field(..., description="Single relevant emoji")
+    why_now: str = Field(..., description="One-sentence explanation of why this matters right now")
+    suggested_hook: str = Field(..., description="LinkedIn post hook the user could write")
+    data_source_detail: str = Field(
+        ..., description="Brief explanation of what data this insight comes from"
+    )
+    confidence: Literal["high", "medium", "low"] = Field(
+        ..., description="How confident the system is in this topic's relevance"
+    )
+
+
+class TrendingTopicsResponse(BaseModel):
+    industry: str = Field(..., description="The industry these topics pertain to")
+    trending_topics: List[TrendingTopicItem] = Field(
+        default_factory=list, description="Top trending topics"
+    )
+    data_source_summary: str = Field(
+        ..., description="Transparency note about where the data comes from"
+    )
+    generated_at: datetime = Field(
+        ..., description="When this response was generated"
+    )
+
+
+class NetworkSuggestionItem(BaseModel):
+    name: str = Field(..., description="Full name of the suggested connection")
+    title: str = Field(..., description="Professional title/role")
+    company: str = Field(..., description="Company or organization")
+    why_connect: str = Field(
+        ..., description="One-sentence explanation of why this is a good connection"
+    )
+    suggested_note: str = Field(
+        ..., description="Personalized LinkedIn connection note the user can send"
+    )
+    data_source_detail: str = Field(
+        ..., description="Brief explanation of what data this insight comes from"
+    )
+    confidence: Literal["high", "medium", "low"] = Field(
+        ..., description="How confident the system is in this suggestion"
+    )
+
+
+class NetworkSuggestionsResponse(BaseModel):
+    suggestions: List[NetworkSuggestionItem] = Field(
+        default_factory=list, description="People to connect with this week"
+    )
+    data_source_summary: str = Field(
+        ..., description="Transparency note about where the data comes from"
+    )
+    generated_at: datetime = Field(
+        ..., description="When this response was generated"
+    )
+
+
+class EngagementOpportunityItem(BaseModel):
+    title: str = Field(..., description="Title of the post or article")
+    author: str = Field(..., description="Author's name")
+    author_context: str = Field(
+        ..., description="Context about the author (e.g. thought leader in SaaS, your network)"
+    )
+    why_engage: str = Field(
+        ..., description="One-sentence explanation of why engaging is valuable"
+    )
+    suggested_comment: str = Field(
+        ..., description="A thoughtful comment the user could post"
+    )
+    data_source_detail: str = Field(
+        ..., description="Brief explanation of what data this insight comes from"
+    )
+    confidence: Literal["high", "medium", "low"] = Field(
+        ..., description="How confident the system is in this opportunity"
+    )
+
+
+class EngagementOpportunitiesResponse(BaseModel):
+    opportunities: List[EngagementOpportunityItem] = Field(
+        default_factory=list, description="Posts to engage with"
+    )
+    data_source_summary: str = Field(
+        ..., description="Transparency note about where the data comes from"
+    )
+    generated_at: datetime = Field(
+        ..., description="When this response was generated"
+    )
+
+
+class PreviewScoreRequest(BaseModel):
+    content: str = Field(..., description="The LinkedIn post draft to analyze", min_length=1)
+    context: Optional[str] = Field(
+        None, description="Optional context about the post (topic, target audience, etc.)"
+    )
+
+
+class PostPreviewDimension(BaseModel):
+    dimension: str = Field(
+        ..., description="The scoring dimension name (e.g. Clarity, Engagement Potential)"
+    )
+    score: int = Field(
+        ..., description="Score from 0-100", ge=0, le=100
+    )
+    feedback: str = Field(
+        ..., description="Actionable feedback to improve this dimension"
+    )
+    data_source_detail: str = Field(
+        ..., description="Brief explanation of what data this score is based on"
+    )
+    confidence: Literal["high", "medium", "low"] = Field(
+        ..., description="How confident the system is in this score"
+    )
+
+
+class PostPreviewScoreResponse(BaseModel):
+    overall_score: int = Field(
+        ..., description="Overall score from 0-100", ge=0, le=100
+    )
+    dimensions: List[PostPreviewDimension] = Field(
+        default_factory=list, description="Individual dimension scores"
+    )
+    top_improvement: str = Field(
+        ..., description="Single most impactful suggestion for improvement"
+    )
+    data_source_summary: str = Field(
+        ..., description="Transparency note about where the data comes from"
+    )
+    generated_at: datetime = Field(
+        ..., description="When this response was generated"
+    )
+
+
+class ViralPattern(BaseModel):
+    pattern_name: str = Field(
+        ..., description="Short label for the viral pattern (e.g. Hot take + data point)"
+    )
+    description: str = Field(
+        ..., description="Explanation of what this pattern is and why it works"
+    )
+    engagement_multiplier: str = Field(
+        ..., description="Estimated engagement impact (e.g. 3x engagement)"
+    )
+    example_headline: str = Field(
+        ..., description="Example post headline that uses this pattern"
+    )
+    example_author: str = Field(
+        ..., description="Name of the person who posted the example"
+    )
+    data_source_detail: str = Field(
+        ..., description="Brief explanation of what data this pattern comes from"
+    )
+    confidence: Literal["high", "medium", "low"] = Field(
+        ..., description="How confident the system is in this pattern"
+    )
+
+
+class ViralAnalysisResponse(BaseModel):
+    industry: str = Field(..., description="The industry being analyzed")
+    patterns: List[ViralPattern] = Field(
+        default_factory=list, description="Identified viral content patterns"
+    )
+    top_recommendation: str = Field(
+        ..., description="Single most impactful pattern to use right now"
+    )
+    data_source_summary: str = Field(
+        ..., description="Transparency note about where the data comes from"
+    )
+    generated_at: datetime = Field(
+        ..., description="When this response was generated"
+    )
+
+
+class DailyPostIdea(BaseModel):
+    day: str = Field(..., description="Day of the week (Monday, Tuesday, etc.)")
+    content_type: str = Field(
+        ..., description="Type of post (How-to, Case study, Hot take, etc.)"
+    )
+    headline: str = Field(
+        ..., description="Catchy headline for the post idea"
+    )
+    hook: str = Field(
+        ..., description="The opening hook to grab attention"
+    )
+    why_this_works: str = Field(
+        ..., description="One-sentence explanation of why this post will perform well"
+    )
+    data_source_detail: str = Field(
+        ..., description="Brief explanation of what data this idea comes from"
+    )
+    confidence: Literal["high", "medium", "low"] = Field(
+        ..., description="How confident the system is in this idea"
+    )
+
+
+class WeeklyStrategyResponse(BaseModel):
+    theme: str = Field(
+        ..., description="The overarching theme for the week (e.g. Share your process)"
+    )
+    week_of: str = Field(
+        ..., description="The start date of this strategy week (ISO format)"
+    )
+    daily_posts: List[DailyPostIdea] = Field(
+        default_factory=list, description="One post idea per weekday"
+    )
+    key_topics: List[str] = Field(
+        default_factory=list, description="3-5 key topics to cover this week"
+    )
+    focus_area: str = Field(
+        ..., description="The primary focus for this week (e.g. Authority building)"
+    )
+    data_source_summary: str = Field(
+        ..., description="Transparency note about where the data comes from"
+    )
+    generated_at: datetime = Field(
+        ..., description="When this response was generated"
+    )
+
+
+class ContentGapItem(BaseModel):
+    gap_topic: str = Field(
+        ..., description="The topic the user hasn't covered (e.g. AI/ML in your industry)"
+    )
+    why_gap: str = Field(
+        ..., description="Explanation of why this topic is missing from their content"
+    )
+    why_it_matters: str = Field(
+        ..., description="Why they should cover this topic now"
+    )
+    suggested_angle: str = Field(
+        ..., description="A specific post angle to fill this gap"
+    )
+    data_source_detail: str = Field(
+        ..., description="Brief explanation of what data this gap comes from"
+    )
+    confidence: Literal["high", "medium", "low"] = Field(
+        ..., description="How confident the system is in this gap"
+    )
+
+
+class ContentGapsResponse(BaseModel):
+    gaps: List[ContentGapItem] = Field(
+        default_factory=list, description="Identified content gaps"
+    )
+    data_source_summary: str = Field(
+        ..., description="Transparency note about where the data comes from"
+    )
+    generated_at: datetime = Field(
+        ..., description="When this response was generated"
+    )
+
+
+class BrandDimension(BaseModel):
+    dimension: str = Field(
+        ..., description="The brand dimension name (e.g. Profile Completeness)"
+    )
+    score: int = Field(
+        ..., description="Score from 0-100", ge=0, le=100
+    )
+    feedback: str = Field(
+        ..., description="Actionable feedback to improve this dimension"
+    )
+    data_source_detail: str = Field(
+        ..., description="Brief explanation of what data this score is based on"
+    )
+    confidence: Literal["high", "medium", "low"] = Field(
+        ..., description="How confident the system is in this score"
+    )
+
+
+class BrandScorecardResponse(BaseModel):
+    overall_score: int = Field(
+        ..., description="Overall brand score from 0-100", ge=0, le=100
+    )
+    dimensions: List[BrandDimension] = Field(
+        default_factory=list, description="Individual brand dimension scores"
+    )
+    top_recommendation: str = Field(
+        ..., description="Single most impactful suggestion to improve your brand"
+    )
+    data_source_summary: str = Field(
+        ..., description="Transparency note about where the data comes from"
+    )
+    generated_at: datetime = Field(
+        ..., description="When this response was generated"
+    )
+
+
+class ConsolidatedGrowthResponse(BaseModel):
+    trending: Optional[TrendingTopicsResponse] = Field(
+        None, description="Trending topics in the user's industry"
+    )
+    network_suggestions: Optional[NetworkSuggestionsResponse] = Field(
+        None, description="People to connect with this week"
+    )
+    engagement_opportunities: Optional[EngagementOpportunitiesResponse] = Field(
+        None, description="Posts to engage with"
+    )
+    viral_analysis: Optional[ViralAnalysisResponse] = Field(
+        None, description="Viral content patterns in user's industry"
+    )
+    weekly_strategy: Optional[WeeklyStrategyResponse] = Field(
+        None, description="Weekly LinkedIn content strategy"
+    )
+    content_gaps: Optional[ContentGapsResponse] = Field(
+        None, description="Content gaps in the user's strategy"
+    )
+    brand_scorecard: Optional[BrandScorecardResponse] = Field(
+        None, description="Personal brand strength evaluation"
+    )
+    generated_at: datetime = Field(
+        default_factory=datetime.now,
+        description="When this consolidated response was generated",
+    )

--- a/backend/services/linkedin/growth/__init__.py
+++ b/backend/services/linkedin/growth/__init__.py
@@ -1,0 +1,21 @@
+from .trending_service import TrendingService
+from .network_growth_service import NetworkGrowthService
+from .engagement_service import EngagementService
+from .preview_score_service import PreviewScoreService
+from .viral_analysis_service import ViralAnalysisService
+from .weekly_strategy_service import WeeklyStrategyService
+from .content_gap_service import ContentGapService
+from .brand_scorecard_service import BrandScorecardService
+from .consolidated_growth_service import ConsolidatedGrowthService
+
+__all__ = [
+    "TrendingService",
+    "NetworkGrowthService",
+    "EngagementService",
+    "PreviewScoreService",
+    "ViralAnalysisService",
+    "WeeklyStrategyService",
+    "ContentGapService",
+    "BrandScorecardService",
+    "ConsolidatedGrowthService",
+]

--- a/backend/services/linkedin/growth/brand_scorecard_service.py
+++ b/backend/services/linkedin/growth/brand_scorecard_service.py
@@ -1,0 +1,172 @@
+import asyncio
+from datetime import datetime, timezone
+from loguru import logger
+
+from models.linkedin_growth_models import BrandDimension, BrandScorecardResponse
+from .cache import growth_cache
+from .circuit_breaker import protected_llm_call
+
+
+class BrandScorecardService:
+    """Evaluates the user's LinkedIn personal brand strength."""
+
+    def __init__(self):
+        self._profile_repo = None
+
+    def _get_profile_repo(self):
+        if self._profile_repo is None:
+            from services.integrations.linkedin.profile_repository import ProfileRepository
+            self._profile_repo = ProfileRepository()
+        return self._profile_repo
+
+    def _get_context(self, user_id: str) -> dict:
+        """Get all available profile context for scoring."""
+        try:
+            repo = self._get_profile_repo()
+            ctx = repo.get_profile_context(user_id)
+            if ctx and isinstance(ctx, dict):
+                return ctx
+        except Exception as exc:
+            logger.debug("[BrandScorecard] Could not load profile context: {}", exc)
+        return {}
+
+    def _profile_summary(self, ctx: dict) -> str:
+        """Build a human-readable summary of profile data."""
+        parts = []
+        pi = ctx.get("personal_information", {}) or {}
+        pr = ctx.get("professional_information", {}) or {}
+
+        headline = pi.get("headline", "")
+        if headline:
+            parts.append(f"Headline: {headline}")
+
+        industry = ctx.get("industry", "")
+        if industry:
+            parts.append(f"Industry: {industry}")
+
+        title = pr.get("title", "")
+        if title:
+            parts.append(f"Title: {title}")
+
+        geo = pi.get("geo", {}) or {}
+        location = geo.get("full", geo.get("city", ""))
+        if location:
+            parts.append(f"Location: {location}")
+
+        return "\n".join(parts) if parts else "Limited profile data available."
+
+    async def score(
+        self,
+        user_id: str,
+    ) -> BrandScorecardResponse:
+        """Score the user's personal brand based on profile data."""
+        ctx = await asyncio.to_thread(self._get_context, user_id)
+        profile_text = self._profile_summary(ctx)
+
+        result = await self._llm_score_brand(profile_text, user_id)
+        if result is None:
+            return BrandScorecardResponse(
+                overall_score=50,
+                dimensions=[],
+                top_recommendation="Connect your LinkedIn account to get your brand scorecard.",
+                data_source_summary="Based on limited profile data. Connect LinkedIn for a full analysis.",
+                generated_at=datetime.now(timezone.utc),
+            )
+
+        dimensions = [BrandDimension(**d) for d in result.get("dimensions", [])]
+        return BrandScorecardResponse(
+            overall_score=result.get("overall_score", 50),
+            dimensions=dimensions,
+            top_recommendation=result.get("top_recommendation", ""),
+            data_source_summary=(
+                f"Based on your LinkedIn profile data across {len(dimensions)} "
+                f"brand dimensions"
+            ),
+            generated_at=datetime.now(timezone.utc),
+        )
+
+    async def _llm_score_brand(self, profile_text: str, user_id: str) -> dict | None:
+        from services.llm_providers.main_text_generation import llm_text_gen
+
+        system_prompt = (
+            "You are a LinkedIn personal branding analyst. Evaluate the user's "
+            "LinkedIn profile and score it across these dimensions (0-100 each):\n\n"
+            "1. Profile Completeness — Does the profile have a photo, headline, "
+            "about section, featured content?\n"
+            "2. Content Consistency — Is there evidence of regular posting?\n"
+            "3. Authority Signals — Does the profile show thought leadership?\n"
+            "4. Network Quality — Does the profile suggest a strong network?\n"
+            "5. Brand Clarity — Is the personal brand message clear?\n\n"
+            "For each dimension provide:\n"
+            "- dimension: name exactly as listed above\n"
+            "- score: integer 0-100\n"
+            "- feedback: 1-2 sentences of actionable advice\n"
+            "- data_source_detail: what data this is based on\n"
+            "- confidence: high/medium/low\n\n"
+            "Also provide:\n"
+            "- overall_score: integer 0-100 (weighted average)\n"
+            "- top_recommendation: single most impactful suggestion (1 sentence)\n\n"
+            "Output ONLY valid JSON. Be honest and critical — don't inflate scores."
+        )
+
+        prompt = (
+            f"User's LinkedIn Profile:\n{profile_text}\n\n"
+            "Score this personal brand. Return JSON with 'dimensions' array of "
+            "exactly 5 items, 'overall_score' (integer), and "
+            "'top_recommendation' (string)."
+        )
+
+        json_schema = {
+            "type": "object",
+            "properties": {
+                "dimensions": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "dimension": {"type": "string"},
+                            "score": {"type": "integer", "minimum": 0, "maximum": 100},
+                            "feedback": {"type": "string"},
+                            "data_source_detail": {"type": "string"},
+                            "confidence": {
+                                "type": "string",
+                                "enum": ["high", "medium", "low"],
+                            },
+                        },
+                        "required": [
+                            "dimension",
+                            "score",
+                            "feedback",
+                            "data_source_detail",
+                            "confidence",
+                        ],
+                    },
+                },
+                "overall_score": {"type": "integer", "minimum": 0, "maximum": 100},
+                "top_recommendation": {"type": "string"},
+            },
+            "required": ["dimensions", "overall_score", "top_recommendation"],
+        }
+
+        llm_cache_key = growth_cache.llm_key(prompt[:200] + str(json_schema), user_id)
+        cached_llm = growth_cache.get(llm_cache_key)
+        if cached_llm is not None:
+            logger.info("[BrandScorecard] LLM cache hit")
+            return cached_llm
+
+        try:
+            raw = await protected_llm_call(
+                llm_text_gen,
+                prompt=prompt,
+                system_prompt=system_prompt,
+                json_struct=json_schema,
+                user_id=user_id,
+            )
+            if isinstance(raw, dict) and "dimensions" in raw and "overall_score" in raw:
+                growth_cache.set(llm_cache_key, raw, ttl_seconds=3600)
+                return raw
+            logger.warning("[BrandScorecard] LLM returned unexpected shape: {}", type(raw))
+            return None
+        except Exception as exc:
+            logger.error("[BrandScorecard] LLM generation failed: {}", exc)
+            return None

--- a/backend/services/linkedin/growth/cache.py
+++ b/backend/services/linkedin/growth/cache.py
@@ -1,0 +1,84 @@
+import hashlib
+from typing import Any, Dict, Optional, Set
+
+from loguru import logger
+from services.analytics_cache_service import analytics_cache
+
+
+class GrowthCache:
+    """Growth engine cache that delegates to the shared ``AnalyticsCacheService``.
+
+    Keeps convenient key helpers (``exa_key``, ``llm_key``) and per-service
+    stats, while reusing the app-wide in-memory TTL cache backend.
+    Exa results default to 300s TTL, LLM responses to 3600s TTL.
+    """
+
+    def __init__(self, default_ttl_seconds: int = 300):
+        self._default_ttl = default_ttl_seconds
+        self._keys: Set[str] = set()
+        self._hits = 0
+        self._misses = 0
+
+    # ------------------------------------------------------------------
+    # public
+    # ------------------------------------------------------------------
+    def get(self, key: str) -> Optional[Any]:
+        """Return cached value if present and not expired."""
+        value = analytics_cache.raw_get(key)
+        if value is None:
+            self._misses += 1
+            return None
+        self._hits += 1
+        return value
+
+    def set(self, key: str, value: Any, ttl_seconds: Optional[int] = None):
+        """Store a value with TTL (defaults to instance default_ttl_seconds)."""
+        analytics_cache.raw_set(key, value, ttl_seconds or self._default_ttl)
+        self._keys.add(key)
+
+    def clear(self):
+        """Clear all growth-cached entries."""
+        removed = 0
+        removed += analytics_cache.raw_invalidate_prefix("exa:")
+        removed += analytics_cache.raw_invalidate_prefix("llm:")
+        self._keys.clear()
+        self._hits = 0
+        self._misses = 0
+        logger.info("[GrowthCache] Cleared {} entries", removed)
+
+    def clear_prefix(self, prefix: str):
+        """Clear entries whose key starts with a given prefix (e.g. 'exa:' or 'llm:')."""
+        count = analytics_cache.raw_invalidate_prefix(prefix)
+        self._keys = {k for k in self._keys if not k.startswith(prefix)}
+        if count:
+            logger.info("[GrowthCache] Cleared {} entries with prefix '{}'", count, prefix)
+
+    def stats(self) -> Dict[str, Any]:
+        """Return cache statistics for monitoring."""
+        return {
+            "entries": len(self._keys),
+            "max_entries": 0,
+            "hits": self._hits,
+            "misses": self._misses,
+            "hit_rate": round(self._hits / (self._hits + self._misses) * 100, 1)
+            if (self._hits + self._misses) > 0
+            else 0.0,
+            "default_ttl_seconds": self._default_ttl,
+        }
+
+    # ------------------------------------------------------------------
+    # key helpers (convenience for services)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def exa_key(query: str, num_results: int, user_id: str) -> str:
+        raw = f"{query}|{num_results}|{user_id}"
+        return f"exa:{hashlib.md5(raw.encode()).hexdigest()}"
+
+    @staticmethod
+    def llm_key(prompt: str, user_id: str) -> str:
+        raw = f"{prompt[:300]}|{user_id}"
+        return f"llm:{hashlib.md5(raw.encode()).hexdigest()}"
+
+
+# Global singleton — shared across all growth services
+growth_cache = GrowthCache()

--- a/backend/services/linkedin/growth/circuit_breaker.py
+++ b/backend/services/linkedin/growth/circuit_breaker.py
@@ -1,0 +1,43 @@
+"""Circuit breaker for growth engine LLM calls.
+
+Reuses the production-grade ``CircuitBreakerManager`` from the blog writer
+module with growth-specific thresholds.  Protects all growth-service LLM
+calls so that a failing LLM doesn't cascade into repeated timeouts.
+"""
+
+from typing import Any, Callable
+
+import asyncio
+from loguru import logger
+from services.blog_writer.circuit_breaker import (
+    CircuitBreakerConfig,
+    circuit_breaker_manager,
+)
+from services.blog_writer.exceptions import CircuitBreakerOpenException
+
+GROWTH_LLM_CB_CONFIG = CircuitBreakerConfig(
+    failure_threshold=3,
+    recovery_timeout=30,
+    success_threshold=2,
+    timeout=90,
+    max_failures_per_minute=5,
+)
+
+
+async def protected_llm_call(llm_func: Callable, **kwargs: Any) -> Any:
+    """Execute an LLM function under the growth circuit breaker.
+
+    Args:
+        llm_func: The LLM provider function (e.g. ``llm_text_gen``).
+        **kwargs: Forwarded directly to ``llm_func``.
+
+    Returns:
+        The raw LLM result.
+
+    Raises:
+        CircuitBreakerOpenException: If the circuit is open.
+        asyncio.TimeoutError: If the call exceeds the breaker timeout.
+        Any exception from the LLM function itself.
+    """
+    breaker = circuit_breaker_manager.get_breaker("growth_llm", GROWTH_LLM_CB_CONFIG)
+    return await breaker.call(asyncio.to_thread, llm_func, **kwargs)

--- a/backend/services/linkedin/growth/consolidated_growth_service.py
+++ b/backend/services/linkedin/growth/consolidated_growth_service.py
@@ -1,0 +1,289 @@
+import asyncio
+import logging
+from datetime import datetime
+from typing import Optional
+
+from models.linkedin_growth_models import (
+    BrandDimension,
+    BrandScorecardResponse,
+    ConsolidatedGrowthResponse,
+    ContentGapItem,
+    ContentGapsResponse,
+    DailyPostIdea,
+    EngagementOpportunitiesResponse,
+    EngagementOpportunityItem,
+    NetworkSuggestionsResponse,
+    NetworkSuggestionItem,
+    TrendingTopicsResponse,
+    TrendingTopicItem,
+    ViralAnalysisResponse,
+    ViralPattern,
+    WeeklyStrategyResponse,
+)
+from pydantic import BaseModel, Field
+from services.integrations.linkedin.profile_repository import ProfileRepository
+from services.llm_providers.main_text_generation import llm_text_gen
+from .cache import growth_cache
+from .circuit_breaker import protected_llm_call
+
+logger = logging.getLogger(__name__)
+
+
+class ConsolidatedLLMData(BaseModel):
+    """Compact data model matching what the single LLM prompt returns."""
+
+    trending_industry: str = Field(..., description="The user's industry")
+    trending_topics: list[TrendingTopicItem] = Field(
+        default_factory=list, description="Top trending topics (exactly 2)"
+    )
+    trending_data_source_summary: str = Field(
+        ..., description="Transparency note for trending data"
+    )
+
+    network_suggestions: list[NetworkSuggestionItem] = Field(
+        default_factory=list, description="People to connect with (exactly 2)"
+    )
+    network_data_source_summary: str = Field(
+        ..., description="Transparency note for network suggestions"
+    )
+
+    engagement_opportunities: list[EngagementOpportunityItem] = Field(
+        default_factory=list, description="Posts to engage with (exactly 2)"
+    )
+    engagement_data_source_summary: str = Field(
+        ..., description="Transparency note for engagement data"
+    )
+
+    viral_industry: str = Field(..., description="The industry being analyzed")
+    viral_patterns: list[ViralPattern] = Field(
+        default_factory=list, description="Viral content patterns (exactly 2)"
+    )
+    viral_top_recommendation: str = Field(
+        ..., description="Most impactful viral pattern to use"
+    )
+    viral_data_source_summary: str = Field(
+        ..., description="Transparency note for viral analysis data"
+    )
+
+    strategy_theme: str = Field(
+        ..., description="Overarching theme for the week"
+    )
+    strategy_week_of: str = Field(
+        ..., description="Start date of this strategy week (ISO)"
+    )
+    strategy_daily_posts: list[DailyPostIdea] = Field(
+        default_factory=list, description="Post ideas for Mon, Wed, Fri (exactly 3)"
+    )
+    strategy_key_topics: list[str] = Field(
+        default_factory=list, description="Key topics to cover (exactly 3)"
+    )
+    strategy_focus_area: str = Field(
+        ..., description="Primary focus for this week"
+    )
+    strategy_data_source_summary: str = Field(
+        ..., description="Transparency note for strategy data"
+    )
+
+    content_gaps: list[ContentGapItem] = Field(
+        default_factory=list, description="Content gaps (exactly 2)"
+    )
+    content_gaps_data_source_summary: str = Field(
+        ..., description="Transparency note for content gap data"
+    )
+
+    brand_overall_score: int = Field(
+        ..., description="Overall brand score 0-100", ge=0, le=100
+    )
+    brand_dimensions: list[BrandDimension] = Field(
+        default_factory=list, description="Brand dimension scores (exactly 5)"
+    )
+    brand_top_recommendation: str = Field(
+        ..., description="Most impactful brand improvement suggestion"
+    )
+    brand_data_source_summary: str = Field(
+        ..., description="Transparency note for brand data"
+    )
+
+
+SYSTEM_PROMPT = """You are a LinkedIn growth strategist. Based on the user's profile, generate concise insights for ALL 7 sections below. Keep responses brief — 2 items per section maximum.
+
+SECTIONS (all required, return the exact schema fields):
+
+1. **Trending Topics** (2 items): topic label, emoji, why_now (1 sentence), suggested_hook (1 sentence).
+2. **Network Suggestions** (2 items): name, title, company, why_connect (1 sentence), suggested_note (1-2 sentences).
+3. **Engagement Opportunities** (2 items): title, author, author_context, why_engage (1 sentence), suggested_comment (1-2 sentences).
+4. **Viral Content Patterns** (2 items): pattern_name, description (1 sentence), engagement_multiplier (e.g. "3x"), example_headline, example_author.
+5. **Weekly Content Strategy** (3 items only — Mon, Wed, Fri): day, content_type, headline, hook, why_this_works. Include theme (1 phrase), key_topics (3 items), focus_area (1 phrase).
+6. **Content Gaps** (2 items): gap_topic, why_gap (1 sentence), why_it_matters (1 sentence), suggested_angle (1 sentence).
+7. **Brand Scorecard** (5 dimensions): Profile Completeness, Content Consistency, Authority Signals, Network Quality, Brand Clarity. Score each 0-100, give 1-sentence feedback each. Include overall_score and top_recommendation.
+
+For ALL items: include data_source_detail ("Profile + industry analysis") and confidence ("high"/"medium"/"low").
+For ALL data_source_summary fields: "Based on your LinkedIn profile and current industry trends."
+"""
+
+
+class ConsolidatedGrowthService:
+    """Generates all growth insights in a single LLM call."""
+
+    def __init__(self):
+        self._profile_repo: Optional[ProfileRepository] = None
+
+    def _get_profile_repo(self):
+        if self._profile_repo is None:
+            from services.integrations.linkedin.profile_repository import (
+                ProfileRepository,
+            )
+
+            self._profile_repo = ProfileRepository()
+        return self._profile_repo
+
+    async def analyze_all(self, user_id: str) -> ConsolidatedGrowthResponse:
+        logger.info(f"[ConsolidatedGrowth] Starting consolidated analysis for user {user_id}")
+
+        repo = self._get_profile_repo()
+        profile_context = await asyncio.to_thread(repo.get_profile_context, user_id)
+        context_str = str(profile_context)
+
+        json_schema = ConsolidatedLLMData.model_json_schema()
+        prompt = f"USER PROFILE:\n{context_str}\n\nGenerate insights for all 7 sections following the schema."
+        llm_cache_key = growth_cache.llm_key(prompt + SYSTEM_PROMPT, user_id)
+
+        cached_raw = growth_cache.get(llm_cache_key)
+        if cached_raw is not None:
+            logger.info("[ConsolidatedGrowth] LLM cache hit")
+            raw = cached_raw
+        else:
+            try:
+                raw = await protected_llm_call(
+                    llm_text_gen,
+                    prompt=prompt,
+                    system_prompt=SYSTEM_PROMPT,
+                    json_struct=json_schema,
+                    user_id=user_id,
+                )
+                if raw:
+                    growth_cache.set(llm_cache_key, raw, ttl_seconds=3600)
+            except Exception as e:
+                logger.error(f"[ConsolidatedGrowth] LLM call failed: {e}")
+                now = datetime.now()
+                return ConsolidatedGrowthResponse(generated_at=now)
+
+        if not raw:
+            logger.warning("[ConsolidatedGrowth] LLM returned empty data")
+            now = datetime.now()
+            return ConsolidatedGrowthResponse(generated_at=now)
+
+        if isinstance(raw, str):
+            import json as _json
+            raw = _json.loads(raw)
+
+        if not isinstance(raw, dict):
+            logger.warning("[ConsolidatedGrowth] LLM returned unexpected type: {}", type(raw))
+            now = datetime.now()
+            return ConsolidatedGrowthResponse(generated_at=now)
+
+        now = datetime.now()
+
+        return ConsolidatedGrowthResponse(
+            trending=self._parse_trending(raw, now),
+            network_suggestions=self._parse_network(raw, now),
+            engagement_opportunities=self._parse_engagement(raw, now),
+            viral_analysis=self._parse_viral(raw, now),
+            weekly_strategy=self._parse_strategy(raw, now),
+            content_gaps=self._parse_content_gaps(raw, now),
+            brand_scorecard=self._parse_brand(raw, now),
+            generated_at=now,
+        )
+
+    def _parse_trending(self, raw: dict, now: datetime) -> TrendingTopicsResponse:
+        try:
+            items = [TrendingTopicItem(**t) for t in raw.get("trending_topics", [])]
+            return TrendingTopicsResponse(
+                industry=raw.get("trending_industry", ""),
+                trending_topics=items,
+                data_source_summary=raw.get("trending_data_source_summary", ""),
+                generated_at=now,
+            )
+        except Exception as e:
+            logger.warning("[ConsolidatedGrowth] Failed to parse trending: {}", e)
+            return TrendingTopicsResponse(generated_at=now)
+
+    def _parse_network(self, raw: dict, now: datetime) -> NetworkSuggestionsResponse:
+        try:
+            items = [NetworkSuggestionItem(**s) for s in raw.get("network_suggestions", [])]
+            return NetworkSuggestionsResponse(
+                suggestions=items,
+                data_source_summary=raw.get("network_data_source_summary", ""),
+                generated_at=now,
+            )
+        except Exception as e:
+            logger.warning("[ConsolidatedGrowth] Failed to parse network: {}", e)
+            return NetworkSuggestionsResponse(generated_at=now)
+
+    def _parse_engagement(self, raw: dict, now: datetime) -> EngagementOpportunitiesResponse:
+        try:
+            items = [EngagementOpportunityItem(**o) for o in raw.get("engagement_opportunities", [])]
+            return EngagementOpportunitiesResponse(
+                opportunities=items,
+                data_source_summary=raw.get("engagement_data_source_summary", ""),
+                generated_at=now,
+            )
+        except Exception as e:
+            logger.warning("[ConsolidatedGrowth] Failed to parse engagement: {}", e)
+            return EngagementOpportunitiesResponse(generated_at=now)
+
+    def _parse_viral(self, raw: dict, now: datetime) -> ViralAnalysisResponse:
+        try:
+            patterns = [ViralPattern(**p) for p in raw.get("viral_patterns", [])]
+            return ViralAnalysisResponse(
+                industry=raw.get("viral_industry", ""),
+                patterns=patterns,
+                top_recommendation=raw.get("viral_top_recommendation", ""),
+                data_source_summary=raw.get("viral_data_source_summary", ""),
+                generated_at=now,
+            )
+        except Exception as e:
+            logger.warning("[ConsolidatedGrowth] Failed to parse viral: {}", e)
+            return ViralAnalysisResponse(generated_at=now)
+
+    def _parse_strategy(self, raw: dict, now: datetime) -> WeeklyStrategyResponse:
+        try:
+            posts = [DailyPostIdea(**p) for p in raw.get("strategy_daily_posts", [])]
+            return WeeklyStrategyResponse(
+                theme=raw.get("strategy_theme", ""),
+                week_of=raw.get("strategy_week_of", ""),
+                daily_posts=posts,
+                key_topics=raw.get("strategy_key_topics", []),
+                focus_area=raw.get("strategy_focus_area", ""),
+                data_source_summary=raw.get("strategy_data_source_summary", ""),
+                generated_at=now,
+            )
+        except Exception as e:
+            logger.warning("[ConsolidatedGrowth] Failed to parse strategy: {}", e)
+            return WeeklyStrategyResponse(generated_at=now)
+
+    def _parse_content_gaps(self, raw: dict, now: datetime) -> ContentGapsResponse:
+        try:
+            items = [ContentGapItem(**g) for g in raw.get("content_gaps", [])]
+            return ContentGapsResponse(
+                gaps=items,
+                data_source_summary=raw.get("content_gaps_data_source_summary", ""),
+                generated_at=now,
+            )
+        except Exception as e:
+            logger.warning("[ConsolidatedGrowth] Failed to parse content gaps: {}", e)
+            return ContentGapsResponse(generated_at=now)
+
+    def _parse_brand(self, raw: dict, now: datetime) -> BrandScorecardResponse:
+        try:
+            dims = [BrandDimension(**d) for d in raw.get("brand_dimensions", [])]
+            return BrandScorecardResponse(
+                overall_score=raw.get("brand_overall_score", 0),
+                dimensions=dims,
+                top_recommendation=raw.get("brand_top_recommendation", ""),
+                data_source_summary=raw.get("brand_data_source_summary", ""),
+                generated_at=now,
+            )
+        except Exception as e:
+            logger.warning("[ConsolidatedGrowth] Failed to parse brand: {}", e)
+            return BrandScorecardResponse(generated_at=now)

--- a/backend/services/linkedin/growth/content_gap_service.py
+++ b/backend/services/linkedin/growth/content_gap_service.py
@@ -1,0 +1,189 @@
+import asyncio
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+from loguru import logger
+
+from models.linkedin_growth_models import ContentGapItem, ContentGapsResponse
+from .cache import growth_cache
+from .circuit_breaker import protected_llm_call
+
+
+class ContentGapService:
+    """Analyzes content gaps — topics the user should be covering."""
+
+    def __init__(self):
+        self._profile_repo = None
+        self._exa_provider = None
+
+    def _get_profile_repo(self):
+        if self._profile_repo is None:
+            from services.integrations.linkedin.profile_repository import ProfileRepository
+            self._profile_repo = ProfileRepository()
+        return self._profile_repo
+
+    def _get_exa_provider(self):
+        if self._exa_provider is None:
+            from services.research import get_exa_content_provider
+            self._exa_provider = get_exa_content_provider()
+        return self._exa_provider
+
+    def _resolve_industry_and_title(self, user_id: str) -> tuple[str, str]:
+        industry = "Technology"
+        title = "professional"
+        try:
+            repo = self._get_profile_repo()
+            context = repo.get_profile_context(user_id)
+            if context and isinstance(context, dict):
+                ind = context.get("industry", "").strip()
+                if ind:
+                    industry = ind
+                t = (
+                    context.get("professional_information", {})
+                    .get("title", "")
+                    .strip()
+                )
+                if t:
+                    title = t
+        except Exception as exc:
+            logger.debug("[ContentGap] Could not load profile context: {}", exc)
+        return industry, title
+
+    async def _search_trends(self, industry: str, title: str, user_id: str) -> List[Dict[str, Any]]:
+        provider = self._get_exa_provider()
+        if not provider:
+            return []
+
+        queries = [
+            f"hot topics {industry} {title} 2026",
+            f"underrated LinkedIn topics {industry} professionals should post about",
+        ]
+        all_results: List[Dict[str, Any]] = []
+        for query in queries:
+            cache_key = growth_cache.exa_key(query, 5, user_id)
+            cached = growth_cache.get(cache_key)
+            if cached is not None:
+                logger.info("[ContentGap] Exa cache hit for '{}'", query[:50])
+                all_results.extend(cached)
+                continue
+            try:
+                results = await provider.simple_search(
+                    query=query,
+                    num_results=5,
+                    user_id=user_id,
+                )
+                all_results.extend(results)
+                growth_cache.set(cache_key, results, ttl_seconds=300)
+            except Exception as exc:
+                logger.warning("[ContentGap] Exa search failed: {}", exc)
+        return all_results
+
+    async def _llm_identify_gaps(
+        self,
+        industry: str,
+        title: str,
+        articles: List[Dict[str, Any]],
+        user_id: str,
+    ) -> List[ContentGapItem]:
+        from services.llm_providers.main_text_generation import llm_text_gen
+
+        articles_text = ""
+        for i, a in enumerate(articles[:8], 1):
+            s = (a.get("text") or a.get("snippet") or "")[:250]
+            articles_text += f'{i}. "{a.get("title", "Untitled")}"\n   {s}\n\n'
+
+        system_prompt = (
+            "You are a LinkedIn content strategist specializing in gap analysis. "
+            "Analyze the user's industry and role, and identify 3-4 content gaps — "
+            "topics that are highly relevant to their audience but that "
+            "professionals in this space commonly overlook.\n\n"
+            "For each gap provide:\n"
+            "- gap_topic: short topic label (e.g. 'AI/ML applications in SaaS')\n"
+            "- why_gap: why professionals in this space miss this topic (1 sentence)\n"
+            "- why_it_matters: why this topic matters right now (1 sentence)\n"
+            "- suggested_angle: a specific post angle they could use today\n"
+            "- data_source_detail: what data this is based on\n"
+            "- confidence: high/medium/low\n\n"
+            "Output ONLY valid JSON. Be specific and actionable."
+        )
+
+        prompt = (
+            f"Industry: {industry}\n"
+            f"Role: {title}\n\n"
+            f"Current trends:\n{articles_text}\n\n"
+            "Identify content gaps. Return JSON with a 'gaps' array of exactly 4 items."
+        )
+
+        json_schema = {
+            "type": "object",
+            "properties": {
+                "gaps": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "gap_topic": {"type": "string"},
+                            "why_gap": {"type": "string"},
+                            "why_it_matters": {"type": "string"},
+                            "suggested_angle": {"type": "string"},
+                            "data_source_detail": {"type": "string"},
+                            "confidence": {
+                                "type": "string",
+                                "enum": ["high", "medium", "low"],
+                            },
+                        },
+                        "required": [
+                            "gap_topic",
+                            "why_gap",
+                            "why_it_matters",
+                            "suggested_angle",
+                            "data_source_detail",
+                            "confidence",
+                        ],
+                    },
+                },
+            },
+            "required": ["gaps"],
+        }
+
+        llm_cache_key = growth_cache.llm_key(prompt[:200] + str(json_schema), user_id)
+        cached_llm = growth_cache.get(llm_cache_key)
+        if cached_llm is not None:
+            logger.info("[ContentGap] LLM cache hit")
+            return cached_llm
+
+        try:
+            raw = await protected_llm_call(
+                llm_text_gen,
+                prompt=prompt,
+                system_prompt=system_prompt,
+                json_struct=json_schema,
+                user_id=user_id,
+            )
+            if isinstance(raw, dict) and "gaps" in raw:
+                result = [ContentGapItem(**g) for g in raw["gaps"]]
+                growth_cache.set(llm_cache_key, result, ttl_seconds=3600)
+                return result
+            logger.warning("[ContentGap] LLM returned unexpected shape: {}", type(raw))
+            return []
+        except Exception as exc:
+            logger.error("[ContentGap] LLM generation failed: {}", exc)
+            return []
+
+    async def analyze(
+        self,
+        user_id: str,
+    ) -> ContentGapsResponse:
+        industry, title = await asyncio.to_thread(self._resolve_industry_and_title, user_id)
+        articles = await self._search_trends(industry, title, user_id)
+
+        gaps = await self._llm_identify_gaps(industry, title, articles, user_id)
+        data_source_summary = (
+            f"Based on your LinkedIn profile ({title} in {industry}) "
+            f"+ industry trend analysis"
+        )
+
+        return ContentGapsResponse(
+            gaps=gaps,
+            data_source_summary=data_source_summary,
+            generated_at=datetime.now(timezone.utc),
+        )

--- a/backend/services/linkedin/growth/engagement_service.py
+++ b/backend/services/linkedin/growth/engagement_service.py
@@ -1,0 +1,207 @@
+import asyncio
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from loguru import logger
+
+from models.linkedin_growth_models import (
+    EngagementOpportunityItem,
+    EngagementOpportunitiesResponse,
+)
+from .cache import growth_cache
+from .circuit_breaker import protected_llm_call
+
+
+class EngagementService:
+    """Finds posts the user should engage with and suggests comments."""
+
+    def __init__(self):
+        self._profile_repo = None
+        self._exa_provider = None
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _get_profile_repo(self):
+        if self._profile_repo is None:
+            from services.integrations.linkedin.profile_repository import ProfileRepository
+            self._profile_repo = ProfileRepository()
+        return self._profile_repo
+
+    def _get_exa_provider(self):
+        if self._exa_provider is None:
+            from services.research import get_exa_content_provider
+            self._exa_provider = get_exa_content_provider()
+        return self._exa_provider
+
+    def _resolve_industry(self, user_id: str) -> str:
+        try:
+            repo = self._get_profile_repo()
+            context = repo.get_profile_context(user_id)
+            if context and isinstance(context, dict):
+                industry = context.get("industry", "").strip()
+                if industry:
+                    return industry
+        except Exception as exc:
+            logger.debug("[Engagement] Could not load profile context: {}", exc)
+        return "Technology"
+
+    async def _search_posts(
+        self, industry: str, user_id: str
+    ) -> List[Dict[str, Any]]:
+        """Search Exa for recent thought-provoking posts in this industry."""
+        provider = self._get_exa_provider()
+        if not provider:
+            logger.warning("[Engagement] Exa provider not available")
+            return []
+
+        queries = [
+            f"{industry} thought leadership insights",
+            f"{industry} debate discussion analysis",
+        ]
+        all_results: List[Dict[str, Any]] = []
+        for query in queries:
+            cache_key = growth_cache.exa_key(query, 5, user_id)
+            cached = growth_cache.get(cache_key)
+            if cached is not None:
+                logger.info("[Engagement] Exa cache hit for '{}'", query[:50])
+                all_results.extend(cached)
+                continue
+            try:
+                results = await provider.simple_search(
+                    query=query,
+                    num_results=5,
+                    user_id=user_id,
+                )
+                all_results.extend(results)
+                growth_cache.set(cache_key, results, ttl_seconds=300)
+            except Exception as exc:
+                logger.warning("[Engagement] Exa search failed: {}", exc)
+        return all_results
+
+    async def _llm_generate_opportunities(
+        self,
+        industry: str,
+        articles: List[Dict[str, Any]],
+        user_id: str,
+    ) -> List[EngagementOpportunityItem]:
+        """Call LLM to generate engagement opportunities from search results."""
+        from services.llm_providers.main_text_generation import llm_text_gen
+
+        articles_text = ""
+        for i, a in enumerate(articles[:8], 1):
+            title = a.get("title", "Untitled")
+            snippet = (a.get("text") or a.get("snippet") or "")[:250]
+            author = a.get("author") or "Unknown author"
+            articles_text += f'{i}. "{title}" by {author}\n   {snippet}\n\n'
+
+        system_prompt = (
+            "You are a LinkedIn engagement strategist. "
+            "Analyze the recent articles in the user's industry and suggest "
+            "3 opportunities where the user could add value by commenting.\n\n"
+            "For each opportunity provide:\n"
+            "- title: The article/post title\n"
+            "- author: The author's name\n"
+            "- author_context: Context about the author (e.g. 'thought leader in SaaS', "
+            "'your network', 'industry analyst')\n"
+            "- why_engage: 1 sentence explaining why commenting is valuable\n"
+            "- suggested_comment: A thoughtful, specific comment (2-3 sentences) that "
+            "adds value, references the content, and shows expertise\n"
+            "- data_source_detail: What data this is based on\n"
+            "- confidence: high/medium/low\n"
+            "Output ONLY valid JSON matching the schema."
+        )
+
+        prompt = (
+            f"Industry: {industry}\n\n"
+            f"Recent content:\n{articles_text}\n\n"
+            "Where should this user engage? Return JSON with an 'opportunities' "
+            "array of exactly 3 items."
+        )
+
+        json_schema = {
+            "type": "object",
+            "properties": {
+                "opportunities": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "title": {"type": "string"},
+                            "author": {"type": "string"},
+                            "author_context": {"type": "string"},
+                            "why_engage": {"type": "string"},
+                            "suggested_comment": {"type": "string"},
+                            "data_source_detail": {"type": "string"},
+                            "confidence": {
+                                "type": "string",
+                                "enum": ["high", "medium", "low"],
+                            },
+                        },
+                        "required": [
+                            "title",
+                            "author",
+                            "author_context",
+                            "why_engage",
+                            "suggested_comment",
+                            "data_source_detail",
+                            "confidence",
+                        ],
+                    },
+                }
+            },
+            "required": ["opportunities"],
+        }
+
+        llm_cache_key = growth_cache.llm_key(prompt[:200] + str(json_schema), user_id)
+        cached_llm = growth_cache.get(llm_cache_key)
+        if cached_llm is not None:
+            logger.info("[Engagement] LLM cache hit")
+            return cached_llm
+
+        try:
+            raw = await protected_llm_call(
+                llm_text_gen,
+                prompt=prompt,
+                system_prompt=system_prompt,
+                json_struct=json_schema,
+                user_id=user_id,
+            )
+            if isinstance(raw, dict) and "opportunities" in raw:
+                result = [EngagementOpportunityItem(**o) for o in raw["opportunities"]]
+                growth_cache.set(llm_cache_key, result, ttl_seconds=3600)
+                return result
+            logger.warning("[Engagement] LLM returned unexpected shape: {}", type(raw))
+            return []
+        except Exception as exc:
+            logger.error("[Engagement] LLM generation failed: {}", exc)
+            return []
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+    async def get_engagement_opportunities(
+        self,
+        user_id: str,
+    ) -> EngagementOpportunitiesResponse:
+        """Return posts the user should engage with and suggested comments."""
+        industry = await asyncio.to_thread(self._resolve_industry, user_id)
+
+        articles = await self._search_posts(industry, user_id)
+        if not articles:
+            return EngagementOpportunitiesResponse(
+                opportunities=[],
+                data_source_summary="No content found in your industry. Connect your LinkedIn account for personalized engagement suggestions.",
+                generated_at=datetime.now(timezone.utc),
+            )
+
+        opportunities = await self._llm_generate_opportunities(industry, articles, user_id)
+        data_source_summary = (
+            f"Based on {len(articles)} recent articles in {industry} "
+            f"+ AI analysis of engagement opportunities"
+        )
+
+        return EngagementOpportunitiesResponse(
+            opportunities=opportunities,
+            data_source_summary=data_source_summary,
+            generated_at=datetime.now(timezone.utc),
+        )

--- a/backend/services/linkedin/growth/logging_utils.py
+++ b/backend/services/linkedin/growth/logging_utils.py
@@ -1,0 +1,85 @@
+import functools
+import time
+from typing import Any, Callable, Optional
+
+from loguru import logger
+
+
+SERVICE_TAG = "[Growth]"
+
+
+def get_growth_logger(service_name: str):
+    """Return a bound logger with a consistent service tag."""
+    return logger.bind(growth_service=service_name)
+
+
+def timed(level: str = "INFO"):
+    """Decorator that logs method execution time with structured tags.
+
+    Usage:
+        @timed("INFO")
+        async def my_method(self, ...):
+            ...
+    """
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        async def async_wrapper(self, *args, **kwargs):
+            start = time.time()
+            try:
+                result = await func(self, *args, **kwargs)
+                elapsed = time.time() - start
+                logger.bind(growth_service=self.__class__.__name__).log(
+                    level,
+                    "{} {}.{} completed in {:.0f}ms",
+                    SERVICE_TAG,
+                    self.__class__.__name__,
+                    func.__name__,
+                    elapsed * 1000,
+                )
+                return result
+            except Exception as e:
+                elapsed = time.time() - start
+                logger.bind(growth_service=self.__class__.__name__).error(
+                    "{} {}.{} failed after {:.0f}ms: {}",
+                    SERVICE_TAG,
+                    self.__class__.__name__,
+                    func.__name__,
+                    elapsed * 1000,
+                    e,
+                )
+                raise
+
+        @functools.wraps(func)
+        def sync_wrapper(self, *args, **kwargs):
+            start = time.time()
+            try:
+                result = func(self, *args, **kwargs)
+                elapsed = time.time() - start
+                logger.bind(growth_service=self.__class__.__name__).log(
+                    level,
+                    "{} {}.{} completed in {:.0f}ms",
+                    SERVICE_TAG,
+                    self.__class__.__name__,
+                    func.__name__,
+                    elapsed * 1000,
+                )
+                return result
+            except Exception as e:
+                elapsed = time.time() - start
+                logger.bind(growth_service=self.__class__.__name__).error(
+                    "{} {}.{} failed after {:.0f}ms: {}",
+                    SERVICE_TAG,
+                    self.__class__.__name__,
+                    func.__name__,
+                    elapsed * 1000,
+                    e,
+                )
+                raise
+
+        if asyncio.iscoroutinefunction(func):
+            return async_wrapper
+        return sync_wrapper
+    return decorator
+
+
+import asyncio

--- a/backend/services/linkedin/growth/network_growth_service.py
+++ b/backend/services/linkedin/growth/network_growth_service.py
@@ -1,0 +1,223 @@
+import asyncio
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from loguru import logger
+
+from models.linkedin_growth_models import (
+    NetworkSuggestionItem,
+    NetworkSuggestionsResponse,
+)
+from .cache import growth_cache
+from .circuit_breaker import protected_llm_call
+
+
+class NetworkGrowthService:
+    """Suggests people for the user to connect with on LinkedIn."""
+
+    def __init__(self):
+        self._profile_repo = None
+        self._exa_provider = None
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _get_profile_repo(self):
+        if self._profile_repo is None:
+            from services.integrations.linkedin.profile_repository import ProfileRepository
+            self._profile_repo = ProfileRepository()
+        return self._profile_repo
+
+    def _get_exa_provider(self):
+        if self._exa_provider is None:
+            from services.research import get_exa_content_provider
+            self._exa_provider = get_exa_content_provider()
+        return self._exa_provider
+
+    def _resolve_profile(self, user_id: str) -> Dict[str, Any]:
+        """Resolve the user's profile context."""
+        result = {"industry": "Technology", "title": "Professional", "headline": ""}
+        try:
+            repo = self._get_profile_repo()
+            context = repo.get_profile_context(user_id)
+            if context and isinstance(context, dict):
+                result["industry"] = context.get("industry", "").strip() or "Technology"
+                headline = ""
+                personal = context.get("personal_information", {})
+                professional = context.get("professional_information", {})
+                if isinstance(personal, dict):
+                    result["headline"] = personal.get("headline", "") or ""
+                if isinstance(professional, dict):
+                    result["title"] = professional.get("title", "") or "Professional"
+                logger.info("[NetworkGrowth] Resolved profile: industry={} title={}",
+                            result["industry"], result["title"])
+        except Exception as exc:
+            logger.debug("[NetworkGrowth] Could not load profile context: {}", exc)
+        return result
+
+    async def _search_people(
+        self, industry: str, title: str, user_id: str
+    ) -> List[Dict[str, Any]]:
+        """Search Exa for people-related content in this industry."""
+        provider = self._get_exa_provider()
+        if not provider:
+            logger.warning("[NetworkGrowth] Exa provider not available")
+            return []
+
+        queries = [
+            f"leading {industry} {title} professionals thought leadership",
+            f"top voices in {industry} LinkedIn",
+        ]
+        all_results: List[Dict[str, Any]] = []
+        for query in queries:
+            cache_key = growth_cache.exa_key(query, 5, user_id)
+            cached = growth_cache.get(cache_key)
+            if cached is not None:
+                logger.info("[NetworkGrowth] Exa cache hit for '{}'", query[:50])
+                all_results.extend(cached)
+                continue
+            try:
+                results = await provider.simple_search(
+                    query=query,
+                    num_results=5,
+                    user_id=user_id,
+                )
+                all_results.extend(results)
+                growth_cache.set(cache_key, results, ttl_seconds=300)
+                logger.info("[NetworkGrowth] Exa returned {} results for '{}'", len(results), query[:50])
+            except Exception as exc:
+                logger.warning("[NetworkGrowth] Exa search failed for '{}': {}", query[:50], exc)
+        return all_results
+
+    async def _llm_generate_suggestions(
+        self, industry: str, title: str, headline: str, articles: List[Dict[str, Any]], user_id: str
+    ) -> List[NetworkSuggestionItem]:
+        """Call LLM to generate connection suggestions from search results."""
+        from services.llm_providers.main_text_generation import llm_text_gen
+
+        articles_text = ""
+        for i, a in enumerate(articles[:8], 1):
+            title_text = a.get("title", "Untitled")
+            snippet = (a.get("text") or a.get("snippet") or "")[:250]
+            author = a.get("author") or ""
+            articles_text += f"{i}. \"{title_text}\""
+            if author:
+                articles_text += f" by {author}"
+            articles_text += f"\n   {snippet}\n\n"
+
+        system_prompt = (
+            "You are a LinkedIn network growth strategist. "
+            "Based on the user's profile and recent industry content, "
+            "suggest 3 people they should connect with on LinkedIn.\n\n"
+            "For each suggestion provide:\n"
+            "- name: Full name\n"
+            "- title: Professional title/role\n"
+            "- company: Company or organization\n"
+            "- why_connect: 1 sentence explaining why this connection is valuable\n"
+            "- suggested_note: A personalized LinkedIn connection note (1-2 sentences, "
+            "conversational, references shared interests)\n"
+            "- data_source_detail: What data this suggestion is based on\n"
+            "- confidence: high/medium/low\n"
+            "Output ONLY valid JSON matching the schema."
+        )
+
+        prompt = (
+            f"User profile:\nIndustry: {industry}\n"
+            f"Title: {title}\n"
+            f"Headline: {headline}\n\n"
+            f"Recent industry content:\n{articles_text}\n\n"
+            "Who should this user connect with? Return JSON with a 'suggestions' array "
+            "of exactly 3 people."
+        )
+
+        json_schema = {
+            "type": "object",
+            "properties": {
+                "suggestions": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "title": {"type": "string"},
+                            "company": {"type": "string"},
+                            "why_connect": {"type": "string"},
+                            "suggested_note": {"type": "string"},
+                            "data_source_detail": {"type": "string"},
+                            "confidence": {
+                                "type": "string",
+                                "enum": ["high", "medium", "low"],
+                            },
+                        },
+                        "required": [
+                            "name",
+                            "title",
+                            "company",
+                            "why_connect",
+                            "suggested_note",
+                            "data_source_detail",
+                            "confidence",
+                        ],
+                    },
+                }
+            },
+            "required": ["suggestions"],
+        }
+
+        llm_cache_key = growth_cache.llm_key(prompt[:200] + str(json_schema), user_id)
+        cached_llm = growth_cache.get(llm_cache_key)
+        if cached_llm is not None:
+            logger.info("[NetworkGrowth] LLM cache hit")
+            return cached_llm
+
+        try:
+            raw = await protected_llm_call(
+                llm_text_gen,
+                prompt=prompt,
+                system_prompt=system_prompt,
+                json_struct=json_schema,
+                user_id=user_id,
+            )
+            if isinstance(raw, dict) and "suggestions" in raw:
+                result = [NetworkSuggestionItem(**s) for s in raw["suggestions"]]
+                growth_cache.set(llm_cache_key, result, ttl_seconds=3600)
+                return result
+            logger.warning("[NetworkGrowth] LLM returned unexpected shape: {}", type(raw))
+            return []
+        except Exception as exc:
+            logger.error("[NetworkGrowth] LLM generation failed: {}", exc)
+            return []
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+    async def get_network_suggestions(
+        self,
+        user_id: str,
+    ) -> NetworkSuggestionsResponse:
+        """Return people the user should connect with this week."""
+        profile = await asyncio.to_thread(self._resolve_profile, user_id)
+        industry = profile["industry"]
+        title = profile["title"]
+        headline = profile["headline"]
+
+        articles = await self._search_people(industry, title, user_id)
+        if not articles:
+            logger.warning("[NetworkGrowth] No content found for industry '{}'", industry)
+            return NetworkSuggestionsResponse(
+                suggestions=[],
+                data_source_summary="No LinkedIn profile or Exa data available yet. "
+                "Connect your LinkedIn account to get personalized network suggestions.",
+                generated_at=datetime.now(timezone.utc),
+            )
+
+        suggestions = await self._llm_generate_suggestions(industry, title, headline, articles, user_id)
+        data_source_summary = (
+            f"Based on your LinkedIn profile ({title} in {industry}) "
+            f"+ {len(articles)} industry articles and thought leadership content"
+        )
+
+        return NetworkSuggestionsResponse(
+            suggestions=suggestions,
+            data_source_summary=data_source_summary,
+            generated_at=datetime.now(timezone.utc),
+        )

--- a/backend/services/linkedin/growth/preview_score_service.py
+++ b/backend/services/linkedin/growth/preview_score_service.py
@@ -1,0 +1,135 @@
+import asyncio
+from datetime import datetime, timezone
+from loguru import logger
+
+from models.linkedin_growth_models import (
+    PreviewScoreRequest,
+    PostPreviewScoreResponse,
+    PostPreviewDimension,
+)
+from .cache import growth_cache
+from .circuit_breaker import protected_llm_call
+
+
+class PreviewScoreService:
+    """Analyzes a LinkedIn post draft and returns scores across dimensions."""
+
+    async def score_post(
+        self,
+        request: PreviewScoreRequest,
+        user_id: str,
+    ) -> PostPreviewScoreResponse:
+        """Score a post draft across multiple quality dimensions."""
+        result = await self._llm_score_post(request, user_id)
+        if result is None:
+            return PostPreviewScoreResponse(
+                overall_score=50,
+                dimensions=[],
+                top_improvement="Could not analyze post. Try again with more content.",
+                data_source_summary="AI-based analysis of your post content.",
+                generated_at=datetime.now(timezone.utc),
+            )
+
+        dimensions = [PostPreviewDimension(**d) for d in result.get("dimensions", [])]
+        return PostPreviewScoreResponse(
+            overall_score=result.get("overall_score", 50),
+            dimensions=dimensions,
+            top_improvement=result.get("top_improvement", ""),
+            data_source_summary=(
+                f"AI scored your {len(request.content.split())}-word post across "
+                f"{len(dimensions)} quality dimensions"
+            ),
+            generated_at=datetime.now(timezone.utc),
+        )
+
+    async def _llm_score_post(
+        self,
+        request: PreviewScoreRequest,
+        user_id: str,
+    ) -> dict | None:
+        """Call LLM to score the post. Returns raw dict or None."""
+        from services.llm_providers.main_text_generation import llm_text_gen
+
+        system_prompt = (
+            "You are a LinkedIn content strategist. Analyze the given LinkedIn post "
+            "and score it across these dimensions (0-100 each):\n\n"
+            "1. Hook Strength — How compelling is the opening?\n"
+            "2. Clarity — Is the message easy to understand?\n"
+            "3. Engagement Potential — Will it spark comments/shares?\n"
+            "4. Value Proposition — Does it provide value to the reader?\n"
+            "5. Call to Action — Is there a clear next step?\n"
+            "6. Readability — Is it well-structured and scannable?\n\n"
+            "For each dimension, provide:\n"
+            "- dimension: name exactly as listed above\n"
+            "- score: integer 0-100\n"
+            "- feedback: 1-2 sentences of actionable advice\n"
+            "- data_source_detail: what this score is based on\n"
+            "- confidence: high/medium/low\n\n"
+            "Also provide:\n"
+            "- overall_score: integer 0-100 (weighted average)\n"
+            "- top_improvement: the single most impactful suggestion (1 sentence)\n\n"
+            "Output ONLY valid JSON. Be critical and specific."
+        )
+
+        prompt = (
+            f"Post content:\n{request.content}\n\n"
+            f"Context: {request.context or 'No additional context provided.'}\n"
+            f"Word count: {len(request.content.split())}\n\n"
+            "Score this LinkedIn post. Return JSON with 'dimensions' array of "
+            "exactly 6 items, 'overall_score' (integer), and 'top_improvement' (string)."
+        )
+
+        json_schema = {
+            "type": "object",
+            "properties": {
+                "dimensions": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "dimension": {"type": "string"},
+                            "score": {"type": "integer", "minimum": 0, "maximum": 100},
+                            "feedback": {"type": "string"},
+                            "data_source_detail": {"type": "string"},
+                            "confidence": {
+                                "type": "string",
+                                "enum": ["high", "medium", "low"],
+                            },
+                        },
+                        "required": [
+                            "dimension",
+                            "score",
+                            "feedback",
+                            "data_source_detail",
+                            "confidence",
+                        ],
+                    },
+                },
+                "overall_score": {"type": "integer", "minimum": 0, "maximum": 100},
+                "top_improvement": {"type": "string"},
+            },
+            "required": ["dimensions", "overall_score", "top_improvement"],
+        }
+
+        llm_cache_key = growth_cache.llm_key(prompt[:200] + str(json_schema), user_id)
+        cached_llm = growth_cache.get(llm_cache_key)
+        if cached_llm is not None:
+            logger.info("[PreviewScore] LLM cache hit")
+            return cached_llm
+
+        try:
+            raw = await protected_llm_call(
+                llm_text_gen,
+                prompt=prompt,
+                system_prompt=system_prompt,
+                json_struct=json_schema,
+                user_id=user_id,
+            )
+            if isinstance(raw, dict) and "dimensions" in raw and "overall_score" in raw:
+                growth_cache.set(llm_cache_key, raw, ttl_seconds=3600)
+                return raw
+            logger.warning("[PreviewScore] LLM returned unexpected shape: {}", type(raw))
+            return None
+        except Exception as exc:
+            logger.error("[PreviewScore] LLM generation failed: {}", exc)
+            return None

--- a/backend/services/linkedin/growth/trending_service.py
+++ b/backend/services/linkedin/growth/trending_service.py
@@ -1,0 +1,229 @@
+import asyncio
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from loguru import logger
+
+from models.linkedin_growth_models import (
+    TrendingTopicItem,
+    TrendingTopicsResponse,
+)
+from .cache import growth_cache
+from .circuit_breaker import protected_llm_call
+
+
+class TrendingService:
+    """Identifies trending topics in the user's industry for LinkedIn growth."""
+
+    def __init__(self):
+        self._profile_repo = None
+        self._exa_provider = None
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _get_profile_repo(self):
+        if self._profile_repo is None:
+            from services.integrations.linkedin.profile_repository import ProfileRepository
+            self._profile_repo = ProfileRepository()
+        return self._profile_repo
+
+    def _get_exa_provider(self):
+        if self._exa_provider is None:
+            from services.research import get_exa_content_provider
+            self._exa_provider = get_exa_content_provider()
+        return self._exa_provider
+
+    def _resolve_industry(self, user_id: str) -> str:
+        """Resolve the user's industry from profile context or persona."""
+        try:
+            repo = self._get_profile_repo()
+            context = repo.get_profile_context(user_id)
+            if context and isinstance(context, dict):
+                industry = context.get("industry", "").strip()
+                if industry:
+                    logger.info("[TrendingService] Resolved industry from profile context: {}", industry)
+                    return industry
+        except Exception as exc:
+            logger.debug("[TrendingService] Could not load profile context: {}", exc)
+
+        try:
+            from services.persona_analysis_service import PersonaAnalysisService
+            persona = PersonaAnalysisService()
+            data = persona.get_user_persona(user_id)
+            if data and isinstance(data, dict):
+                industry = (
+                    data.get("industry")
+                    or data.get("target_industry")
+                    or (data.get("audience_intel") or {}).get("industry_focus")
+                    or ""
+                )
+                if isinstance(industry, str) and industry.strip():
+                    logger.info("[TrendingService] Resolved industry from persona: {}", industry.strip())
+                    return industry.strip()
+        except Exception as exc:
+            logger.debug("[TrendingService] Could not load persona: {}", exc)
+
+        logger.info("[TrendingService] No industry found, defaulting to Technology")
+        return "Technology"
+
+    def _build_search_query(self, industry: str) -> str:
+        return f"{industry} trends insights news {datetime.now().year}"
+
+    async def _search_trending_articles(
+        self, industry: str, user_id: str
+    ) -> List[Dict[str, Any]]:
+        """Search Exa for recent trending articles in the given industry."""
+        query = self._build_search_query(industry)
+        cache_key = growth_cache.exa_key(query, 10, user_id)
+        cached = growth_cache.get(cache_key)
+        if cached is not None:
+            logger.info("[TrendingService] Exa cache hit for '{}'", query[:60])
+            return cached
+
+        provider = self._get_exa_provider()
+        if not provider:
+            logger.warning("[TrendingService] Exa provider not available")
+            return []
+
+        try:
+            results = await provider.simple_search(
+                query=query,
+                num_results=10,
+                user_id=user_id,
+            )
+            logger.info("[TrendingService] Exa returned {} results for '{}'", len(results), query)
+            growth_cache.set(cache_key, results, ttl_seconds=300)
+            return results
+        except Exception as exc:
+            logger.warning("[TrendingService] Exa search failed: {}", exc)
+            return []
+
+    async def _llm_extract_topics(
+        self, industry: str, articles: List[Dict[str, Any]], user_id: str
+    ) -> List[TrendingTopicItem]:
+        """Call LLM to extract trending topics from search results."""
+        from services.llm_providers.main_text_generation import llm_text_gen
+
+        articles_text = ""
+        for i, a in enumerate(articles[:10], 1):
+            title = a.get("title", "Untitled")
+            snippet = (a.get("text") or a.get("snippet") or "")[:300]
+            articles_text += f"{i}. {title}\n   {snippet}\n\n"
+
+        system_prompt = (
+            "You are a LinkedIn growth strategist. "
+            "Analyze the search results and identify the top 3 trending topics in the given industry. "
+            "For each topic provide:\n"
+            "- topic: short label (2-4 words)\n"
+            "- emoji: a single relevant emoji\n"
+            "- why_now: 1-sentence explanation of why this matters right now\n"
+            "- suggested_hook: a LinkedIn post hook the user could write\n"
+            "- data_source_detail: brief explanation of what data this comes from\n"
+            "- confidence: high/medium/low\n"
+            "Output ONLY valid JSON matching the schema."
+        )
+
+        prompt = (
+            f"Industry: {industry}\n\n"
+            f"Recent articles and content:\n{articles_text}\n\n"
+            "What are the top 3 trending topics right now? "
+            "Return JSON with a 'trending_topics' array."
+        )
+
+        json_schema = {
+            "type": "object",
+            "properties": {
+                "trending_topics": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "topic": {"type": "string"},
+                            "emoji": {"type": "string"},
+                            "why_now": {"type": "string"},
+                            "suggested_hook": {"type": "string"},
+                            "data_source_detail": {"type": "string"},
+                            "confidence": {"type": "string", "enum": ["high", "medium", "low"]},
+                        },
+                        "required": [
+                            "topic",
+                            "emoji",
+                            "why_now",
+                            "suggested_hook",
+                            "data_source_detail",
+                            "confidence",
+                        ],
+                    },
+                }
+            },
+            "required": ["trending_topics"],
+        }
+
+        llm_cache_key = growth_cache.llm_key(prompt[:200] + str(json_schema), user_id)
+        cached_llm = growth_cache.get(llm_cache_key)
+        if cached_llm is not None:
+            logger.info("[TrendingService] LLM cache hit")
+            return cached_llm
+
+        try:
+            raw = await protected_llm_call(
+                llm_text_gen,
+                prompt=prompt,
+                system_prompt=system_prompt,
+                json_struct=json_schema,
+                user_id=user_id,
+            )
+            if isinstance(raw, dict) and "trending_topics" in raw:
+                topics_data = raw["trending_topics"]
+                result = [TrendingTopicItem(**t) for t in topics_data]
+                growth_cache.set(llm_cache_key, result, ttl_seconds=3600)
+                return result
+            logger.warning("[TrendingService] LLM returned unexpected shape: {}", type(raw))
+            return []
+        except Exception as exc:
+            logger.error("[TrendingService] LLM extraction failed: {}", exc)
+            return []
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+    async def get_trending_topics(
+        self,
+        user_id: str,
+        industry_override: Optional[str] = None,
+    ) -> TrendingTopicsResponse:
+        """
+        Main entry point — returns trending topics for the user's industry.
+        """
+        industry = industry_override or await asyncio.to_thread(self._resolve_industry, user_id)
+
+        articles = await self._search_trending_articles(industry, user_id)
+        if not articles:
+            logger.warning("[TrendingService] No articles found for industry '{}'", industry)
+            return TrendingTopicsResponse(
+                industry=industry,
+                trending_topics=[],
+                data_source_summary="No trending data available at this time. Connect Exa API key to enable.",
+                generated_at=datetime.now(timezone.utc),
+            )
+
+        topics = await self._llm_extract_topics(industry, articles, user_id)
+        if not topics:
+            return TrendingTopicsResponse(
+                industry=industry,
+                trending_topics=[],
+                data_source_summary="Could not extract trending topics from search results.",
+                generated_at=datetime.now(timezone.utc),
+            )
+
+        data_source_summary = (
+            f"Exa search of {len(articles)} recent articles in {industry} "
+            f"+ AI analysis of posting patterns"
+        )
+
+        return TrendingTopicsResponse(
+            industry=industry,
+            trending_topics=topics,
+            data_source_summary=data_source_summary,
+            generated_at=datetime.now(timezone.utc),
+        )

--- a/backend/services/linkedin/growth/viral_analysis_service.py
+++ b/backend/services/linkedin/growth/viral_analysis_service.py
@@ -1,0 +1,202 @@
+import asyncio
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+from loguru import logger
+
+from models.linkedin_growth_models import ViralPattern, ViralAnalysisResponse
+from .cache import growth_cache
+from .circuit_breaker import protected_llm_call
+
+
+class ViralAnalysisService:
+    """Analyzes viral content patterns in the user's industry."""
+
+    def __init__(self):
+        self._profile_repo = None
+        self._exa_provider = None
+
+    def _get_profile_repo(self):
+        if self._profile_repo is None:
+            from services.integrations.linkedin.profile_repository import ProfileRepository
+            self._profile_repo = ProfileRepository()
+        return self._profile_repo
+
+    def _get_exa_provider(self):
+        if self._exa_provider is None:
+            from services.research import get_exa_content_provider
+            self._exa_provider = get_exa_content_provider()
+        return self._exa_provider
+
+    def _resolve_industry(self, user_id: str) -> str:
+        try:
+            repo = self._get_profile_repo()
+            context = repo.get_profile_context(user_id)
+            if context and isinstance(context, dict):
+                industry = context.get("industry", "").strip()
+                if industry:
+                    return industry
+        except Exception as exc:
+            logger.debug("[ViralAnalysis] Could not load profile context: {}", exc)
+        return "Technology"
+
+    async def _search_viral_content(self, industry: str, user_id: str) -> List[Dict[str, Any]]:
+        """Search Exa for high-engagement LinkedIn posts in this industry."""
+        provider = self._get_exa_provider()
+        if not provider:
+            logger.warning("[ViralAnalysis] Exa provider not available")
+            return []
+
+        queries = [
+            f"viral LinkedIn post {industry} high engagement",
+            f"trending LinkedIn content {industry} strategy",
+            f"LinkedIn post that went viral {industry}",
+        ]
+        all_results: List[Dict[str, Any]] = []
+        for query in queries:
+            cache_key = growth_cache.exa_key(query, 5, user_id)
+            cached = growth_cache.get(cache_key)
+            if cached is not None:
+                logger.info("[ViralAnalysis] Exa cache hit for '{}'", query[:50])
+                all_results.extend(cached)
+                continue
+            try:
+                results = await provider.simple_search(
+                    query=query,
+                    num_results=5,
+                    user_id=user_id,
+                )
+                all_results.extend(results)
+                growth_cache.set(cache_key, results, ttl_seconds=300)
+            except Exception as exc:
+                logger.warning("[ViralAnalysis] Exa search failed: {}", exc)
+        return all_results
+
+    async def _llm_extract_patterns(
+        self,
+        industry: str,
+        articles: List[Dict[str, Any]],
+        user_id: str,
+    ) -> List[ViralPattern]:
+        """Call LLM to identify viral content patterns from search results."""
+        from services.llm_providers.main_text_generation import llm_text_gen
+
+        articles_text = ""
+        for i, a in enumerate(articles[:10], 1):
+            title = a.get("title", "Untitled")
+            snippet = (a.get("text") or a.get("snippet") or "")[:300]
+            author = a.get("author") or "Unknown"
+            articles_text += f'{i}. "{title}" by {author}\n   {snippet}\n\n'
+
+        system_prompt = (
+            "You are a LinkedIn viral content analyst. Analyze the given articles "
+            "and identify 3-4 content patterns that drive high engagement in the "
+            "user's industry.\n\n"
+            "For each pattern provide:\n"
+            "- pattern_name: short label (e.g. 'Hot take + data point')\n"
+            "- description: 1-2 sentences explaining the pattern and why it works\n"
+            "- engagement_multiplier: estimated impact (e.g. '3x engagement')\n"
+            "- example_headline: a real example post headline\n"
+            "- example_author: who posted the example\n"
+            "- data_source_detail: what data this is based on\n"
+            "- confidence: high/medium/low\n\n"
+            "Also provide:\n"
+            "- top_recommendation: which single pattern the user should use right now (1 sentence)\n\n"
+            "Output ONLY valid JSON. Be specific and actionable."
+        )
+
+        prompt = (
+            f"Industry: {industry}\n\n"
+            f"Recent high-engagement content:\n{articles_text}\n\n"
+            "Identify viral content patterns. Return JSON with a 'patterns' array "
+            "of exactly 4 items and a 'top_recommendation' string."
+        )
+
+        json_schema = {
+            "type": "object",
+            "properties": {
+                "patterns": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "pattern_name": {"type": "string"},
+                            "description": {"type": "string"},
+                            "engagement_multiplier": {"type": "string"},
+                            "example_headline": {"type": "string"},
+                            "example_author": {"type": "string"},
+                            "data_source_detail": {"type": "string"},
+                            "confidence": {
+                                "type": "string",
+                                "enum": ["high", "medium", "low"],
+                            },
+                        },
+                        "required": [
+                            "pattern_name",
+                            "description",
+                            "engagement_multiplier",
+                            "example_headline",
+                            "example_author",
+                            "data_source_detail",
+                            "confidence",
+                        ],
+                    },
+                },
+                "top_recommendation": {"type": "string"},
+            },
+            "required": ["patterns", "top_recommendation"],
+        }
+
+        llm_cache_key = growth_cache.llm_key(prompt[:200] + str(json_schema), user_id)
+        cached_llm = growth_cache.get(llm_cache_key)
+        if cached_llm is not None:
+            logger.info("[ViralAnalysis] LLM cache hit")
+            return cached_llm
+
+        try:
+            raw = await protected_llm_call(
+                llm_text_gen,
+                prompt=prompt,
+                system_prompt=system_prompt,
+                json_struct=json_schema,
+                user_id=user_id,
+            )
+            if isinstance(raw, dict) and "patterns" in raw:
+                result = [ViralPattern(**p) for p in raw["patterns"]]
+                growth_cache.set(llm_cache_key, result, ttl_seconds=3600)
+                return result
+            logger.warning("[ViralAnalysis] LLM returned unexpected shape: {}", type(raw))
+            return []
+        except Exception as exc:
+            logger.error("[ViralAnalysis] LLM generation failed: {}", exc)
+            return []
+
+    async def analyze(
+        self,
+        user_id: str,
+    ) -> ViralAnalysisResponse:
+        """Return viral content patterns for the user's industry."""
+        industry = await asyncio.to_thread(self._resolve_industry, user_id)
+
+        articles = await self._search_viral_content(industry, user_id)
+        if not articles:
+            return ViralAnalysisResponse(
+                industry=industry,
+                patterns=[],
+                top_recommendation="No viral content data found for your industry yet.",
+                data_source_summary="No content found. Connect your LinkedIn account for personalized analysis.",
+                generated_at=datetime.now(timezone.utc),
+            )
+
+        patterns = await self._llm_extract_patterns(industry, articles, user_id)
+        data_source_summary = (
+            f"Based on {len(articles)} high-engagement posts in {industry} "
+            f"+ AI pattern recognition"
+        )
+
+        return ViralAnalysisResponse(
+            industry=industry,
+            patterns=patterns,
+            top_recommendation=patterns[0].pattern_name if patterns else "No patterns identified.",
+            data_source_summary=data_source_summary,
+            generated_at=datetime.now(timezone.utc),
+        )

--- a/backend/services/linkedin/growth/weekly_strategy_service.py
+++ b/backend/services/linkedin/growth/weekly_strategy_service.py
@@ -1,0 +1,226 @@
+import asyncio
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, List
+from loguru import logger
+
+from models.linkedin_growth_models import DailyPostIdea, WeeklyStrategyResponse
+from .cache import growth_cache
+from .circuit_breaker import protected_llm_call
+
+
+class WeeklyStrategyService:
+    """Generates a weekly content strategy brief."""
+
+    def __init__(self):
+        self._profile_repo = None
+        self._exa_provider = None
+
+    def _get_profile_repo(self):
+        if self._profile_repo is None:
+            from services.integrations.linkedin.profile_repository import ProfileRepository
+            self._profile_repo = ProfileRepository()
+        return self._profile_repo
+
+    def _get_exa_provider(self):
+        if self._exa_provider is None:
+            from services.research import get_exa_content_provider
+            self._exa_provider = get_exa_content_provider()
+        return self._exa_provider
+
+    def _resolve_industry_and_title(self, user_id: str) -> tuple[str, str]:
+        industry = "Technology"
+        title = "professional"
+        try:
+            repo = self._get_profile_repo()
+            context = repo.get_profile_context(user_id)
+            if context and isinstance(context, dict):
+                ind = context.get("industry", "").strip()
+                if ind:
+                    industry = ind
+                t = (
+                    context.get("professional_information", {})
+                    .get("title", "")
+                    .strip()
+                )
+                if t:
+                    title = t
+        except Exception as exc:
+            logger.debug("[WeeklyStrategy] Could not load profile context: {}", exc)
+        return industry, title
+
+    def _week_start(self) -> str:
+        """Return Monday of the current week as ISO date."""
+        today = datetime.now(timezone.utc)
+        monday = today - timedelta(days=today.weekday())
+        return monday.strftime("%Y-%m-%d")
+
+    async def _search_content(self, industry: str, title: str, user_id: str) -> List[Dict[str, Any]]:
+        provider = self._get_exa_provider()
+        if not provider:
+            return []
+
+        queries = [
+            f"LinkedIn content strategy {industry} {title}",
+            f"trending LinkedIn posts {industry} this week",
+        ]
+        all_results: List[Dict[str, Any]] = []
+        for query in queries:
+            cache_key = growth_cache.exa_key(query, 5, user_id)
+            cached = growth_cache.get(cache_key)
+            if cached is not None:
+                logger.info("[WeeklyStrategy] Exa cache hit for '{}'", query[:50])
+                all_results.extend(cached)
+                continue
+            try:
+                results = await provider.simple_search(
+                    query=query,
+                    num_results=5,
+                    user_id=user_id,
+                )
+                all_results.extend(results)
+                growth_cache.set(cache_key, results, ttl_seconds=300)
+            except Exception as exc:
+                logger.warning("[WeeklyStrategy] Exa search failed: {}", exc)
+        return all_results
+
+    async def _llm_generate_strategy(
+        self,
+        industry: str,
+        title: str,
+        articles: List[Dict[str, Any]],
+        user_id: str,
+    ) -> WeeklyStrategyResponse | None:
+        from services.llm_providers.main_text_generation import llm_text_gen
+
+        articles_text = ""
+        for i, a in enumerate(articles[:8], 1):
+            s = (a.get("text") or a.get("snippet") or "")[:200]
+            articles_text += f'{i}. "{a.get("title", "Untitled")}"\n   {s}\n\n'
+
+        system_prompt = (
+            "You are a LinkedIn content strategist. Create a weekly content strategy "
+            "for a professional in the given industry.\n\n"
+            "For each weekday (Monday-Friday) provide:\n"
+            "- day: the day name\n"
+            "- content_type: type of post (e.g. How-to, Case study, Hot take, "
+            "Personal story, Roundup, Thought leadership, Tutorial)\n"
+            "- headline: a catchy, clickable headline\n"
+            "- hook: the opening line to grab attention\n"
+            "- why_this_works: 1 sentence on why this will perform well\n"
+            "- data_source_detail: what data this is based on\n"
+            "- confidence: high/medium/low\n\n"
+            "Also provide:\n"
+            "- theme: overarching weekly theme (3-5 words)\n"
+            "- key_topics: 3-5 key topics to cover this week\n"
+            "- focus_area: the primary focus (e.g. Authority building, "
+            "Thought leadership, Community engagement)\n\n"
+            "Output ONLY valid JSON. Make it specific and actionable."
+        )
+
+        prompt = (
+            f"Industry: {industry}\n"
+            f"Role: {title}\n"
+            f"Week starting: {self._week_start()}\n\n"
+            f"Recent trends:\n{articles_text}\n\n"
+            "Create a weekly LinkedIn content strategy. Return JSON with "
+            "'theme' (string), 'daily_posts' (array of 5 items for Mon-Fri), "
+            "'key_topics' (array of 3-5 strings), and 'focus_area' (string)."
+        )
+
+        json_schema = {
+            "type": "object",
+            "properties": {
+                "theme": {"type": "string"},
+                "daily_posts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "day": {"type": "string"},
+                            "content_type": {"type": "string"},
+                            "headline": {"type": "string"},
+                            "hook": {"type": "string"},
+                            "why_this_works": {"type": "string"},
+                            "data_source_detail": {"type": "string"},
+                            "confidence": {
+                                "type": "string",
+                                "enum": ["high", "medium", "low"],
+                            },
+                        },
+                        "required": [
+                            "day",
+                            "content_type",
+                            "headline",
+                            "hook",
+                            "why_this_works",
+                            "data_source_detail",
+                            "confidence",
+                        ],
+                    },
+                },
+                "key_topics": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "focus_area": {"type": "string"},
+            },
+            "required": ["theme", "daily_posts", "key_topics", "focus_area"],
+        }
+
+        llm_cache_key = growth_cache.llm_key(prompt[:200] + str(json_schema), user_id)
+        cached_llm = growth_cache.get(llm_cache_key)
+        if cached_llm is not None:
+            logger.info("[WeeklyStrategy] LLM cache hit")
+            return cached_llm
+
+        try:
+            raw = await protected_llm_call(
+                llm_text_gen,
+                prompt=prompt,
+                system_prompt=system_prompt,
+                json_struct=json_schema,
+                user_id=user_id,
+            )
+            if isinstance(raw, dict) and "daily_posts" in raw:
+                result = WeeklyStrategyResponse(
+                    theme=raw.get("theme", ""),
+                    week_of=self._week_start(),
+                    daily_posts=[DailyPostIdea(**p) for p in raw["daily_posts"]],
+                    key_topics=raw.get("key_topics", []),
+                    focus_area=raw.get("focus_area", ""),
+                    data_source_summary=(
+                        f"Based on your LinkedIn profile ({title} in {industry}) "
+                        f"+ recent content trends"
+                    ),
+                    generated_at=datetime.now(timezone.utc),
+                )
+                growth_cache.set(llm_cache_key, result, ttl_seconds=3600)
+                return result
+            logger.warning("[WeeklyStrategy] LLM returned unexpected shape: {}", type(raw))
+            return None
+        except Exception as exc:
+            logger.error("[WeeklyStrategy] LLM generation failed: {}", exc)
+            return None
+
+    async def generate(
+        self,
+        user_id: str,
+    ) -> WeeklyStrategyResponse:
+        industry, title = await asyncio.to_thread(self._resolve_industry_and_title, user_id)
+        articles = await self._search_content(industry, title, user_id)
+
+        result = await self._llm_generate_strategy(industry, title, articles, user_id)
+        if result is not None:
+            return result
+
+        return WeeklyStrategyResponse(
+            theme="Build your authority",
+            week_of=self._week_start(),
+            daily_posts=[],
+            key_topics=[],
+            focus_area="Content consistency",
+            data_source_summary=(
+                f"Based on your LinkedIn profile ({title} in {industry})"
+            ),
+            generated_at=datetime.now(timezone.utc),
+        )

--- a/frontend/src/components/LinkedInWriter/components/GrowthEngine/BrandScorecard.tsx
+++ b/frontend/src/components/LinkedInWriter/components/GrowthEngine/BrandScorecard.tsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import type { BrandDimension } from '../../../../services/linkedInGrowthApi';
+import { DataSourceBadge } from './DataSourceBadge';
+import { EmptyState } from './EmptyState';
+import { cardBase, headerRow, dismissBtn, scoreColor, scoreBg, barColor, CONFIDENCE_COLORS, colors } from './styles';
+
+interface BrandScorecardProps {
+  overallScore: number;
+  dimensions: BrandDimension[];
+  topRecommendation: string;
+  dataSourceSummary: string;
+  onDismiss?: () => void;
+}
+
+const RANK_LABELS: Record<string, string> = {
+  beginner: 'Beginner',
+  developing: 'Developing',
+  strong: 'Strong',
+  exceptional: 'Exceptional',
+};
+
+const getRank = (score: number): string => {
+  if (score >= 85) return 'exceptional';
+  if (score >= 65) return 'strong';
+  if (score >= 40) return 'developing';
+  return 'beginner';
+};
+
+export const BrandScorecard: React.FC<BrandScorecardProps> = React.memo(({
+  overallScore,
+  dimensions,
+  topRecommendation,
+  dataSourceSummary,
+  onDismiss,
+}) => {
+  if (!dimensions || dimensions.length === 0) {
+    return <EmptyState icon="🏆" message="Brand scorecard data not available. Connect your LinkedIn account for a full analysis." />;
+  }
+
+  return (
+    <div style={cardBase}>
+      <div style={headerRow}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ fontSize: 20 }} aria-hidden="true">🏆</span>
+          <div style={{ fontWeight: 700, fontSize: 15, color: colors.textDark }}>
+            Personal Brand Scorecard
+          </div>
+        </div>
+        {onDismiss && (
+          <button onClick={onDismiss} style={dismissBtn} title="Dismiss" aria-label="Dismiss brand scorecard">
+            ✕
+          </button>
+        )}
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 14,
+          marginTop: 14,
+          marginBottom: 16,
+          padding: '14px 16px',
+          background: scoreBg(overallScore),
+          borderRadius: 10,
+          border: `1px solid ${barColor(overallScore)}33`,
+        }}
+      >
+        <div
+          style={{
+            width: 64,
+            height: 64,
+            borderRadius: '50%',
+            background: colors.white,
+            color: scoreColor(overallScore),
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontWeight: 800,
+            fontSize: 22,
+            flexShrink: 0,
+            boxShadow: '0 2px 4px rgba(0,0,0,0.08)',
+          }}
+        >
+          {overallScore}
+        </div>
+        <div>
+          <div style={{ fontWeight: 700, fontSize: 16, color: scoreColor(overallScore) }}>
+            {RANK_LABELS[getRank(overallScore)]} Brand
+          </div>
+          <div style={{ fontSize: 12, color: scoreColor(overallScore), marginTop: 2, opacity: 0.8 }}>
+            {overallScore >= 75
+              ? 'Strong personal brand — keep building momentum'
+              : overallScore >= 50
+              ? 'Developing brand — focused improvements will help'
+              : 'Early stage — big opportunities to build your brand'}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {dimensions.map((d, i) => (
+          <DimensionRow key={i} dim={d} />
+        ))}
+      </div>
+
+      <div
+        style={{
+          marginTop: 14,
+          padding: '10px 14px',
+          background: colors.badgeBg,
+          borderRadius: 8,
+          border: `1px solid ${colors.border}`,
+        }}
+      >
+        <div style={{ fontSize: 11, fontWeight: 700, color: colors.textMedium, marginBottom: 4, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+          Top Recommendation
+        </div>
+        <div style={{ fontSize: 13, color: colors.textBody, lineHeight: 1.5 }}>
+          💡 {topRecommendation}
+        </div>
+      </div>
+
+      <div style={{ marginTop: 12 }}>
+        <DataSourceBadge label="Growth Engine" detail={dataSourceSummary} />
+      </div>
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// DimensionRow sub-component
+// ---------------------------------------------------------------------------
+interface DimensionRowProps {
+  dim: BrandDimension;
+}
+
+const DimensionRow: React.FC<DimensionRowProps> = React.memo(({ dim }) => {
+  const color = scoreColor(dim.score);
+  const bg = scoreBg(dim.score);
+  const bar = barColor(dim.score);
+  const cc = CONFIDENCE_COLORS[dim.confidence] || CONFIDENCE_COLORS.medium;
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+        <span style={{ fontSize: 12, fontWeight: 600, color: colors.textBody }}>
+          {dim.dimension}
+        </span>
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color,
+            background: bg,
+            padding: '1px 8px',
+            borderRadius: 4,
+          }}
+        >
+          {dim.score}/100
+        </span>
+      </div>
+      <div
+        style={{
+          height: 6,
+          background: colors.border,
+          borderRadius: 3,
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            width: `${dim.score}%`,
+            height: '100%',
+            background: bar,
+            borderRadius: 3,
+            transition: 'width 0.6s ease',
+          }}
+        />
+      </div>
+      <div style={{ fontSize: 11, color: colors.textSecondary, marginTop: 3, lineHeight: 1.4 }}>
+        {dim.feedback}
+      </div>
+      <div style={{ fontSize: 10, color: colors.textTertiary, marginTop: 1 }}>
+        {dim.data_source_detail} ·
+        <span
+          style={{
+            background: cc.bg,
+            color: cc.text,
+            padding: '1px 5px',
+            borderRadius: 3,
+            fontWeight: 600,
+            marginLeft: 4,
+          }}
+        >
+          {dim.confidence} confidence
+        </span>
+      </div>
+    </div>
+  );
+});

--- a/frontend/src/components/LinkedInWriter/components/GrowthEngine/ContentGapCard.tsx
+++ b/frontend/src/components/LinkedInWriter/components/GrowthEngine/ContentGapCard.tsx
@@ -1,0 +1,153 @@
+import React, { useCallback, useState } from 'react';
+import type { ContentGapItem } from '../../../../services/linkedInGrowthApi';
+import { DataSourceBadge } from './DataSourceBadge';
+import { EmptyState } from './EmptyState';
+import { cardBase, headerRow, dismissBtn, primaryBtn, secondaryBtn, rowBase, CONFIDENCE_COLORS, colors } from './styles';
+
+interface ContentGapCardProps {
+  gaps: ContentGapItem[];
+  dataSourceSummary: string;
+  onDismiss?: () => void;
+  onGeneratePost?: (params?: { topic?: string; context?: string }) => Promise<{ success: boolean; data?: any; error?: string }>;
+}
+
+export const ContentGapCard: React.FC<ContentGapCardProps> = React.memo(({
+  gaps,
+  dataSourceSummary,
+  onDismiss,
+  onGeneratePost,
+}) => {
+  const [dismissed, setDismissed] = useState<Set<number>>(new Set());
+
+  const handleDismiss = useCallback((index: number) => {
+    setDismissed((prev) => new Set(prev).add(index));
+  }, []);
+
+  const visible = gaps.filter((_, i) => !dismissed.has(i));
+
+  if (visible.length === 0 && gaps.length > 0) {
+    return null;
+  }
+
+  if (gaps.length === 0) {
+    return <EmptyState icon="🔍" message="No content gaps identified. Your content strategy looks well-rounded!" />;
+  }
+
+  return (
+    <div style={cardBase}>
+      <div style={headerRow}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ fontSize: 20 }} aria-hidden="true">🔍</span>
+          <div style={{ fontWeight: 700, fontSize: 15, color: colors.textDark }}>
+            Content Gap Analyzer
+          </div>
+        </div>
+        {onDismiss && (
+          <button onClick={onDismiss} style={dismissBtn} title="Dismiss" aria-label="Dismiss content gap analysis">
+            ✕
+          </button>
+        )}
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginTop: 12 }}>
+        {visible.map((gap, i) => {
+          const originalIndex = gaps.indexOf(gap);
+          return (
+            <GapRow
+              key={originalIndex}
+              gap={gap}
+              index={originalIndex}
+              onDismiss={handleDismiss}
+              onGeneratePost={onGeneratePost}
+            />
+          );
+        })}
+      </div>
+
+      <div style={{ marginTop: 12 }}>
+        <DataSourceBadge label="Growth Engine" detail={dataSourceSummary} />
+      </div>
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// GapRow sub-component
+// ---------------------------------------------------------------------------
+interface GapRowProps {
+  gap: ContentGapItem;
+  index: number;
+  onDismiss: (index: number) => void;
+  onGeneratePost?: (params?: { topic?: string; context?: string }) => Promise<{ success: boolean; data?: any; error?: string }>;
+}
+
+const GapRow: React.FC<GapRowProps> = React.memo(({ gap, index, onDismiss, onGeneratePost }) => {
+  const cc = CONFIDENCE_COLORS[gap.confidence] || CONFIDENCE_COLORS.medium;
+
+  return (
+    <div style={rowBase}>
+      <div style={{ fontWeight: 700, fontSize: 14, color: colors.textDark, marginBottom: 6 }}>
+        🔎 Gap: {gap.gap_topic}
+      </div>
+
+      <div style={{ fontSize: 12, color: colors.textMedium, lineHeight: 1.5, marginBottom: 4 }}>
+        <span style={{ fontWeight: 600, color: colors.textBody }}>Why it's missing:</span>{' '}
+        {gap.why_gap}
+      </div>
+
+      <div style={{ fontSize: 12, color: colors.textMedium, lineHeight: 1.5, marginBottom: 8 }}>
+        <span style={{ fontWeight: 600, color: colors.textBody }}>Why it matters now:</span>{' '}
+        {gap.why_it_matters}
+      </div>
+
+      <div
+        style={{
+          background: colors.white,
+          border: `1px solid ${colors.border}`,
+          borderRadius: 6,
+          padding: '8px 10px',
+          fontSize: 12,
+          color: colors.textBody,
+          marginBottom: 10,
+          fontStyle: 'italic',
+        }}
+      >
+        💡 Post idea: {gap.suggested_angle}
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        {onGeneratePost && (
+          <button
+            onClick={() => onGeneratePost({ topic: gap.gap_topic, context: `Content gap: ${gap.gap_topic}. Suggested angle: ${gap.suggested_angle}` })}
+            style={primaryBtn}
+            aria-label={`Create post about ${gap.gap_topic}`}
+          >
+            Create Post ✨
+          </button>
+        )}
+        <button
+          onClick={() => onDismiss(index)}
+          style={secondaryBtn}
+          aria-label="Dismiss gap"
+        >
+          Dismiss
+        </button>
+        <span style={{ fontSize: 10, color: colors.textTertiary, marginLeft: 'auto' }}>
+          {gap.data_source_detail} ·
+          <span
+            style={{
+              background: cc.bg,
+              color: cc.text,
+              padding: '1px 5px',
+              borderRadius: 3,
+              fontWeight: 600,
+              marginLeft: 4,
+            }}
+          >
+            {gap.confidence} confidence
+          </span>
+        </span>
+      </div>
+    </div>
+  );
+});

--- a/frontend/src/components/LinkedInWriter/components/GrowthEngine/DataSourceBadge.tsx
+++ b/frontend/src/components/LinkedInWriter/components/GrowthEngine/DataSourceBadge.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { CONFIDENCE_COLORS, colors } from './styles';
+
+interface DataSourceBadgeProps {
+  label: string;
+  detail?: string;
+  confidence?: 'high' | 'medium' | 'low';
+}
+
+const CONFIDENCE_LABELS: Record<string, string> = {
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+};
+
+export const DataSourceBadge: React.FC<DataSourceBadgeProps> = React.memo(({
+  label,
+  detail,
+  confidence,
+}) => {
+  const cc = confidence ? CONFIDENCE_COLORS[confidence] : null;
+
+  return (
+    <div
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '4px 10px',
+        borderRadius: 6,
+        background: colors.badgeBg,
+        fontSize: 11,
+        color: colors.textMedium,
+        flexWrap: 'wrap',
+      }}
+    >
+      <span style={{ fontWeight: 600, whiteSpace: 'nowrap' }}>📊 {label}</span>
+      {detail && (
+        <span style={{ opacity: 0.75, whiteSpace: 'nowrap' }}>· {detail}</span>
+      )}
+      {cc && (
+        <span
+          style={{
+            background: cc.bg,
+            color: cc.text,
+            padding: '1px 6px',
+            borderRadius: 4,
+            fontWeight: 600,
+            fontSize: 10,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {CONFIDENCE_LABELS[confidence!]} confidence
+        </span>
+      )}
+    </div>
+  );
+});

--- a/frontend/src/components/LinkedInWriter/components/GrowthEngine/EmptyState.tsx
+++ b/frontend/src/components/LinkedInWriter/components/GrowthEngine/EmptyState.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { colors } from './styles';
+
+interface EmptyStateProps {
+  icon?: string;
+  message: string;
+}
+
+export const EmptyState: React.FC<EmptyStateProps> = React.memo(({ icon = '📭', message }) => (
+  <div
+    style={{
+      border: `1px dashed ${colors.dashedBorder}`,
+      borderRadius: 10,
+      padding: 32,
+      textAlign: 'center',
+      color: colors.textMuted,
+      fontSize: 13,
+      lineHeight: 1.6,
+    }}
+  >
+    <span style={{ fontSize: 24, marginBottom: 8, display: 'block' }} aria-hidden="true">
+      {icon}
+    </span>
+    {message}
+  </div>
+));

--- a/frontend/src/components/LinkedInWriter/components/GrowthEngine/EngagementCard.tsx
+++ b/frontend/src/components/LinkedInWriter/components/GrowthEngine/EngagementCard.tsx
@@ -1,0 +1,168 @@
+import React, { useCallback, useState } from 'react';
+import type { EngagementOpportunityItem } from '../../../../services/linkedInGrowthApi';
+import { DataSourceBadge } from './DataSourceBadge';
+import { EmptyState } from './EmptyState';
+import { cardBase, headerRow, primaryBtn, greenBtn, secondaryBtn, rowBase, colors } from './styles';
+
+interface EngagementCardProps {
+  opportunities: EngagementOpportunityItem[];
+  dataSourceSummary: string;
+  onGeneratePost?: (params?: { topic?: string; context?: string }) => Promise<{ success: boolean; data?: any; error?: string }>;
+}
+
+export const EngagementCard: React.FC<EngagementCardProps> = React.memo(({
+  opportunities,
+  dataSourceSummary,
+  onGeneratePost,
+}) => {
+  const [dismissed, setDismissed] = useState<Set<number>>(new Set());
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
+
+  const handleCopy = useCallback(async (text: string, index: number) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedIndex(index);
+      setTimeout(() => setCopiedIndex(null), 2000);
+    } catch {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+      setCopiedIndex(index);
+      setTimeout(() => setCopiedIndex(null), 2000);
+    }
+  }, []);
+
+  const handleDismiss = useCallback((index: number) => {
+    setDismissed((prev) => new Set(prev).add(index));
+  }, []);
+
+  const visible = opportunities.filter((_, i) => !dismissed.has(i));
+
+  if (visible.length === 0 && opportunities.length > 0) {
+    return null;
+  }
+
+  if (opportunities.length === 0) {
+    return <EmptyState icon="💬" message="No engagement opportunities found. Check back later for posts to engage with." />;
+  }
+
+  return (
+    <div style={cardBase}>
+      <div style={headerRow}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ fontSize: 20 }} aria-hidden="true">💬</span>
+          <div style={{ fontWeight: 700, fontSize: 15, color: colors.textDark }}>
+            Engagement Opportunities
+          </div>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginTop: 12 }}>
+        {visible.map((item, i) => {
+          const originalIndex = opportunities.indexOf(item);
+          return (
+            <EngagementRow
+              key={originalIndex}
+              item={item}
+              index={originalIndex}
+              copied={copiedIndex === originalIndex}
+              onCopy={handleCopy}
+              onDismiss={handleDismiss}
+              onGeneratePost={onGeneratePost}
+            />
+          );
+        })}
+      </div>
+
+      <div style={{ marginTop: 12 }}>
+        <DataSourceBadge label="Growth Engine" detail={dataSourceSummary} />
+      </div>
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// EngagementRow sub-component
+// ---------------------------------------------------------------------------
+interface EngagementRowProps {
+  item: EngagementOpportunityItem;
+  index: number;
+  copied: boolean;
+  onCopy: (text: string, index: number) => void;
+  onDismiss: (index: number) => void;
+  onGeneratePost?: (params?: { topic?: string; context?: string }) => Promise<{ success: boolean; data?: any; error?: string }>;
+}
+
+const EngagementRow: React.FC<EngagementRowProps> = React.memo(({
+  item,
+  index,
+  copied,
+  onCopy,
+  onDismiss,
+  onGeneratePost,
+}) => {
+  return (
+    <div style={rowBase}>
+      <div style={{ marginBottom: 8 }}>
+        <div style={{ fontWeight: 600, fontSize: 14, color: colors.textDark, lineHeight: 1.4 }}>
+          📢 {item.title}
+        </div>
+        <div style={{ fontSize: 12, color: colors.textSecondary, marginTop: 2 }}>
+          by {item.author} ({item.author_context})
+        </div>
+      </div>
+
+      <div style={{ fontSize: 12, color: colors.textMedium, marginBottom: 8, fontStyle: 'italic' }}>
+        💡 {item.why_engage}
+      </div>
+
+      <div
+        style={{
+          background: colors.white,
+          border: `1px solid ${colors.border}`,
+          borderRadius: 8,
+          padding: '10px 12px',
+          marginBottom: 10,
+          fontSize: 13,
+          color: colors.textBody,
+          lineHeight: 1.5,
+        }}
+      >
+        💬 {item.suggested_comment}
+      </div>
+
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+        <button
+          onClick={() => onCopy(item.suggested_comment, index)}
+          style={{
+            ...primaryBtn,
+            background: copied ? colors.successBg : colors.primary,
+            color: copied ? colors.successText : '#fff',
+          }}
+          aria-label={copied ? 'Comment copied' : 'Copy suggested comment'}
+        >
+          {copied ? 'Copied ✓' : 'Copy Comment'}
+        </button>
+        {onGeneratePost && (
+          <button
+            onClick={() => onGeneratePost({ topic: item.title, context: `Engaging with: "${item.title}" by ${item.author}. Suggested comment: ${item.suggested_comment}` })}
+            style={greenBtn}
+            aria-label={`Create post about ${item.title}`}
+          >
+            Create Post ✨
+          </button>
+        )}
+        <button
+          onClick={() => onDismiss(index)}
+          style={secondaryBtn}
+          aria-label="Dismiss opportunity"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+});

--- a/frontend/src/components/LinkedInWriter/components/GrowthEngine/GrowthEnginePanel.tsx
+++ b/frontend/src/components/LinkedInWriter/components/GrowthEngine/GrowthEnginePanel.tsx
@@ -1,0 +1,603 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  linkedInGrowthApi,
+  type ConsolidatedGrowthResponse,
+  type TrendingTopicsResponse,
+  type NetworkSuggestionsResponse,
+  type EngagementOpportunitiesResponse,
+  type ViralAnalysisResponse,
+  type WeeklyStrategyResponse,
+  type ContentGapsResponse,
+  type BrandScorecardResponse,
+} from '../../../../services/linkedInGrowthApi';
+import { TrendingTopicCard } from './TrendingTopicCard';
+import { NetworkSuggestionCard } from './NetworkSuggestionCard';
+import { EngagementCard } from './EngagementCard';
+import { ViralAnalysisCard } from './ViralAnalysisCard';
+import { StrategyBriefCard } from './StrategyBriefCard';
+import { ContentGapCard } from './ContentGapCard';
+import { BrandScorecard } from './BrandScorecard';
+import { EmptyState } from './EmptyState';
+import ComponentErrorBoundary from '../../../../components/shared/ComponentErrorBoundary';
+import { colors, primaryBtn } from './styles';
+
+interface GrowthEnginePanelProps {
+  onGeneratePost: (params?: { topic?: string; context?: string }) => Promise<{ success: boolean; data?: any; error?: string }>;
+}
+
+type PanelState = 'idle' | 'loading' | 'loaded' | 'error';
+
+type RefreshKey = 'trending' | 'network' | 'engagement' | 'viral' | 'strategy' | 'gaps' | 'brand';
+
+export const GrowthEnginePanel: React.FC<GrowthEnginePanelProps> = ({
+  onGeneratePost,
+}) => {
+  const [consolidated, setConsolidated] = useState<ConsolidatedGrowthResponse | null>(null);
+  const [panelState, setPanelState] = useState<PanelState>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+  const [refreshing, setRefreshing] = useState<Set<RefreshKey>>(new Set());
+  const [tick, setTick] = useState(0);
+
+  const mountedRef = useRef(true);
+  const fetchedRef = useRef(false);
+
+  // Re-render every 60s so relative timestamps stay current
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 60000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Restore sessionStorage cache on mount
+  useEffect(() => {
+    if (fetchedRef.current) return;
+    fetchedRef.current = true;
+
+    try {
+      const raw = sessionStorage.getItem('alwrity_growth_engine');
+      if (raw) {
+        const parsed = JSON.parse(raw) as { data: ConsolidatedGrowthResponse; cachedAt: number };
+        const age = Date.now() - parsed.cachedAt;
+        const TTL = 60 * 60 * 1000; // 1 hour
+        if (age < TTL) {
+          setConsolidated(parsed.data);
+          setPanelState('loaded');
+        } else {
+          sessionStorage.removeItem('alwrity_growth_engine');
+        }
+      }
+    } catch {
+      sessionStorage.removeItem('alwrity_growth_engine');
+    }
+  }, []);
+
+  // Persist the latest consolidated data to sessionStorage
+  const persistToSession = useCallback((data: ConsolidatedGrowthResponse) => {
+    try {
+      sessionStorage.setItem(
+        'alwrity_growth_engine',
+        JSON.stringify({ data, cachedAt: Date.now() }),
+      );
+    } catch {
+      // sessionStorage full or unavailable — silently skip
+    }
+  }, []);
+
+  const runAllAnalyses = useCallback(async () => {
+    setPanelState('loading');
+    setErrorMsg('');
+    try {
+      const data = await linkedInGrowthApi.analyzeAll();
+      if (!mountedRef.current) return;
+      setConsolidated(data);
+      setPanelState('loaded');
+      persistToSession(data);
+    } catch (err: unknown) {
+      if (!mountedRef.current) return;
+      const msg =
+        (err as any)?.response?.data?.detail ||
+        (err instanceof Error ? err.message : 'Failed to load growth insights');
+      setErrorMsg(msg);
+      setPanelState('error');
+    }
+  }, [persistToSession]);
+
+  const refreshCard = useCallback(async (key: RefreshKey) => {
+    setRefreshing((prev) => new Set(prev).add(key));
+    try {
+      let result: unknown;
+      switch (key) {
+        case 'trending':
+          result = await linkedInGrowthApi.getTrendingTopics();
+          break;
+        case 'network':
+          result = await linkedInGrowthApi.getNetworkSuggestions();
+          break;
+        case 'engagement':
+          result = await linkedInGrowthApi.getEngagementOpportunities();
+          break;
+        case 'viral':
+          result = await linkedInGrowthApi.getViralAnalysis();
+          break;
+        case 'strategy':
+          result = await linkedInGrowthApi.getWeeklyStrategy();
+          break;
+        case 'gaps':
+          result = await linkedInGrowthApi.getContentGaps();
+          break;
+        case 'brand':
+          result = await linkedInGrowthApi.getBrandScorecard();
+          break;
+      }
+      if (!mountedRef.current) return;
+      setConsolidated((prev) => {
+        if (!prev) return prev;
+        const updated = { ...prev };
+        switch (key) {
+          case 'trending':
+            updated.trending = result as TrendingTopicsResponse;
+            break;
+          case 'network':
+            updated.network_suggestions = result as NetworkSuggestionsResponse;
+            break;
+          case 'engagement':
+            updated.engagement_opportunities = result as EngagementOpportunitiesResponse;
+            break;
+          case 'viral':
+            updated.viral_analysis = result as ViralAnalysisResponse;
+            break;
+          case 'strategy':
+            updated.weekly_strategy = result as WeeklyStrategyResponse;
+            break;
+          case 'gaps':
+            updated.content_gaps = result as ContentGapsResponse;
+            break;
+          case 'brand':
+            updated.brand_scorecard = result as BrandScorecardResponse;
+            break;
+        }
+        persistToSession(updated);
+        return updated;
+      });
+    } catch (err: unknown) {
+      console.error(`[GrowthEngine] Failed to refresh ${key}:`, err);
+    } finally {
+      if (mountedRef.current) {
+        setRefreshing((prev) => {
+          const next = new Set(prev);
+          next.delete(key);
+          return next;
+        });
+      }
+    }
+  }, [persistToSession]);
+
+  const handlePostAbout = useCallback((topic: string, hook: string) => {
+    onGeneratePost({ topic, context: `Topic: ${topic}\nSuggested hook: ${hook}` });
+  }, [onGeneratePost]);
+
+  // ------------------------------------------------------------------
+  // Idle state — user hasn't triggered any analysis yet
+  // ------------------------------------------------------------------
+  if (panelState === 'idle') {
+    return (
+      <div style={{ padding: '24px 32px', maxWidth: 900, margin: '0 auto' }}>
+        <h2 style={{ margin: '0 0 4px', fontSize: 20, fontWeight: 700, color: colors.textDark }}>
+          Growth Engine
+        </h2>
+        <p style={{ margin: '0 0 24px', fontSize: 13, color: colors.textSecondary }}>
+          AI-powered insights to grow your LinkedIn reach. Data-backed, actionable suggestions.
+        </p>
+        <EmptyState
+          icon="🚀"
+          message="Ready to analyze your LinkedIn growth. Click below to generate all insights in one go, or load individual cards."
+        />
+        <div style={{ textAlign: 'center', marginTop: 16 }}>
+          <button
+            onClick={runAllAnalyses}
+            style={{
+              ...primaryBtn,
+              padding: '10px 28px',
+              fontSize: 14,
+              borderRadius: 8,
+            }}
+            aria-label="Run all growth analyses"
+          >
+            🚀 Load All Insights (1 AI call)
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ------------------------------------------------------------------
+  // Loading state — per-card skeleton placeholders matching the layout
+  // ------------------------------------------------------------------
+  if (panelState === 'loading') {
+    const shimmerKeyframes = `
+      @keyframes gs-shimmer {
+        0% { background-position: -400px 0; }
+        100% { background-position: 400px 0; }
+      }
+    `;
+    const sk = (h: number, w?: string): React.CSSProperties => ({
+      height: h,
+      width: w || '100%',
+      borderRadius: 6,
+      background: `linear-gradient(90deg, ${colors.badgeBg} 25%, ${colors.border} 50%, ${colors.badgeBg} 75%)`,
+      backgroundSize: '800px 100%',
+      animation: 'gs-shimmer 1.5s ease-in-out infinite',
+    });
+
+    return (
+      <div style={{ padding: '24px 32px', maxWidth: 900, margin: '0 auto' }}>
+        <div style={{ marginBottom: 4 }}>
+          <div style={sk(24, '280px')} />
+          <div style={{ ...sk(13, '420px'), marginTop: 8 }} />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 20, marginTop: 20 }}>
+          {[1, 2, 3, 4, 5, 6, 7].map((i) => (
+            <div
+              key={i}
+              style={{
+                border: `1px solid ${colors.border}`,
+                borderRadius: 10,
+                padding: 16,
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
+                <div style={sk(22, '70px')} />
+              </div>
+              <div style={sk(16)} />
+              <div style={{ ...sk(14), marginTop: 8, width: '70%' }} />
+              <div style={{ ...sk(14), marginTop: 6, width: '50%' }} />
+              <div style={{ ...sk(14), marginTop: 6, width: '60%' }} />
+            </div>
+          ))}
+        </div>
+        <style>{shimmerKeyframes}</style>
+      </div>
+    );
+  }
+
+  // ------------------------------------------------------------------
+  // Error state
+  // ------------------------------------------------------------------
+  if (panelState === 'error') {
+    return (
+      <div style={{ padding: '24px 32px', maxWidth: 900, margin: '0 auto' }}>
+        <div
+          style={{
+            background: '#fef2f2',
+            border: '1px solid #fecaca',
+            borderRadius: 10,
+            padding: '20px 24px',
+            textAlign: 'center',
+          }}
+        >
+          <div style={{ fontSize: 16, marginBottom: 8, color: '#991b1b' }}>
+            Could not load growth insights
+          </div>
+          <div style={{ fontSize: 13, color: '#b91c1c', marginBottom: 16 }}>{errorMsg}</div>
+          <button
+            onClick={runAllAnalyses}
+            style={{
+              padding: '8px 20px',
+              background: colors.primary,
+              color: '#fff',
+              border: 'none',
+              borderRadius: 8,
+              cursor: 'pointer',
+              fontWeight: 600,
+              fontSize: 13,
+            }}
+            aria-label="Retry loading growth insights"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ------------------------------------------------------------------
+  // Loaded — render insight cards with per-card refresh
+  // ------------------------------------------------------------------
+  if (!consolidated) return null;
+
+  const spinKeyframes = `
+    @keyframes gs-spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
+  `;
+
+  const overlayStyle: React.CSSProperties = {
+    position: 'absolute',
+    inset: 0,
+    background: 'rgba(255,255,255,0.6)',
+    zIndex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 10,
+  };
+
+  const spinnerStyle: React.CSSProperties = {
+    fontSize: 20,
+    animation: 'gs-spin 0.8s linear infinite',
+    display: 'inline-block',
+  };
+
+  const cardWrapper = (key: RefreshKey, children: React.ReactNode) => (
+    <div style={{ position: 'relative' }}>
+      {refreshing.has(key) && (
+        <div style={overlayStyle}>
+          <span style={spinnerStyle}>⟳</span>
+        </div>
+      )}
+      {children}
+    </div>
+  );
+
+  // ---- stale detection ----
+  const allGeneratedAts: string[] = [];
+  const c = consolidated!; // non-null at this point
+  if (c.trending?.generated_at) allGeneratedAts.push(c.trending.generated_at);
+  if (c.network_suggestions?.generated_at) allGeneratedAts.push(c.network_suggestions.generated_at);
+  if (c.engagement_opportunities?.generated_at) allGeneratedAts.push(c.engagement_opportunities.generated_at);
+  if (c.viral_analysis?.generated_at) allGeneratedAts.push(c.viral_analysis.generated_at);
+  if (c.weekly_strategy?.generated_at) allGeneratedAts.push(c.weekly_strategy.generated_at);
+  if (c.content_gaps?.generated_at) allGeneratedAts.push(c.content_gaps.generated_at);
+  if (c.brand_scorecard?.generated_at) allGeneratedAts.push(c.brand_scorecard.generated_at);
+
+  const oldestMs = allGeneratedAts.length > 0
+    ? Math.min(...allGeneratedAts.map((s) => new Date(s).getTime()))
+    : 0;
+  const isStale = oldestMs > 0 && (Date.now() - oldestMs) > 30 * 60 * 1000;
+
+  const formatTimeAgo = (dateStr: string | null | undefined): string => {
+    tick; // reference tick to ensure re-render when interval fires
+    if (!dateStr) return '';
+    const ms = Date.now() - new Date(dateStr).getTime();
+    const min = Math.floor(ms / 60000);
+    if (min < 1) return 'just now';
+    if (min < 60) return `${min} min ago`;
+    const hr = Math.floor(min / 60);
+    if (hr < 24) return `${hr}h ago`;
+    return `${Math.floor(hr / 24)}d ago`;
+  };
+
+  const { trending, network_suggestions, engagement_opportunities, viral_analysis, weekly_strategy, content_gaps, brand_scorecard } = consolidated;
+
+  const hasContent = (trending?.trending_topics?.length ?? 0) > 0
+    || (network_suggestions?.suggestions?.length ?? 0) > 0
+    || (engagement_opportunities?.opportunities?.length ?? 0) > 0
+    || (viral_analysis?.patterns?.length ?? 0) > 0
+    || (weekly_strategy?.daily_posts?.length ?? 0) > 0
+    || (content_gaps?.gaps?.length ?? 0) > 0
+    || (brand_scorecard?.dimensions?.length ?? 0) > 0;
+
+  const cardActionBtn = (key: RefreshKey, label: string, hasData: boolean) => (
+    <button
+      onClick={() => refreshCard(key)}
+      disabled={refreshing.has(key)}
+      style={{
+        ...primaryBtn,
+        fontSize: 11,
+        padding: '4px 10px',
+        opacity: refreshing.has(key) ? 0.6 : 1,
+      }}
+      aria-label={`${hasData ? 'Refresh' : 'Load'} ${key.replace('-', ' ')}`}
+    >
+      {refreshing.has(key) ? '⟳' : hasData ? '↻' : '▶'} {label}
+    </button>
+  );
+
+  return (
+    <div
+      style={{
+        padding: '24px 32px',
+        maxWidth: 900,
+        margin: '0 auto',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 20,
+      }}
+    >
+      <div style={{ marginBottom: 4 }}>
+        <h2 style={{ margin: 0, fontSize: 20, fontWeight: 700, color: colors.textDark }}>
+          Growth Engine
+        </h2>
+        <p style={{ margin: '4px 0 0', fontSize: 13, color: colors.textSecondary }}>
+          AI-powered insights. Refresh individual cards to get fresh AI-generated recommendations.
+        </p>
+      </div>
+
+      {isStale && (
+        <div
+          style={{
+            background: '#fef9c3',
+            border: '1px solid #facc15',
+            borderRadius: 8,
+            padding: '10px 16px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            fontSize: 13,
+          }}
+        >
+          <span style={{ color: '#854d0e' }}>
+            Some data may be stale (last updated {formatTimeAgo(c.generated_at)})
+          </span>
+          <button
+            onClick={runAllAnalyses}
+            style={{
+              ...primaryBtn,
+              fontSize: 12,
+              padding: '5px 14px',
+              borderRadius: 6,
+            }}
+            aria-label="Refresh all insights"
+          >
+            Refresh All
+          </button>
+        </div>
+      )}
+
+      {trending && trending.trending_topics.length > 0 && (
+        <ComponentErrorBoundary componentName="TrendingTopicCard">
+          {cardWrapper('trending', (
+            <div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+                <span style={{ fontSize: 11, color: colors.textSecondary }}>
+                  Updated {formatTimeAgo(trending.generated_at)}
+                </span>
+                {cardActionBtn('trending', 'Refresh', true)}
+              </div>
+              <TrendingTopicCard
+                industry={trending.industry}
+                topics={trending.trending_topics}
+                dataSourceSummary={trending.data_source_summary}
+                onPostAbout={handlePostAbout}
+              />
+            </div>
+          ))}
+        </ComponentErrorBoundary>
+      )}
+
+      {network_suggestions && network_suggestions.suggestions.length > 0 && (
+        <ComponentErrorBoundary componentName="NetworkSuggestionCard">
+          {cardWrapper('network', (
+            <div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+                <span style={{ fontSize: 11, color: colors.textSecondary }}>
+                  Updated {formatTimeAgo(network_suggestions.generated_at)}
+                </span>
+                {cardActionBtn('network', 'Refresh', true)}
+              </div>
+              <NetworkSuggestionCard
+                suggestions={network_suggestions.suggestions}
+                dataSourceSummary={network_suggestions.data_source_summary}
+              />
+            </div>
+          ))}
+        </ComponentErrorBoundary>
+      )}
+
+      {engagement_opportunities && engagement_opportunities.opportunities.length > 0 && (
+        <ComponentErrorBoundary componentName="EngagementCard">
+          {cardWrapper('engagement', (
+            <div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+                <span style={{ fontSize: 11, color: colors.textSecondary }}>
+                  Updated {formatTimeAgo(engagement_opportunities.generated_at)}
+                </span>
+                {cardActionBtn('engagement', 'Refresh', true)}
+              </div>
+              <EngagementCard
+                opportunities={engagement_opportunities.opportunities}
+                dataSourceSummary={engagement_opportunities.data_source_summary}
+                onGeneratePost={onGeneratePost}
+              />
+            </div>
+          ))}
+        </ComponentErrorBoundary>
+      )}
+
+      {viral_analysis && viral_analysis.patterns.length > 0 && (
+        <ComponentErrorBoundary componentName="ViralAnalysisCard">
+          {cardWrapper('viral', (
+            <div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+                <span style={{ fontSize: 11, color: colors.textSecondary }}>
+                  Updated {formatTimeAgo(viral_analysis.generated_at)}
+                </span>
+                {cardActionBtn('viral', 'Refresh', true)}
+              </div>
+              <ViralAnalysisCard
+                industry={viral_analysis.industry}
+                patterns={viral_analysis.patterns}
+                topRecommendation={viral_analysis.top_recommendation}
+                dataSourceSummary={viral_analysis.data_source_summary}
+              />
+            </div>
+          ))}
+        </ComponentErrorBoundary>
+      )}
+
+      {weekly_strategy && weekly_strategy.daily_posts.length > 0 && (
+        <ComponentErrorBoundary componentName="StrategyBriefCard">
+          {cardWrapper('strategy', (
+            <div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+                <span style={{ fontSize: 11, color: colors.textSecondary }}>
+                  Updated {formatTimeAgo(weekly_strategy.generated_at)}
+                </span>
+                {cardActionBtn('strategy', 'Refresh', true)}
+              </div>
+              <StrategyBriefCard
+                theme={weekly_strategy.theme}
+                weekOf={weekly_strategy.week_of}
+                dailyPosts={weekly_strategy.daily_posts}
+                keyTopics={weekly_strategy.key_topics}
+                focusArea={weekly_strategy.focus_area}
+                dataSourceSummary={weekly_strategy.data_source_summary}
+                onGeneratePost={onGeneratePost}
+              />
+            </div>
+          ))}
+        </ComponentErrorBoundary>
+      )}
+
+      {content_gaps && content_gaps.gaps.length > 0 && (
+        <ComponentErrorBoundary componentName="ContentGapCard">
+          {cardWrapper('gaps', (
+            <div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+                <span style={{ fontSize: 11, color: colors.textSecondary }}>
+                  Updated {formatTimeAgo(content_gaps.generated_at)}
+                </span>
+                {cardActionBtn('gaps', 'Refresh', true)}
+              </div>
+              <ContentGapCard
+                gaps={content_gaps.gaps}
+                dataSourceSummary={content_gaps.data_source_summary}
+                onGeneratePost={onGeneratePost}
+              />
+            </div>
+          ))}
+        </ComponentErrorBoundary>
+      )}
+
+      {brand_scorecard && brand_scorecard.dimensions.length > 0 && (
+        <ComponentErrorBoundary componentName="BrandScorecard">
+          {cardWrapper('brand', (
+            <div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+                <span style={{ fontSize: 11, color: colors.textSecondary }}>
+                  Updated {formatTimeAgo(brand_scorecard.generated_at)}
+                </span>
+                {cardActionBtn('brand', 'Refresh', true)}
+              </div>
+              <BrandScorecard
+                overallScore={brand_scorecard.overall_score}
+                dimensions={brand_scorecard.dimensions}
+                topRecommendation={brand_scorecard.top_recommendation}
+                dataSourceSummary={brand_scorecard.data_source_summary}
+              />
+            </div>
+          ))}
+        </ComponentErrorBoundary>
+      )}
+
+      {!hasContent && (
+        <EmptyState
+          icon="📭"
+          message="No growth insights returned. Try refreshing a card individually, or run Load All again."
+        />
+      )}
+
+      <style>{spinKeyframes}</style>
+    </div>
+  );
+};

--- a/frontend/src/components/LinkedInWriter/components/GrowthEngine/NetworkSuggestionCard.tsx
+++ b/frontend/src/components/LinkedInWriter/components/GrowthEngine/NetworkSuggestionCard.tsx
@@ -1,0 +1,153 @@
+import React, { useCallback, useState } from 'react';
+import type { NetworkSuggestionItem } from '../../../../services/linkedInGrowthApi';
+import { DataSourceBadge } from './DataSourceBadge';
+import { EmptyState } from './EmptyState';
+import { cardBase, headerRow, primaryBtn, secondaryBtn, rowBase, colors } from './styles';
+
+interface NetworkSuggestionCardProps {
+  suggestions: NetworkSuggestionItem[];
+  dataSourceSummary: string;
+}
+
+export const NetworkSuggestionCard: React.FC<NetworkSuggestionCardProps> = React.memo(({
+  suggestions,
+  dataSourceSummary,
+}) => {
+  const [dismissed, setDismissed] = useState<Set<number>>(new Set());
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
+
+  const handleCopy = useCallback(async (note: string, index: number) => {
+    try {
+      await navigator.clipboard.writeText(note);
+      setCopiedIndex(index);
+      setTimeout(() => setCopiedIndex(null), 2000);
+    } catch {
+      const ta = document.createElement('textarea');
+      ta.value = note;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+      setCopiedIndex(index);
+      setTimeout(() => setCopiedIndex(null), 2000);
+    }
+  }, []);
+
+  const handleDismiss = useCallback((index: number) => {
+    setDismissed((prev) => new Set(prev).add(index));
+  }, []);
+
+  const visible = suggestions.filter((_, i) => !dismissed.has(i));
+
+  if (visible.length === 0 && suggestions.length > 0) {
+    return null;
+  }
+
+  if (suggestions.length === 0) {
+    return <EmptyState icon="🤝" message="No network suggestions available. Connect your LinkedIn account for personalized recommendations." />;
+  }
+
+  return (
+    <div style={cardBase}>
+      <div style={headerRow}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ fontSize: 20 }} aria-hidden="true">🤝</span>
+          <div style={{ fontWeight: 700, fontSize: 15, color: colors.textDark }}>
+            People to Connect With This Week
+          </div>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginTop: 12 }}>
+        {visible.map((person, i) => {
+          const originalIndex = suggestions.indexOf(person);
+          return (
+            <PersonRow
+              key={originalIndex}
+              person={person}
+              index={originalIndex}
+              copied={copiedIndex === originalIndex}
+              onCopy={handleCopy}
+              onDismiss={handleDismiss}
+            />
+          );
+        })}
+      </div>
+
+      <div style={{ marginTop: 12 }}>
+        <DataSourceBadge label="Growth Engine" detail={dataSourceSummary} />
+      </div>
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// PersonRow sub-component
+// ---------------------------------------------------------------------------
+interface PersonRowProps {
+  person: NetworkSuggestionItem;
+  index: number;
+  copied: boolean;
+  onCopy: (note: string, index: number) => void;
+  onDismiss: (index: number) => void;
+}
+
+const PersonRow: React.FC<PersonRowProps> = React.memo(({
+  person,
+  index,
+  copied,
+  onCopy,
+  onDismiss,
+}) => {
+  return (
+    <div style={rowBase}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+        <span style={{ fontSize: 20 }} aria-hidden="true">👤</span>
+        <div>
+          <span style={{ fontWeight: 700, fontSize: 14, color: colors.textDark }}>
+            {person.name}
+          </span>
+          <span style={{ color: colors.textSecondary, fontSize: 13, marginLeft: 6 }}>
+            · {person.title} @ {person.company}
+          </span>
+        </div>
+      </div>
+
+      <div
+        style={{
+          background: colors.white,
+          border: `1px solid ${colors.border}`,
+          borderRadius: 8,
+          padding: '10px 12px',
+          marginBottom: 10,
+          fontSize: 13,
+          color: colors.textBody,
+          lineHeight: 1.5,
+        }}
+      >
+        💬 {person.suggested_note}
+      </div>
+
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <button
+          onClick={() => onCopy(person.suggested_note, index)}
+          style={{
+            ...primaryBtn,
+            background: copied ? colors.successBg : colors.primary,
+            color: copied ? colors.successText : '#fff',
+          }}
+          aria-label={copied ? 'Connection note copied' : 'Copy connection note'}
+        >
+          {copied ? 'Copied ✓' : 'Copy Note'}
+        </button>
+        <button
+          onClick={() => onDismiss(index)}
+          style={secondaryBtn}
+          aria-label="Dismiss suggestion"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+});

--- a/frontend/src/components/LinkedInWriter/components/GrowthEngine/PreviewScoreCard.tsx
+++ b/frontend/src/components/LinkedInWriter/components/GrowthEngine/PreviewScoreCard.tsx
@@ -1,0 +1,210 @@
+import React from 'react';
+import type { PostPreviewDimension } from '../../../../services/linkedInGrowthApi';
+import { DataSourceBadge } from './DataSourceBadge';
+import { EmptyState } from './EmptyState';
+import { cardBase, headerRow, dismissBtn, scoreColor, scoreBg, barColor, colors } from './styles';
+
+interface PreviewScoreCardProps {
+  overallScore: number;
+  dimensions: PostPreviewDimension[];
+  topImprovement: string;
+  dataSourceSummary: string;
+  onApply?: () => void;
+  onDismiss?: () => void;
+}
+
+export const PreviewScoreCard: React.FC<PreviewScoreCardProps> = React.memo(({
+  overallScore,
+  dimensions,
+  topImprovement,
+  dataSourceSummary,
+  onApply,
+  onDismiss,
+}) => {
+  if (!dimensions || dimensions.length === 0) {
+    return <EmptyState icon="📊" message="No score data available. Write a post and try again." />;
+  }
+
+  return (
+    <div style={cardBase}>
+      <div style={headerRow}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ fontSize: 20 }} aria-hidden="true">📊</span>
+          <div style={{ fontWeight: 700, fontSize: 15, color: colors.textDark }}>
+            Post Preview Score
+          </div>
+        </div>
+        {onDismiss && (
+          <button onClick={onDismiss} style={dismissBtn} title="Dismiss" aria-label="Dismiss preview score">
+            ✕
+          </button>
+        )}
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 14,
+          marginTop: 14,
+          marginBottom: 16,
+        }}
+      >
+        <div
+          style={{
+            width: 64,
+            height: 64,
+            borderRadius: '50%',
+            background: scoreBg(overallScore),
+            color: scoreColor(overallScore),
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontWeight: 800,
+            fontSize: 22,
+            flexShrink: 0,
+          }}
+        >
+          {overallScore}
+        </div>
+        <div>
+          <div style={{ fontWeight: 600, fontSize: 14, color: colors.textDark }}>
+            Overall Score
+          </div>
+          <div style={{ fontSize: 12, color: colors.textSecondary, marginTop: 2 }}>
+            {overallScore >= 80
+              ? 'Strong post — ready to publish'
+              : overallScore >= 60
+              ? 'Good post — could use some improvements'
+              : 'Needs work — review suggestions below'}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {dimensions.map((d, i) => (
+          <DimensionRow key={i} dim={d} />
+        ))}
+      </div>
+
+      <div
+        style={{
+          marginTop: 14,
+          padding: '10px 14px',
+          background: colors.badgeBg,
+          borderRadius: 8,
+          border: `1px solid ${colors.border}`,
+        }}
+      >
+        <div style={{ fontSize: 11, fontWeight: 700, color: colors.textMedium, marginBottom: 4, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+          Top Improvement
+        </div>
+        <div style={{ fontSize: 13, color: colors.textBody, lineHeight: 1.5 }}>
+          💡 {topImprovement}
+        </div>
+      </div>
+
+      {onApply && (
+        <div style={{ display: 'flex', gap: 8, marginTop: 14 }}>
+          <button
+            onClick={onApply}
+            style={{
+              padding: '8px 18px',
+              background: colors.primary,
+              color: '#fff',
+              border: 'none',
+              borderRadius: 8,
+              cursor: 'pointer',
+              fontSize: 13,
+              fontWeight: 600,
+            }}
+            aria-label="Apply suggestions"
+          >
+            Apply Suggestions
+          </button>
+          {onDismiss && (
+            <button
+              onClick={onDismiss}
+              style={{
+                padding: '8px 18px',
+                background: 'none',
+                color: colors.textTertiary,
+                border: `1px solid ${colors.border}`,
+                borderRadius: 8,
+                cursor: 'pointer',
+                fontSize: 13,
+                fontWeight: 500,
+              }}
+              aria-label="Dismiss preview score"
+            >
+              Dismiss
+            </button>
+          )}
+        </div>
+      )}
+
+      <div style={{ marginTop: 12 }}>
+        <DataSourceBadge label="Growth Engine" detail={dataSourceSummary} />
+      </div>
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// DimensionRow sub-component
+// ---------------------------------------------------------------------------
+interface DimensionRowProps {
+  dim: PostPreviewDimension;
+}
+
+const DimensionRow: React.FC<DimensionRowProps> = React.memo(({ dim }) => {
+  const color = scoreColor(dim.score);
+  const bg = scoreBg(dim.score);
+  const bar = barColor(dim.score);
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+        <span style={{ fontSize: 12, fontWeight: 600, color: colors.textBody }}>
+          {dim.dimension}
+        </span>
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color,
+            background: bg,
+            padding: '1px 8px',
+            borderRadius: 4,
+          }}
+        >
+          {dim.score}/100
+        </span>
+      </div>
+      <div
+        style={{
+          height: 6,
+          background: colors.border,
+          borderRadius: 3,
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            width: `${dim.score}%`,
+            height: '100%',
+            background: bar,
+            borderRadius: 3,
+            transition: 'width 0.6s ease',
+          }}
+        />
+      </div>
+      <div style={{ fontSize: 11, color: colors.textSecondary, marginTop: 3, lineHeight: 1.4 }}>
+        {dim.feedback}
+      </div>
+      <div style={{ fontSize: 10, color: colors.textTertiary, marginTop: 1 }}>
+        {dim.data_source_detail} · {dim.confidence} confidence
+      </div>
+    </div>
+  );
+});

--- a/frontend/src/components/LinkedInWriter/components/GrowthEngine/StrategyBriefCard.tsx
+++ b/frontend/src/components/LinkedInWriter/components/GrowthEngine/StrategyBriefCard.tsx
@@ -1,0 +1,212 @@
+import React from 'react';
+import type { DailyPostIdea } from '../../../../services/linkedInGrowthApi';
+import { DataSourceBadge } from './DataSourceBadge';
+import { EmptyState } from './EmptyState';
+import { cardBase, headerRow, dismissBtn, primaryBtn, rowBase, colors } from './styles';
+
+interface StrategyBriefCardProps {
+  theme: string;
+  weekOf: string;
+  dailyPosts: DailyPostIdea[];
+  keyTopics: string[];
+  focusArea: string;
+  dataSourceSummary: string;
+  onDismiss?: () => void;
+  onGeneratePost?: (params?: { topic?: string; context?: string }) => Promise<{ success: boolean; data?: any; error?: string }>;
+}
+
+const CONTENT_TYPE_COLORS: Record<string, string> = {
+  'How-to': '#0a66c2',
+  'Case study': '#9333ea',
+  'Hot take': '#dc2626',
+  'Personal story': '#059669',
+  'Roundup': '#d97706',
+  'Thought leadership': '#0891b2',
+  'Tutorial': '#0a66c2',
+};
+
+const CONTENT_TYPE_EMOJIS: Record<string, string> = {
+  'How-to': '🛠️',
+  'Case study': '📊',
+  'Hot take': '🔥',
+  'Personal story': '💭',
+  'Roundup': '📋',
+  'Thought leadership': '💡',
+  'Tutorial': '📝',
+};
+
+export const StrategyBriefCard: React.FC<StrategyBriefCardProps> = React.memo(({
+  theme,
+  weekOf,
+  dailyPosts,
+  keyTopics,
+  focusArea,
+  dataSourceSummary,
+  onDismiss,
+  onGeneratePost,
+}) => {
+  const formatDate = (iso: string) => {
+    const d = new Date(iso);
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  };
+
+  if (!dailyPosts || dailyPosts.length === 0) {
+    return <EmptyState icon="📅" message="Weekly strategy not available. Check back after connecting your LinkedIn account." />;
+  }
+
+  return (
+    <div style={cardBase}>
+      <div style={headerRow}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ fontSize: 20 }} aria-hidden="true">📅</span>
+          <div>
+            <div style={{ fontWeight: 700, fontSize: 15, color: colors.textDark }}>
+              Weekly Content Strategy
+            </div>
+            <div style={{ fontSize: 11, color: colors.textSecondary }}>
+              Week of {formatDate(weekOf)}
+            </div>
+          </div>
+        </div>
+        {onDismiss && (
+          <button onClick={onDismiss} style={dismissBtn} title="Dismiss" aria-label="Dismiss weekly strategy">
+            ✕
+          </button>
+        )}
+      </div>
+
+      <div
+        style={{
+          marginTop: 14,
+          padding: '10px 14px',
+          background: colors.badgeBg,
+          borderRadius: 8,
+          border: `1px solid ${colors.border}`,
+        }}
+      >
+        <div style={{ fontSize: 11, fontWeight: 700, color: colors.textMedium, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+          Weekly Theme
+        </div>
+        <div style={{ fontSize: 16, fontWeight: 700, color: colors.textDark, marginTop: 2 }}>
+          &ldquo;{theme}&rdquo;
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginTop: 14 }}>
+        {dailyPosts.map((post, i) => (
+          <DayRow
+            key={i}
+            post={post}
+            theme={theme}
+            onGeneratePost={onGeneratePost}
+          />
+        ))}
+      </div>
+
+      {keyTopics.length > 0 && (
+        <div style={{ marginTop: 14 }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: colors.textMedium, marginBottom: 6, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+            Key Topics to Cover
+          </div>
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            {keyTopics.map((t, i) => (
+              <span
+                key={i}
+                style={{
+                  padding: '3px 10px',
+                  background: '#eff6ff',
+                  color: '#1e40af',
+                  borderRadius: 12,
+                  fontSize: 11,
+                  fontWeight: 600,
+                  border: '1px solid #bfdbfe',
+                }}
+              >
+                {t}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div
+        style={{
+          marginTop: 14,
+          padding: '10px 14px',
+          background: '#faf5ff',
+          borderRadius: 8,
+          border: '1px solid #e9d5ff',
+        }}
+      >
+        <div style={{ fontSize: 11, fontWeight: 700, color: '#7c3aed', marginBottom: 2, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+          This Week's Focus
+        </div>
+        <div style={{ fontSize: 13, color: '#4c1d95', lineHeight: 1.5 }}>
+          🎯 {focusArea}
+        </div>
+      </div>
+
+      <div style={{ marginTop: 12 }}>
+        <DataSourceBadge label="Growth Engine" detail={dataSourceSummary} />
+      </div>
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// DayRow sub-component
+// ---------------------------------------------------------------------------
+interface DayRowProps {
+  post: DailyPostIdea;
+  theme: string;
+  onGeneratePost?: (params?: { topic?: string; context?: string }) => Promise<{ success: boolean; data?: any; error?: string }>;
+}
+
+const DayRow: React.FC<DayRowProps> = React.memo(({ post, theme, onGeneratePost }) => {
+  const color = CONTENT_TYPE_COLORS[post.content_type] || '#64748b';
+  const emoji = CONTENT_TYPE_EMOJIS[post.content_type] || '📌';
+
+  return (
+    <div style={rowBase}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+        <span style={{ fontWeight: 700, fontSize: 13, color: colors.textDark, minWidth: 50 }}>
+          {post.day}
+        </span>
+        <span
+          style={{
+            padding: '2px 8px',
+            background: `${color}15`,
+            color,
+            borderRadius: 4,
+            fontSize: 11,
+            fontWeight: 600,
+          }}
+        >
+          {emoji} {post.content_type}
+        </span>
+      </div>
+
+      <div style={{ fontWeight: 600, fontSize: 13, color: colors.textDark, marginBottom: 4 }}>
+        &ldquo;{post.headline}&rdquo;
+      </div>
+
+      <div style={{ fontSize: 12, color: colors.textSecondary, fontStyle: 'italic', marginBottom: 4 }}>
+        Hook: {post.hook}
+      </div>
+
+      <div style={{ fontSize: 11, color: colors.textMedium, lineHeight: 1.4 }}>
+        💡 {post.why_this_works}
+      </div>
+
+      {onGeneratePost && (
+        <button
+          onClick={() => onGeneratePost({ topic: post.headline, context: `Weekly strategy: ${post.day} - ${post.content_type} post. Theme: "${theme}". Hook: ${post.hook}` })}
+          style={{ ...primaryBtn, marginTop: 8 }}
+          aria-label={`Generate post for ${post.day}`}
+        >
+          Generate Post ✨
+        </button>
+      )}
+    </div>
+  );
+});

--- a/frontend/src/components/LinkedInWriter/components/GrowthEngine/TrendingTopicCard.tsx
+++ b/frontend/src/components/LinkedInWriter/components/GrowthEngine/TrendingTopicCard.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import type { TrendingTopicItem } from '../../../../services/linkedInGrowthApi';
+import { DataSourceBadge } from './DataSourceBadge';
+import { EmptyState } from './EmptyState';
+import { cardBase, headerRow, dismissBtn, roundBtn, colors } from './styles';
+
+interface TrendingTopicCardProps {
+  industry: string;
+  topics: TrendingTopicItem[];
+  dataSourceSummary: string;
+  onPostAbout: (topic: string, hook: string) => void;
+  onDismiss?: () => void;
+}
+
+export const TrendingTopicCard: React.FC<TrendingTopicCardProps> = React.memo(({
+  industry,
+  topics,
+  dataSourceSummary,
+  onPostAbout,
+  onDismiss,
+}) => {
+  if (!topics || topics.length === 0) {
+    return <EmptyState icon="📈" message="No trending topics available right now. Check back later." />;
+  }
+
+  return (
+    <div style={cardBase}>
+      <div style={headerRow}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ fontSize: 20 }} aria-hidden="true">📈</span>
+          <div>
+            <div style={{ fontWeight: 700, fontSize: 15, color: colors.textDark }}>
+              Trending Now in {industry}
+            </div>
+          </div>
+        </div>
+        {onDismiss && (
+          <button onClick={onDismiss} style={dismissBtn} title="Dismiss" aria-label="Dismiss trending topics">
+            ✕
+          </button>
+        )}
+      </div>
+
+      <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginTop: 12 }}>
+        {topics.map((t, i) => (
+          <div key={i} style={{
+            flex: '1 1 160px',
+            background: colors.rowBg,
+            border: `1px solid ${colors.border}`,
+            borderRadius: 10,
+            padding: '14px 12px',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            textAlign: 'center',
+            minWidth: 0,
+          }}>
+            <div style={{ fontSize: 22, marginBottom: 4 }} aria-hidden="true">
+              {t.emoji || '🔥'}
+            </div>
+            <div style={{ fontWeight: 700, fontSize: 13, color: colors.textDark, marginBottom: 2 }}>
+              {t.topic}
+            </div>
+            <div style={{ fontSize: 11, color: colors.textSecondary, marginBottom: 8, lineHeight: 1.4 }}>
+              {t.why_now}
+            </div>
+            <button
+              onClick={() => onPostAbout(t.topic, t.suggested_hook)}
+              style={roundBtn}
+              title={t.suggested_hook}
+              aria-label={`Create post about ${t.topic}`}
+            >
+              Post about {t.topic}
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ marginTop: 12 }}>
+        <DataSourceBadge label="Growth Engine" detail={dataSourceSummary} />
+      </div>
+    </div>
+  );
+});

--- a/frontend/src/components/LinkedInWriter/components/GrowthEngine/ViralAnalysisCard.tsx
+++ b/frontend/src/components/LinkedInWriter/components/GrowthEngine/ViralAnalysisCard.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import type { ViralPattern } from '../../../../services/linkedInGrowthApi';
+import { DataSourceBadge } from './DataSourceBadge';
+import { EmptyState } from './EmptyState';
+import { cardBase, headerRow, dismissBtn, rowBase, CONFIDENCE_COLORS, colors } from './styles';
+
+interface ViralAnalysisCardProps {
+  industry: string;
+  patterns: ViralPattern[];
+  topRecommendation: string;
+  dataSourceSummary: string;
+  onDismiss?: () => void;
+}
+
+const CONFIDENCE_LABELS: Record<string, string> = {
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+};
+
+export const ViralAnalysisCard: React.FC<ViralAnalysisCardProps> = React.memo(({
+  industry,
+  patterns,
+  topRecommendation,
+  dataSourceSummary,
+  onDismiss,
+}) => {
+  if (!patterns || patterns.length === 0) {
+    return <EmptyState icon="🔥" message={`No viral patterns available for ${industry} right now.`} />;
+  }
+
+  return (
+    <div style={cardBase}>
+      <div style={headerRow}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ fontSize: 20 }} aria-hidden="true">🔥</span>
+          <div style={{ fontWeight: 700, fontSize: 15, color: colors.textDark }}>
+            Viral Content Analysis
+          </div>
+        </div>
+        {onDismiss && (
+          <button onClick={onDismiss} style={dismissBtn} title="Dismiss" aria-label="Dismiss viral analysis">
+            ✕
+          </button>
+        )}
+      </div>
+
+      <div style={{ fontSize: 12, color: colors.textSecondary, marginTop: 2, marginLeft: 30 }}>
+        Patterns driving engagement in {industry}
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginTop: 14 }}>
+        {patterns.map((p, i) => (
+          <PatternRow key={i} pattern={p} />
+        ))}
+      </div>
+
+      <div
+        style={{
+          marginTop: 14,
+          padding: '10px 14px',
+          background: '#eff6ff',
+          borderRadius: 8,
+          border: '1px solid #bfdbfe',
+        }}
+      >
+        <div style={{ fontSize: 11, fontWeight: 700, color: '#1e40af', marginBottom: 4, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+          Recommended Action
+        </div>
+        <div style={{ fontSize: 13, color: '#1e3a5f', lineHeight: 1.5 }}>
+          🎯 {topRecommendation}
+        </div>
+      </div>
+
+      <div style={{ marginTop: 12 }}>
+        <DataSourceBadge label="Growth Engine" detail={dataSourceSummary} />
+      </div>
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// PatternRow sub-component
+// ---------------------------------------------------------------------------
+interface PatternRowProps {
+  pattern: ViralPattern;
+}
+
+const PatternRow: React.FC<PatternRowProps> = React.memo(({ pattern }) => {
+  const cc = CONFIDENCE_COLORS[pattern.confidence] || CONFIDENCE_COLORS.medium;
+
+  return (
+    <div style={rowBase}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 6 }}>
+        <div style={{ fontWeight: 700, fontSize: 14, color: colors.textDark }}>
+          📌 {pattern.pattern_name}
+        </div>
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: colors.successText,
+            background: colors.successBg,
+            padding: '2px 8px',
+            borderRadius: 4,
+            whiteSpace: 'nowrap',
+            flexShrink: 0,
+            marginLeft: 8,
+          }}
+        >
+          {pattern.engagement_multiplier}
+        </span>
+      </div>
+
+      <div style={{ fontSize: 12, color: colors.textMedium, lineHeight: 1.5, marginBottom: 8 }}>
+        {pattern.description}
+      </div>
+
+      <div
+        style={{
+          background: colors.white,
+          border: `1px solid ${colors.border}`,
+          borderRadius: 6,
+          padding: '8px 10px',
+          fontSize: 12,
+          color: colors.textBody,
+          marginBottom: 8,
+          fontStyle: 'italic',
+        }}
+      >
+        Example: "{pattern.example_headline}" — {pattern.example_author}
+      </div>
+
+      <div style={{ fontSize: 10, color: colors.textTertiary }}>
+        {pattern.data_source_detail} ·
+        <span
+          style={{
+            background: cc.bg,
+            color: cc.text,
+            padding: '1px 5px',
+            borderRadius: 3,
+            fontWeight: 600,
+            marginLeft: 4,
+          }}
+        >
+          {CONFIDENCE_LABELS[pattern.confidence]} confidence
+        </span>
+      </div>
+    </div>
+  );
+});

--- a/frontend/src/components/LinkedInWriter/components/GrowthEngine/index.ts
+++ b/frontend/src/components/LinkedInWriter/components/GrowthEngine/index.ts
@@ -1,0 +1,11 @@
+export { GrowthEnginePanel } from './GrowthEnginePanel';
+export { TrendingTopicCard } from './TrendingTopicCard';
+export { NetworkSuggestionCard } from './NetworkSuggestionCard';
+export { EngagementCard } from './EngagementCard';
+export { PreviewScoreCard } from './PreviewScoreCard';
+export { ViralAnalysisCard } from './ViralAnalysisCard';
+export { StrategyBriefCard } from './StrategyBriefCard';
+export { ContentGapCard } from './ContentGapCard';
+export { BrandScorecard } from './BrandScorecard';
+export { EmptyState } from './EmptyState';
+export { DataSourceBadge } from './DataSourceBadge';

--- a/frontend/src/components/LinkedInWriter/components/GrowthEngine/styles.ts
+++ b/frontend/src/components/LinkedInWriter/components/GrowthEngine/styles.ts
@@ -1,0 +1,114 @@
+import React from 'react';
+
+// Card layout
+export const cardBase: React.CSSProperties = {
+  background: '#ffffff',
+  border: '1px solid #e2e8f0',
+  borderRadius: 12,
+  padding: '16px 20px',
+  boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
+};
+
+export const headerRow: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'space-between',
+};
+
+export const dismissBtn: React.CSSProperties = {
+  background: 'none',
+  border: 'none',
+  color: '#94a3b8',
+  cursor: 'pointer',
+  fontSize: 16,
+  padding: '4px 8px',
+  borderRadius: 4,
+  lineHeight: 1,
+};
+
+// Row styles
+export const rowBase: React.CSSProperties = {
+  background: '#f8fafc',
+  border: '1px solid #e2e8f0',
+  borderRadius: 10,
+  padding: '14px 16px',
+};
+
+// Colors
+export const colors = {
+  white: '#ffffff',
+  cardBg: '#ffffff',
+  rowBg: '#f8fafc',
+  badgeBg: '#f0f4f8',
+  border: '#e2e8f0',
+  dashedBorder: '#d1d5db',
+  textDark: '#0f172a',
+  textMedium: '#475569',
+  textBody: '#334155',
+  textSecondary: '#64748b',
+  textTertiary: '#94a3b8',
+  textMuted: '#9ca3af',
+  primary: '#0a66c2',
+  primaryGreen: '#059669',
+  successBg: '#dcfce7',
+  successText: '#166534',
+} as const;
+
+// Button styles
+export const primaryBtn: React.CSSProperties = {
+  padding: '6px 14px',
+  background: colors.primary,
+  color: '#fff',
+  border: 'none',
+  borderRadius: 6,
+  cursor: 'pointer',
+  fontSize: 12,
+  fontWeight: 600,
+};
+
+export const secondaryBtn: React.CSSProperties = {
+  padding: '6px 14px',
+  background: 'none',
+  color: colors.textTertiary,
+  border: `1px solid ${colors.border}`,
+  borderRadius: 6,
+  cursor: 'pointer',
+  fontSize: 12,
+  fontWeight: 500,
+};
+
+export const greenBtn: React.CSSProperties = {
+  ...primaryBtn,
+  background: colors.primaryGreen,
+};
+
+export const roundBtn: React.CSSProperties = {
+  ...primaryBtn,
+  borderRadius: 20,
+  whiteSpace: 'nowrap',
+};
+
+// Score / confidence helpers
+export const CONFIDENCE_COLORS: Record<string, { bg: string; text: string }> = {
+  high: { bg: '#dcfce7', text: '#166534' },
+  medium: { bg: '#fef9c3', text: '#854d0e' },
+  low: { bg: '#fee2e2', text: '#991b1b' },
+};
+
+export function scoreColor(score: number, high = 75, mid = 50): string {
+  if (score >= high) return '#166534';
+  if (score >= mid) return '#854d0e';
+  return '#991b1b';
+}
+
+export function scoreBg(score: number, high = 75, mid = 50): string {
+  if (score >= high) return '#dcfce7';
+  if (score >= mid) return '#fef9c3';
+  return '#fee2e2';
+}
+
+export function barColor(score: number, high = 75, mid = 50): string {
+  if (score >= high) return '#22c55e';
+  if (score >= mid) return '#eab308';
+  return '#ef4444';
+}

--- a/frontend/src/components/OnboardingWizard/IntegrationsStep.tsx
+++ b/frontend/src/components/OnboardingWizard/IntegrationsStep.tsx
@@ -25,7 +25,6 @@ import {
   Facebook as FacebookIcon,
   Twitter as TwitterIcon,
   Instagram as InstagramIcon,
-  LinkedIn as LinkedInIcon,
   YouTube as YouTubeIcon,
   VideoLibrary as TikTokIcon,
   Pinterest as PinterestIcon,
@@ -211,17 +210,6 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
       features: ['Auto-tweeting', 'Trend analysis', 'Engagement tracking'],
       benefits: ['Automated Twitter posts', 'Trend monitoring', 'Audience insights'],
       isEnabled: false
-    },
-    {
-      id: 'linkedin',
-      name: 'LinkedIn',
-      description: 'Connect your LinkedIn profile for professional content publishing',
-      icon: <LinkedInIcon />,
-      category: 'social',
-      status: 'available',
-      features: ['Professional posting', 'Network insights', 'Content optimization'],
-      benefits: ['LinkedIn article publishing', 'Professional network analytics', 'B2B content insights'],
-      isEnabled: true
     },
     {
       id: 'instagram',
@@ -439,7 +427,6 @@ const IntegrationsStep: React.FC<IntegrationsStepProps> = ({ onContinue, updateH
     const socialIntegrations = {
       facebook: connectedPlatforms.includes('facebook'),
       twitter: connectedPlatforms.includes('twitter'),
-      linkedin: connectedPlatforms.includes('linkedin'),
       instagram: connectedPlatforms.includes('instagram'),
       youtube: connectedPlatforms.includes('youtube'),
       tiktok: connectedPlatforms.includes('tiktok'),

--- a/frontend/src/components/OnboardingWizard/WebsiteStep.tsx
+++ b/frontend/src/components/OnboardingWizard/WebsiteStep.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Box,
   Button,
@@ -23,7 +23,7 @@ import {
 // Extracted components
 import { AnalysisResultsDisplay, AnalysisProgressDisplay, WebsiteIntegrationsSection } from './WebsiteStep/components';
 import type { StyleAnalysis } from './WebsiteStep/components/AnalysisResultsDisplay';
-import LinkedInPlatformCard from './common/LinkedInPlatformCard';
+import PlatformSection from './common/PlatformSection';
 
 // Import API client for saving
 import { apiClient } from '../../api/client';
@@ -82,7 +82,9 @@ const WebsiteStep: React.FC<WebsiteStepProps> = ({ onContinue, updateHeaderConte
   const [hasCheckedExisting, setHasCheckedExisting] = useState(false);
   const [activeTab, setActiveTab] = useState<'website' | 'linkedin'>('website');
   const [integrationData, setIntegrationData] = useState<any>(null);
-  const [linkedinConnected, setLinkedinConnected] = useState(false);
+  const [connectedPlatforms, setConnectedPlatforms] = useState<string[]>([]);
+
+  const linkedinConnected = connectedPlatforms.includes('linkedin');
   const [isProgressModalOpen, setIsProgressModalOpen] = useState(false);
   const [progress, setProgress] = useState<AnalysisProgress[]>([
     { step: 1, message: 'Validating website URL & connection', subMessage: 'Ensuring your site is accessible and ready for analysis', completed: false },
@@ -359,27 +361,26 @@ const WebsiteStep: React.FC<WebsiteStepProps> = ({ onContinue, updateHeaderConte
     setIntegrationData(data);
   };
 
-  const handleLinkedInPlatformsChange = useCallback((platforms: string[]) => {
-    setLinkedinConnected(platforms.includes('linkedin'));
-  }, []);
-
   // Register data collector so the Wizard footer button is the single gate to step 3
   useEffect(() => {
     if (onDataReady) {
       onDataReady(() => {
         const fixedUrl = fixUrlFormat(website);
+        const integrationsPayload = integrationData || {
+          connectedPlatforms,
+          updatedAt: new Date().toISOString(),
+        };
         return {
           website: fixedUrl || website,
           domainName,
           analysis,
           crawlResult,
           useAnalysisForGenAI,
-          integrations: integrationData,
-          linkedinConnected,
+          integrations: integrationsPayload,
         };
       });
     }
-  }, [onDataReady, website, domainName, analysis, crawlResult, useAnalysisForGenAI, integrationData, linkedinConnected]);
+  }, [onDataReady, website, domainName, analysis, crawlResult, useAnalysisForGenAI, integrationData, connectedPlatforms]);
 
   const hasWebsiteAnalysis = !!(website.trim() && analysis);
 
@@ -601,6 +602,8 @@ const WebsiteStep: React.FC<WebsiteStepProps> = ({ onContinue, updateHeaderConte
           <WebsiteIntegrationsSection
             websiteUrl={website}
             onIntegrationChange={handleIntegrationChange}
+            connectedPlatforms={connectedPlatforms}
+            setConnectedPlatforms={setConnectedPlatforms}
           />
         </>
       )}
@@ -616,29 +619,28 @@ const WebsiteStep: React.FC<WebsiteStepProps> = ({ onContinue, updateHeaderConte
             boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
           }}
         >
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 2 }}>
-            <Box
-              sx={{
-                color: '#0A66C2',
-                bgcolor: '#ffffff',
-                p: 0.5,
-                borderRadius: 1,
-                border: '1px solid #e2e8f0',
-                display: 'flex',
-              }}
-            >
-              <LinkedInIcon fontSize="small" />
-            </Box>
-            <Typography variant="subtitle1" sx={{ fontWeight: 600, color: '#1e293b' }}>
-              LinkedIn
-            </Typography>
-          </Box>
-          <Typography variant="body2" sx={{ color: '#64748b', mb: 2 }}>
-            Connect your LinkedIn profile for professional content publishing.
-          </Typography>
-          <LinkedInPlatformCard
-            connectedPlatforms={linkedinConnected ? ['linkedin'] : []}
-            setConnectedPlatforms={handleLinkedInPlatformsChange}
+          <PlatformSection
+            title="LinkedIn"
+            description="Connect your LinkedIn profile for professional content publishing."
+            platforms={[
+              {
+                id: 'linkedin',
+                name: 'LinkedIn',
+                description: 'Connect your LinkedIn profile for professional content publishing',
+                icon: <LinkedInIcon />,
+                category: 'social',
+                status: 'available',
+                features: ['Professional posting', 'Network insights', 'Content optimization'],
+                benefits: ['LinkedIn article publishing', 'Professional network analytics', 'B2B content insights'],
+                isEnabled: true,
+              },
+            ]}
+            filterPlatformIds={['linkedin']}
+            connectedPlatforms={connectedPlatforms}
+            gscSites={null}
+            isLoading={false}
+            onConnect={() => {}}
+            setConnectedPlatforms={setConnectedPlatforms}
           />
         </Paper>
       )}

--- a/frontend/src/components/OnboardingWizard/WebsiteStep/components/WebsiteIntegrationsSection.tsx
+++ b/frontend/src/components/OnboardingWizard/WebsiteStep/components/WebsiteIntegrationsSection.tsx
@@ -44,6 +44,8 @@ interface IntegrationData {
 interface WebsiteIntegrationsSectionProps {
   websiteUrl: string;
   onIntegrationChange: (data: IntegrationData) => void;
+  connectedPlatforms: string[];
+  setConnectedPlatforms: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
 const WALKTHROUGH_TITLES: readonly string[] = [
@@ -71,8 +73,10 @@ const WALKTHROUGH_LABELS: readonly string[] = [
 const WebsiteIntegrationsSection: React.FC<WebsiteIntegrationsSectionProps> = ({
   websiteUrl,
   onIntegrationChange,
+  connectedPlatforms,
+  setConnectedPlatforms,
 }) => {
-  const { gscSites, connectedPlatforms, setConnectedPlatforms, handleGSCConnect } = useGSCConnection();
+  const { gscSites, connectedPlatforms: gscInternalPlatforms, handleGSCConnect } = useGSCConnection();
   const { isLoading, showToast, setShowToast, toastMessage, handleConnect } = usePlatformConnections();
   const { connected: wordpressConnected, sites: wordpressSites } = useWordPressOAuth();
   const { connected: bingConnected, sites: bingSites, connect: connectBing, refreshStatus: refreshBingStatus } = useBingOAuth();
@@ -84,18 +88,7 @@ const WebsiteIntegrationsSection: React.FC<WebsiteIntegrationsSectionProps> = ({
     cachedAnalyticsAPI.invalidateAll();
   }, []);
 
-  useEffect(() => {
-    if (wordpressConnected && wordpressSites.length > 0) {
-      if (!connectedPlatforms.includes('wordpress')) {
-        setConnectedPlatforms([...connectedPlatforms, 'wordpress']);
-        invalidateAnalyticsCache();
-      }
-    } else if (!wordpressConnected && connectedPlatforms.includes('wordpress')) {
-      setConnectedPlatforms(connectedPlatforms.filter(p => p !== 'wordpress'));
-      invalidateAnalyticsCache();
-    }
-  }, [wordpressConnected, wordpressSites, connectedPlatforms, setConnectedPlatforms, invalidateAnalyticsCache]);
-
+  // Refresh Bing status on mount
   useEffect(() => {
     (async () => {
       try {
@@ -106,17 +99,37 @@ const WebsiteIntegrationsSection: React.FC<WebsiteIntegrationsSectionProps> = ({
     })();
   }, [refreshBingStatus]);
 
+  // Consolidate platform sync: WordPress, Bing, and GSC all follow the same pattern
   useEffect(() => {
-    if (bingConnected && bingSites.length > 0) {
-      if (!connectedPlatforms.includes('bing')) {
-        setConnectedPlatforms([...connectedPlatforms, 'bing']);
-        invalidateAnalyticsCache();
+    const updated = [...connectedPlatforms];
+    let changed = false;
+
+    const sync = (platformId: string, isConnected: boolean, hasSites: boolean) => {
+      if (isConnected && hasSites) {
+        if (!updated.includes(platformId)) {
+          updated.push(platformId);
+          changed = true;
+        }
+      } else if (!isConnected && updated.includes(platformId)) {
+        updated.splice(updated.indexOf(platformId), 1);
+        changed = true;
       }
-    } else if (!bingConnected && connectedPlatforms.includes('bing')) {
-      setConnectedPlatforms(connectedPlatforms.filter(p => p !== 'bing'));
+    };
+
+    sync('wordpress', wordpressConnected, wordpressSites.length > 0);
+    sync('bing', bingConnected, bingSites.length > 0);
+    sync('gsc', gscInternalPlatforms.includes('gsc'), true);
+
+    if (changed) {
+      setConnectedPlatforms(updated);
       invalidateAnalyticsCache();
     }
-  }, [bingConnected, bingSites, connectedPlatforms, setConnectedPlatforms, invalidateAnalyticsCache]);
+  }, [
+    wordpressConnected, wordpressSites,
+    bingConnected, bingSites,
+    gscInternalPlatforms,
+    connectedPlatforms, setConnectedPlatforms, invalidateAnalyticsCache,
+  ]);
 
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);

--- a/frontend/src/components/OnboardingWizard/Wizard.tsx
+++ b/frontend/src/components/OnboardingWizard/Wizard.tsx
@@ -88,8 +88,8 @@ const Wizard: React.FC<WizardProps> = ({ onComplete }) => {
     trace(`Wizard: Validating step ${step} with data:`, data);
     
     switch (step) {
-      case 0: // Website Analysis
-        return !!(data && (data.website || data.website_url));
+      case 0: // Website Analysis — website URL or LinkedIn connection is sufficient
+        return !!(data && (data.website || data.website_url || data?.integrations?.connectedPlatforms?.includes('linkedin')));
       
       case 1: // Competitor Analysis
         return !!(data && (data.competitors || data.researchSummary || data.sitemapAnalysis));
@@ -577,7 +577,6 @@ const Wizard: React.FC<WizardProps> = ({ onComplete }) => {
     const hasCoreStepData = currentStepData && typeof currentStepData === 'object' && (
       currentStepData.website || 
       currentStepData.businessData || 
-      currentStepData.linkedinConnected ||
       currentStepData.competitors ||
       currentStepData.researchSummary ||
       currentStepData.sitemapAnalysis ||

--- a/frontend/src/components/OnboardingWizard/common/LinkedInPlatformCard.tsx
+++ b/frontend/src/components/OnboardingWizard/common/LinkedInPlatformCard.tsx
@@ -10,6 +10,8 @@ import React, { useEffect, useState } from 'react';
 
 import {
 
+  Avatar,
+
   Box,
 
   Card,
@@ -83,6 +85,14 @@ const LinkedInPlatformCard: React.FC<LinkedInPlatformCardProps> = ({
     hasPerUserToken,
 
     accountName,
+
+    displayName,
+
+    avatarUrl,
+
+    primaryProfile,
+
+    profileLoadWarning,
 
     accounts,
 
@@ -288,11 +298,75 @@ const LinkedInPlatformCard: React.FC<LinkedInPlatformCardProps> = ({
 
         <Box mt={1} display="flex" flexDirection="column" gap={1.5}>
 
-          {accountName && (
+          <Box display="flex" alignItems="center" gap={1.5} mb={1}>
 
-            <Typography variant="caption" sx={{ color: '#334155' }}>
+            {avatarUrl ? (
 
-              {accountName}
+              <Avatar src={avatarUrl} alt={displayName} sx={{ width: 40, height: 40 }} />
+
+            ) : (
+
+              <Box
+
+                sx={{
+
+                  width: 40,
+
+                  height: 40,
+
+                  borderRadius: '50%',
+
+                  bgcolor: '#0A66C2',
+
+                  display: 'flex',
+
+                  alignItems: 'center',
+
+                  justifyContent: 'center',
+
+                  color: '#fff',
+
+                  fontSize: 16,
+
+                  fontWeight: 700,
+
+                }}
+
+              >
+
+                {(displayName || accountName || 'L')[0]}
+
+              </Box>
+
+            )}
+
+            <Box>
+
+              <Typography variant="subtitle2" sx={{ fontWeight: 600, color: '#1e293b', lineHeight: 1.3 }}>
+
+                {displayName || accountName || 'LinkedIn account'}
+
+              </Typography>
+
+              {primaryProfile?.accountTypeLabel && (
+
+                <Typography variant="caption" sx={{ color: '#64748b' }}>
+
+                  {primaryProfile.accountTypeLabel}
+
+                </Typography>
+
+              )}
+
+            </Box>
+
+          </Box>
+
+          {profileLoadWarning && (
+
+            <Typography variant="caption" sx={{ color: '#b91c1c', display: 'block', mb: 1 }}>
+
+              {profileLoadWarning}
 
             </Typography>
 

--- a/frontend/src/components/OnboardingWizard/common/PlatformSection.tsx
+++ b/frontend/src/components/OnboardingWizard/common/PlatformSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   Box,
   Typography,
@@ -47,6 +47,7 @@ interface PlatformSectionProps {
   onDisconnect?: (platformId: string) => void;
   setConnectedPlatforms?: (platforms: string[]) => void;
   fadeTimeout?: number;
+  filterPlatformIds?: string[];
 }
 
 const PlatformSection: React.FC<PlatformSectionProps> = ({
@@ -59,7 +60,8 @@ const PlatformSection: React.FC<PlatformSectionProps> = ({
   onConnect,
   onDisconnect,
   setConnectedPlatforms,
-  fadeTimeout = 800
+  fadeTimeout = 800,
+  filterPlatformIds,
 }) => {
   const getStatusColor = (status: string) => {
     switch (status) {
@@ -91,10 +93,20 @@ const PlatformSection: React.FC<PlatformSectionProps> = ({
     }
   };
 
-  const platformsWithStatus = platforms.map(platform => ({
-    ...platform,
-    status: connectedPlatforms.includes(platform.id) ? 'connected' : platform.status
-  }));
+  const visiblePlatforms = useMemo(
+    () => filterPlatformIds
+      ? platforms.filter(p => filterPlatformIds.includes(p.id))
+      : platforms,
+    [platforms, filterPlatformIds],
+  );
+
+  const platformsWithStatus = useMemo(
+    () => visiblePlatforms.map(platform => ({
+      ...platform,
+      status: connectedPlatforms.includes(platform.id) ? 'connected' : platform.status,
+    })),
+    [visiblePlatforms, connectedPlatforms],
+  );
 
   return (
     <Box sx={{ mb: 4 }}>

--- a/frontend/src/services/linkedInGrowthApi.ts
+++ b/frontend/src/services/linkedInGrowthApi.ts
@@ -1,0 +1,232 @@
+import { aiApiClient } from '../api/client';
+
+// ---------------------------------------------------------------------------
+// Types — Trending Topics
+// ---------------------------------------------------------------------------
+export interface TrendingTopicItem {
+  topic: string;
+  emoji: string;
+  why_now: string;
+  suggested_hook: string;
+  data_source_detail: string;
+  confidence: 'high' | 'medium' | 'low';
+}
+
+export interface TrendingTopicsResponse {
+  industry: string;
+  trending_topics: TrendingTopicItem[];
+  data_source_summary: string;
+  generated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Types — Network Suggestions
+// ---------------------------------------------------------------------------
+export interface NetworkSuggestionItem {
+  name: string;
+  title: string;
+  company: string;
+  why_connect: string;
+  suggested_note: string;
+  data_source_detail: string;
+  confidence: 'high' | 'medium' | 'low';
+}
+
+export interface NetworkSuggestionsResponse {
+  suggestions: NetworkSuggestionItem[];
+  data_source_summary: string;
+  generated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Types — Engagement Opportunities
+// ---------------------------------------------------------------------------
+export interface EngagementOpportunityItem {
+  title: string;
+  author: string;
+  author_context: string;
+  why_engage: string;
+  suggested_comment: string;
+  data_source_detail: string;
+  confidence: 'high' | 'medium' | 'low';
+}
+
+export interface EngagementOpportunitiesResponse {
+  opportunities: EngagementOpportunityItem[];
+  data_source_summary: string;
+  generated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Types — Post Preview Score
+// ---------------------------------------------------------------------------
+export interface PostPreviewDimension {
+  dimension: string;
+  score: number;
+  feedback: string;
+  data_source_detail: string;
+  confidence: 'high' | 'medium' | 'low';
+}
+
+export interface PostPreviewScoreResponse {
+  overall_score: number;
+  dimensions: PostPreviewDimension[];
+  top_improvement: string;
+  data_source_summary: string;
+  generated_at: string;
+}
+
+export interface PreviewScoreRequest {
+  content: string;
+  context?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Types — Viral Content Analysis
+// ---------------------------------------------------------------------------
+export interface ViralPattern {
+  pattern_name: string;
+  description: string;
+  engagement_multiplier: string;
+  example_headline: string;
+  example_author: string;
+  data_source_detail: string;
+  confidence: 'high' | 'medium' | 'low';
+}
+
+export interface ViralAnalysisResponse {
+  industry: string;
+  patterns: ViralPattern[];
+  top_recommendation: string;
+  data_source_summary: string;
+  generated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Types — Weekly Content Strategy
+// ---------------------------------------------------------------------------
+export interface DailyPostIdea {
+  day: string;
+  content_type: string;
+  headline: string;
+  hook: string;
+  why_this_works: string;
+  data_source_detail: string;
+  confidence: 'high' | 'medium' | 'low';
+}
+
+export interface WeeklyStrategyResponse {
+  theme: string;
+  week_of: string;
+  daily_posts: DailyPostIdea[];
+  key_topics: string[];
+  focus_area: string;
+  data_source_summary: string;
+  generated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Types — Content Gap Analyzer
+// ---------------------------------------------------------------------------
+export interface ContentGapItem {
+  gap_topic: string;
+  why_gap: string;
+  why_it_matters: string;
+  suggested_angle: string;
+  data_source_detail: string;
+  confidence: 'high' | 'medium' | 'low';
+}
+
+export interface ContentGapsResponse {
+  gaps: ContentGapItem[];
+  data_source_summary: string;
+  generated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Types — Brand Scorecard
+// ---------------------------------------------------------------------------
+export interface BrandDimension {
+  dimension: string;
+  score: number;
+  feedback: string;
+  data_source_detail: string;
+  confidence: 'high' | 'medium' | 'low';
+}
+
+export interface BrandScorecardResponse {
+  overall_score: number;
+  dimensions: BrandDimension[];
+  top_recommendation: string;
+  data_source_summary: string;
+  generated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Types — Consolidated Growth Response
+// ---------------------------------------------------------------------------
+export interface ConsolidatedGrowthResponse {
+  trending: TrendingTopicsResponse | null;
+  network_suggestions: NetworkSuggestionsResponse | null;
+  engagement_opportunities: EngagementOpportunitiesResponse | null;
+  viral_analysis: ViralAnalysisResponse | null;
+  weekly_strategy: WeeklyStrategyResponse | null;
+  content_gaps: ContentGapsResponse | null;
+  brand_scorecard: BrandScorecardResponse | null;
+  generated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Growth Engine API client — uses aiApiClient for longer timeout (180s)
+// ---------------------------------------------------------------------------
+const BASE = '/api/linkedin/growth';
+const client = aiApiClient;
+
+export const linkedInGrowthApi = {
+  /** Single consolidated call that loads all growth insights at once. */
+  async analyzeAll(): Promise<ConsolidatedGrowthResponse> {
+    const { data } = await client.post<ConsolidatedGrowthResponse>(`${BASE}/analyze-all`);
+    return data;
+  },
+
+  /** Per-card refresh endpoints — kept for individual card refresh. */
+  async getTrendingTopics(): Promise<TrendingTopicsResponse> {
+    const { data } = await client.post<TrendingTopicsResponse>(`${BASE}/trending`);
+    return data;
+  },
+
+  async getNetworkSuggestions(): Promise<NetworkSuggestionsResponse> {
+    const { data } = await client.post<NetworkSuggestionsResponse>(`${BASE}/network-suggestions`);
+    return data;
+  },
+
+  async getEngagementOpportunities(): Promise<EngagementOpportunitiesResponse> {
+    const { data } = await client.post<EngagementOpportunitiesResponse>(`${BASE}/engagement-opportunities`);
+    return data;
+  },
+
+  async getPostPreviewScore(params: PreviewScoreRequest): Promise<PostPreviewScoreResponse> {
+    const { data } = await client.post<PostPreviewScoreResponse>(`${BASE}/preview-score`, params);
+    return data;
+  },
+
+  async getViralAnalysis(): Promise<ViralAnalysisResponse> {
+    const { data } = await client.post<ViralAnalysisResponse>(`${BASE}/viral-analysis`);
+    return data;
+  },
+
+  async getWeeklyStrategy(): Promise<WeeklyStrategyResponse> {
+    const { data } = await client.post<WeeklyStrategyResponse>(`${BASE}/weekly-strategy`);
+    return data;
+  },
+
+  async getContentGaps(): Promise<ContentGapsResponse> {
+    const { data } = await client.post<ContentGapsResponse>(`${BASE}/content-gaps`);
+    return data;
+  },
+
+  async getBrandScorecard(): Promise<BrandScorecardResponse> {
+    const { data } = await client.get<BrandScorecardResponse>(`${BASE}/brand-scorecard`);
+    return data;
+  },
+};


### PR DESCRIPTION
## Summary

Consolidates LinkedIn OAuth exclusively into Step 1's LinkedIn tab via the common PlatformSection pattern, unifies connection state so Step 1 has a single source of truth, and displays the connected LinkedIn profile in the LinkedIn tab.

## Changes

### State Unification (Phases 2-3)
- WebsiteIntegrationsSection now accepts connectedPlatforms/setConnectedPlatforms as props instead of using internal useGSCConnection state
- Added GSC sync effect to bridge useGSCConnection internal state to the unified state
- linkedinConnected is now derived from connectedPlatforms.includes('linkedin') — single source of truth
- Consolidated repeated WordPress/Bing/GSC sync effects into one with a local sync() helper
- Memoized filter/status logic in PlatformSection

### Cleanup (Phase 4)
- Removed orphaned linkedinConnected from onDataReady output and Wizard checks
- isStepDataValid now reads from integrations.connectedPlatforms instead
- LinkedIn removed entirely from Step 5 (IntegrationsStep)

### Profile Display
- Added avatar, display name, and account type label to LinkedInPlatformCard in the connected state

## Files Changed
IntegrationsStep.tsx, WebsiteStep.tsx, WebsiteIntegrationsSection.tsx, Wizard.tsx, PlatformSection.tsx, LinkedInPlatformCard.tsx