### PR TITLE
Fix ESLint no-unused-expressions error in GrowthEnginePanel

### DIFF
--- a/frontend/src/components/LinkedInWriter/components/GrowthEngine/GrowthEnginePanel.tsx
+++ b/frontend/src/components/LinkedInWriter/components/GrowthEngine/GrowthEnginePanel.tsx
@@ -458,7 +458,7 @@ export const GrowthEnginePanel: React.FC<GrowthEnginePanelProps> = ({
   const isStale = oldestMs > 0 && (Date.now() - oldestMs) > 30 * 60 * 1000;
 
   const formatTimeAgo = (dateStr: string | null | undefined): string => {
-    tick; // reference tick to ensure re-render when interval fires
+    void tick; // reference tick to ensure re-render when interval fires
     if (!dateStr) return '';
     const ms = Date.now() - new Date(dateStr).getTime();
     const min = Math.floor(ms / 60000);


### PR DESCRIPTION
## Summary
Fixes the ESLint error `@typescript-eslint/no-unused-expressions` on line 461 of `GrowthEnginePanel.tsx`.

## Change
- Added `void` operator before `tick` expression to satisfy ESLint rule
- This ensures the expression is properly marked as intentionally unused while preserving the re-render behavior

## Related Error
```
Expected an assignment or function call and instead saw an expression
@typescript-eslint/no-unused-expressions
```
