### PR TITLE
feat(linkedin): guided studio tour (react-joyride)

### DIFF
--- a/frontend/src/components/LinkedInWriter/components/LinkedInConnectionPlaceholder.tsx
+++ b/frontend/src/components/LinkedInWriter/components/LinkedInConnectionPlaceholder.tsx
@@ -295,6 +295,12 @@ const ConnectionLoadingState: React.FC<{ centered?: boolean }> = ({ centered = f
   </div>
 );
 
+const ConnectTourAnchor: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div data-tour="li-connect-action" style={{ display: 'inline-flex' }}>
+    {children}
+  </div>
+);
+
 export const LinkedInPlanConnectAction: React.FC<LinkedInPlanConnectActionProps> = ({
   social,
   isDisconnecting = false,
@@ -318,18 +324,20 @@ export const LinkedInPlanConnectAction: React.FC<LinkedInPlanConnectActionProps>
 
   if (isLoading) {
     return (
-      <button
-        type="button"
-        disabled
-        aria-busy="true"
-        style={{
-          ...CONNECT_BUTTON_STYLE,
-          opacity: 0.82,
-          cursor: 'default',
-        }}
-      >
-        Checking connection...
-      </button>
+      <ConnectTourAnchor>
+        <button
+          type="button"
+          disabled
+          aria-busy="true"
+          style={{
+            ...CONNECT_BUTTON_STYLE,
+            opacity: 0.82,
+            cursor: 'default',
+          }}
+        >
+          Checking connection...
+        </button>
+      </ConnectTourAnchor>
     );
   }
 
@@ -342,31 +350,33 @@ export const LinkedInPlanConnectAction: React.FC<LinkedInPlanConnectActionProps>
           message={disconnectError ?? ''}
           onClose={dismissError}
         />
-        <button
-          type="button"
-          onClick={() => void onDisconnect()}
-          disabled={isDisconnecting}
-          title={isDisconnecting ? 'Disconnecting...' : 'Disconnect LinkedIn'}
-          aria-label={isDisconnecting ? 'Disconnecting LinkedIn' : 'Disconnect LinkedIn'}
-          style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 8,
-            padding: '10px 24px',
-            borderRadius: 10,
-            border: '2px solid #fecaca',
-            backgroundColor: '#fff',
-            color: '#b91c1c',
-            fontSize: 14,
-            fontWeight: 700,
-            cursor: isDisconnecting ? 'default' : 'pointer',
-            opacity: isDisconnecting ? 0.7 : 1,
-            boxShadow: '0 4px 14px rgba(185, 28, 28, 0.12)',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {isDisconnecting ? 'Disconnecting...' : 'Disconnect LinkedIn'}
-        </button>
+        <ConnectTourAnchor>
+          <button
+            type="button"
+            onClick={() => void onDisconnect()}
+            disabled={isDisconnecting}
+            title={isDisconnecting ? 'Disconnecting...' : 'Disconnect LinkedIn'}
+            aria-label={isDisconnecting ? 'Disconnecting LinkedIn' : 'Disconnect LinkedIn'}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '10px 24px',
+              borderRadius: 10,
+              border: '2px solid #fecaca',
+              backgroundColor: '#fff',
+              color: '#b91c1c',
+              fontSize: 14,
+              fontWeight: 700,
+              cursor: isDisconnecting ? 'default' : 'pointer',
+              opacity: isDisconnecting ? 0.7 : 1,
+              boxShadow: '0 4px 14px rgba(185, 28, 28, 0.12)',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {isDisconnecting ? 'Disconnecting...' : 'Disconnect LinkedIn'}
+          </button>
+        </ConnectTourAnchor>
       </>
     );
   }
@@ -381,19 +391,21 @@ export const LinkedInPlanConnectAction: React.FC<LinkedInPlanConnectActionProps>
         onRetry={modalError ? handleConnect : undefined}
         isRetrying={isConnecting}
       />
-      <button
-        type="button"
-        onClick={handleConnect}
-        disabled={isConnecting}
-        style={{
-          ...CONNECT_BUTTON_STYLE,
-          cursor: isConnecting ? 'default' : 'pointer',
-          opacity: isConnecting ? 0.7 : 1,
-          boxShadow: '0 6px 20px rgba(10, 102, 194, 0.35)',
-        }}
-      >
-        {isConnecting ? 'Connecting...' : 'Connect LinkedIn'}
-      </button>
+      <ConnectTourAnchor>
+        <button
+          type="button"
+          onClick={handleConnect}
+          disabled={isConnecting}
+          style={{
+            ...CONNECT_BUTTON_STYLE,
+            cursor: isConnecting ? 'default' : 'pointer',
+            opacity: isConnecting ? 0.7 : 1,
+            boxShadow: '0 6px 20px rgba(10, 102, 194, 0.35)',
+          }}
+        >
+          {isConnecting ? 'Connecting...' : 'Connect LinkedIn'}
+        </button>
+      </ConnectTourAnchor>
     </>
   );
 };

--- a/frontend/src/components/LinkedInWriter/components/WelcomeMessage.tsx
+++ b/frontend/src/components/LinkedInWriter/components/WelcomeMessage.tsx
@@ -16,6 +16,8 @@ import {
   type WorkflowModalId,
 } from './dashboard/WorkflowActionModals';
 import { DashboardSimpleErrorModal } from './dashboard/DashboardSimpleErrorModal';
+import { LinkedInStudioTour } from './dashboard/LinkedInStudioTour';
+import { LINKEDIN_STUDIO_TOUR_SEEN_KEY } from '../../../utils/walkthroughs/linkedInStudioTourSteps';
 import { useLinkedInSocialConnection } from '../../../hooks/useLinkedInSocialConnection';
 
 interface WelcomeMessageProps {
@@ -44,8 +46,9 @@ export const WelcomeMessage: React.FC<WelcomeMessageProps> = ({
   const [watchdogOpen, setWatchdogOpen] = useState(false);
   const [copilotError, setCopilotError] = useState<string | null>(null);
   const [isDisconnecting, setIsDisconnecting] = useState(false);
+  const [runStudioTour, setRunStudioTour] = useState(false);
   const social = useLinkedInSocialConnection();
-  const { connected, connectWithOAuth, disconnect } = social;
+  const { connected, connectWithOAuth, disconnect, isLoading: isSocialLoading } = social;
 
   const handleDisconnect = useCallback(async () => {
     if (!window.confirm('Disconnect LinkedIn? You can reconnect anytime.')) {
@@ -70,6 +73,20 @@ export const WelcomeMessage: React.FC<WelcomeMessageProps> = ({
     window.addEventListener('linkedinwriter:openWatchdog', onOpenWatchdog);
     return () => window.removeEventListener('linkedinwriter:openWatchdog', onOpenWatchdog);
   }, []);
+
+  useEffect(() => {
+    const onStartTour = () => setRunStudioTour(true);
+    window.addEventListener('linkedinwriter:startStudioTour', onStartTour);
+    return () => window.removeEventListener('linkedinwriter:startStudioTour', onStartTour);
+  }, []);
+
+  useEffect(() => {
+    if (isSocialLoading) return;
+    if (localStorage.getItem(LINKEDIN_STUDIO_TOUR_SEEN_KEY)) return;
+
+    const timer = window.setTimeout(() => setRunStudioTour(true), 800);
+    return () => window.clearTimeout(timer);
+  }, [isSocialLoading]);
 
   useEffect(() => {
     const requireConnection = (event: Event) => {
@@ -194,6 +211,18 @@ export const WelcomeMessage: React.FC<WelcomeMessageProps> = ({
           color: '#666',
         }}
       >
+        <button
+          type="button"
+          className="linkedin-studio-tour-trigger"
+          data-tour="li-tour-trigger"
+          onClick={() => setRunStudioTour(true)}
+          aria-label="How to use LinkedIn Studio — start guided tour"
+          title="How to use LinkedIn Studio"
+        >
+          <span aria-hidden>?</span>
+          <span className="linkedin-studio-tour-trigger-label">Tour</span>
+        </button>
+
         <LinkedInDashboardHero
           onWorkflowCardAction={handleWorkflowCardAction}
           planAnchorSlot={
@@ -278,6 +307,8 @@ export const WelcomeMessage: React.FC<WelcomeMessageProps> = ({
         message={copilotError ?? ''}
         onClose={() => setCopilotError(null)}
       />
+
+      <LinkedInStudioTour run={runStudioTour} onRunChange={setRunStudioTour} />
     </div>
   );
 };

--- a/frontend/src/components/LinkedInWriter/components/dashboard/DashboardRadialWorkflow.tsx
+++ b/frontend/src/components/LinkedInWriter/components/dashboard/DashboardRadialWorkflow.tsx
@@ -189,6 +189,7 @@ export const DashboardRadialWorkflow: React.FC<DashboardRadialWorkflowProps> = (
       <g
         key={card.id}
         className="workflow-wedge"
+        data-tour={`li-wedge-${card.id}`}
         transform={wedgeTransform(
           centerX,
           centerY,

--- a/frontend/src/components/LinkedInWriter/components/dashboard/LinkedInDashboardHero.tsx
+++ b/frontend/src/components/LinkedInWriter/components/dashboard/LinkedInDashboardHero.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { DashboardRadialWorkflow } from './DashboardRadialWorkflow';
 import type { DashboardWorkflowCardId } from './dashboardWorkflowConfig';
-import { computeRadialLayout, layoutYToPixel, PLAN_CONNECT_UI_LIFT_PX } from './dashboardRadialLayout';
+import { computeRadialLayout, layoutYToPixel, PLAN_CONNECT_UI_LIFT_PX, ringSpotlightDiameter } from './dashboardRadialLayout';
 
 interface LinkedInDashboardHeroProps {
   children: React.ReactNode;
@@ -46,6 +46,8 @@ export const LinkedInDashboardHero: React.FC<LinkedInDashboardHeroProps> = ({
   );
   const hubTop = layoutYToPixel(layout.centerY + layout.hubOffsetY, layout.viewBoxY);
   const planAnchorTop = layoutYToPixel(layout.planAnchorY, layout.viewBoxY);
+  const ringCenterTop = layoutYToPixel(layout.centerY, layout.viewBoxY);
+  const lifecycleSpotlightSize = ringSpotlightDiameter(layout.outerR);
 
   return (
     <div
@@ -75,6 +77,22 @@ export const LinkedInDashboardHero: React.FC<LinkedInDashboardHeroProps> = ({
         }}
       >
         <DashboardRadialWorkflow layout={layout} onCardAction={onWorkflowCardAction} />
+
+        {/* Invisible tour anchors — tight bounds for Joyride spotlight */}
+        <div
+          data-tour="li-content-lifecycle"
+          className="linkedin-tour-lifecycle-spotlight"
+          aria-hidden
+          style={{
+            position: 'absolute',
+            left: '50%',
+            top: ringCenterTop,
+            width: lifecycleSpotlightSize,
+            height: lifecycleSpotlightSize,
+            transform: 'translate(-50%, -50%)',
+            pointerEvents: 'none',
+          }}
+        />
         <div
           className="linkedin-dashboard-hero-hub"
           style={{

--- a/frontend/src/components/LinkedInWriter/components/dashboard/LinkedInStudioTour.tsx
+++ b/frontend/src/components/LinkedInWriter/components/dashboard/LinkedInStudioTour.tsx
@@ -1,0 +1,102 @@
+import React, { useCallback } from 'react';
+import Joyride, { CallBackProps, STATUS } from 'react-joyride';
+import {
+  linkedInStudioTourSteps,
+  LINKEDIN_STUDIO_TOUR_SEEN_KEY,
+} from '../../../../utils/walkthroughs/linkedInStudioTourSteps';
+
+interface LinkedInStudioTourProps {
+  run: boolean;
+  onRunChange: (run: boolean) => void;
+}
+
+const JOYRIDE_STYLES = {
+  options: {
+    primaryColor: '#0a66c2',
+    textColor: '#1e293b',
+    backgroundColor: '#ffffff',
+    overlayColor: 'rgba(15, 23, 42, 0.55)',
+    zIndex: 13000,
+    arrowColor: '#ffffff',
+    width: 300,
+  },
+  tooltip: {
+    borderRadius: 12,
+    padding: '14px 16px',
+    boxShadow: '0 16px 48px rgba(10, 102, 194, 0.18)',
+    maxWidth: 300,
+  },
+  tooltipTitle: {
+    fontSize: 15,
+    fontWeight: 700,
+    marginBottom: 4,
+  },
+  tooltipContent: {
+    fontSize: 13,
+    lineHeight: 1.5,
+    padding: '2px 0 0',
+  },
+  buttonNext: {
+    borderRadius: 8,
+    fontSize: 13,
+    fontWeight: 700,
+    padding: '7px 12px',
+  },
+  buttonBack: {
+    color: '#64748b',
+    fontSize: 13,
+    marginRight: 8,
+  },
+  buttonSkip: {
+    color: '#64748b',
+    fontSize: 12,
+  },
+  spotlight: {
+    borderRadius: 12,
+  },
+} as const;
+
+export const LinkedInStudioTour: React.FC<LinkedInStudioTourProps> = ({ run, onRunChange }) => {
+  const handleCallback = useCallback(
+    (data: CallBackProps) => {
+      const { status } = data;
+      if (status === STATUS.FINISHED || status === STATUS.SKIPPED) {
+        localStorage.setItem(LINKEDIN_STUDIO_TOUR_SEEN_KEY, 'true');
+        onRunChange(false);
+      }
+    },
+    [onRunChange]
+  );
+
+  return (
+    <Joyride
+      steps={linkedInStudioTourSteps}
+      run={run}
+      continuous
+      showProgress
+      showSkipButton
+      scrollToFirstStep={false}
+      disableScrolling
+      spotlightPadding={8}
+      spotlightClicks={false}
+      disableOverlayClose
+      floaterProps={{
+        options: {
+          preventOverflow: {
+            boundariesElement: 'viewport',
+            padding: 12,
+          },
+        },
+      }}
+      locale={{
+        back: 'Back',
+        close: 'Close',
+        last: 'Done',
+        next: 'Next',
+        skip: 'Skip tour',
+      }}
+      styles={JOYRIDE_STYLES}
+      callback={handleCallback}
+    />
+  );
+};

--- a/frontend/src/components/LinkedInWriter/components/dashboard/dashboardRadialLayout.ts
+++ b/frontend/src/components/LinkedInWriter/components/dashboard/dashboardRadialLayout.ts
@@ -190,3 +190,13 @@ export function computeRadialLayout(containerWidth: number, maxHeight?: number):
 export function layoutYToPixel(y: number, viewBoxY: number): number {
   return y - viewBoxY;
 }
+
+/** Outer visual radius of the wedge ring (includes convex bulge). */
+export function ringOuterVisualRadius(outerR: number): number {
+  return outerR * (1 + OUTER_BULGE_FACTOR);
+}
+
+/** Square spotlight diameter that bounds the six workflow wedges only. */
+export function ringSpotlightDiameter(outerR: number): number {
+  return Math.round(ringOuterVisualRadius(outerR) * 2 + 4);
+}

--- a/frontend/src/components/LinkedInWriter/styles/alwrity-copilot.css
+++ b/frontend/src/components/LinkedInWriter/styles/alwrity-copilot.css
@@ -529,6 +529,63 @@
   padding-top: 0;
 }
 
+.linkedin-studio-tour-trigger {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 12;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 2px solid #bce0fd;
+  background: #ffffff;
+  color: #0a66c2;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 2px 10px rgba(10, 102, 194, 0.12);
+  transition: background 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.linkedin-studio-tour-trigger:hover {
+  background: #eff6ff;
+  box-shadow: 0 4px 14px rgba(10, 102, 194, 0.18);
+  transform: translateY(-1px);
+}
+
+.linkedin-studio-tour-trigger span[aria-hidden] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #0a66c2;
+  color: #fff;
+  font-size: 12px;
+  line-height: 1;
+}
+
+.linkedin-studio-tour-trigger-label {
+  letter-spacing: 0.01em;
+}
+
+@media (max-width: 640px) {
+  .linkedin-studio-tour-trigger-label {
+    display: none;
+  }
+
+  .linkedin-studio-tour-trigger {
+    padding: 6px 8px;
+  }
+}
+
+.linkedin-tour-lifecycle-spotlight {
+  box-sizing: border-box;
+}
+
 .linkedin-dashboard-hero {
   z-index: 1;
   flex: 1;

--- a/frontend/src/utils/walkthroughs/linkedInStudioTourSteps.ts
+++ b/frontend/src/utils/walkthroughs/linkedInStudioTourSteps.ts
@@ -1,0 +1,121 @@
+import type { Step } from 'react-joyride';
+
+/** localStorage key — first visit auto-starts the studio tour when unset. */
+export const LINKEDIN_STUDIO_TOUR_SEEN_KEY = 'linkedin_studio_tour_seen';
+
+const TOUR_TOOLTIP_STYLE = {
+  tooltip: { maxWidth: 300 },
+};
+
+const VIEWPORT_FLOATER = {
+  options: {
+    preventOverflow: {
+      boundariesElement: 'viewport' as const,
+      padding: 16,
+    },
+  },
+};
+
+const WEDGE_PLAN: Step = {
+  target: '[data-tour="li-wedge-plan"]',
+  title: 'Plan — strategy first',
+  content:
+    'Start your content workflow here. Brainstorm ideas with persona-aware research, open Industry Watchdog to monitor trends, and shape what you will publish before you write.',
+  placement: 'top',
+  disableBeacon: true,
+  styles: TOUR_TOOLTIP_STYLE,
+};
+
+const WEDGE_CREATE: Step = {
+  target: '[data-tour="li-wedge-create"]',
+  title: 'Create — draft faster',
+  content:
+    'Turn ideas into LinkedIn posts, articles, video scripts, and carousels. Tap Get Topic Ideas for AI suggestions matched to your profile, then pick a format to open Quick Create.',
+  placement: 'right',
+  styles: TOUR_TOOLTIP_STYLE,
+};
+
+const WEDGE_PUBLISH: Step = {
+  target: '[data-tour="li-wedge-publish"]',
+  title: 'Publish — ship with confidence',
+  content:
+    'Open saved drafts from your asset library or jump to the content calendar to schedule posts when your audience is most active.',
+  placement: 'right',
+  styles: TOUR_TOOLTIP_STYLE,
+};
+
+const WEDGE_ANALYSIS: Step = {
+  target: '[data-tour="li-wedge-analysis"]',
+  title: 'Analysis — measure what works',
+  content:
+    'Review profile strength, post performance, and SEO visibility so every piece of content improves your LinkedIn presence.',
+  placement: 'bottom',
+  styles: TOUR_TOOLTIP_STYLE,
+};
+
+const WEDGE_ENGAGEMENT: Step = {
+  target: '[data-tour="li-wedge-engagement"]',
+  title: 'Engagement — grow reach',
+  content:
+    'Use the growth engine to boost interaction, expand reach, and turn passive viewers into active followers.',
+  placement: 'left',
+  styles: TOUR_TOOLTIP_STYLE,
+};
+
+const WEDGE_REMARKET: Step = {
+  target: '[data-tour="li-wedge-remarket"]',
+  title: 'Remarket — refresh winners',
+  content:
+    'Identify high-performing posts and repurpose or refresh them to extend the life of your best LinkedIn content.',
+  placement: 'left',
+  styles: TOUR_TOOLTIP_STYLE,
+};
+
+/** Welcome → connect → lifecycle pie → wedges (Plan & Create first) → replay hint. */
+export const linkedInStudioTourSteps: Step[] = [
+  {
+    target: 'body',
+    title: 'Welcome to LinkedIn Studio',
+    content:
+      'This quick tour shows how to use the studio dashboard — your command center for planning, creating, publishing, and improving LinkedIn content.',
+    placement: 'center',
+    disableBeacon: true,
+    styles: TOUR_TOOLTIP_STYLE,
+  },
+  {
+    target: '[data-tour="li-connect-action"]',
+    title: 'Connect LinkedIn',
+    content:
+      'Click Connect LinkedIn to link your account. This unlocks publishing, analytics, topic ideas, and profile tools across the studio.',
+    placement: 'top',
+    disableScrolling: true,
+    spotlightPadding: 4,
+    styles: TOUR_TOOLTIP_STYLE,
+    floaterProps: VIEWPORT_FLOATER,
+  },
+  {
+    target: '[data-tour="li-content-lifecycle"]',
+    title: 'LinkedIn content lifecycle',
+    content:
+      'These six wedges map your full LinkedIn workflow — from planning through remarketing. Click any wedge to open its tools. Next we walk through each step, starting with Plan.',
+    placement: 'bottom',
+    disableScrolling: true,
+    spotlightPadding: 4,
+    styles: TOUR_TOOLTIP_STYLE,
+    floaterProps: VIEWPORT_FLOATER,
+  },
+  WEDGE_PLAN,
+  WEDGE_CREATE,
+  WEDGE_PUBLISH,
+  WEDGE_ANALYSIS,
+  WEDGE_ENGAGEMENT,
+  WEDGE_REMARKET,
+  {
+    target: '[data-tour="li-tour-trigger"]',
+    title: 'You are ready',
+    content:
+      'Replay this tour anytime from the Tour button. Start with Plan or Create — connect LinkedIn when you are ready to publish.',
+    placement: 'bottom',
+    styles: TOUR_TOOLTIP_STYLE,
+  },
+];


### PR DESCRIPTION
## Summary

- Add a **react-joyride** guided tour for the signed-in LinkedIn Studio dashboard (`/linkedin-writer`, no draft open).
- Tour flow: Welcome → **Connect LinkedIn** → **LinkedIn content lifecycle** (six-wedge ring) → Plan → Create → Publish → Analysis → Engagement → Remarket → replay hint.
- **First-visit auto-start** after connection status loads (`localStorage`: `linkedin_studio_tour_seen`); replay via **Tour** pill or `linkedinwriter:startStudioTour` custom event.
- Tight Joyride spotlight anchors: connect button only, lifecycle pie bounds (not full hero width), per-wedge `data-tour` targets on SVG wedges.
- Compact tooltips (max 300px), viewport-aware placement, z-index 13000 (above dashboard modals).

## Depends on

Requires the LinkedIn Studio dashboard from **#775** (merged).

## Test plan

- [ ] Open `/linkedin-writer` signed in with no draft — tour auto-starts on first visit
- [ ] Step 2 highlights **Connect LinkedIn** button only (tooltip above button)
- [ ] Step 3 highlights **six-wedge ring** only (not full dashboard width)
- [ ] Walk through Plan and Create wedge steps — spotlights align with wedges
- [ ] Skip tour — does not auto-restart; clear `linkedin_studio_tour_seen` to verify first-visit again
- [ ] Click **Tour** pill (top-right) to replay
- [ ] Mobile: tooltips stay on-screen; no page scroll jump during tour
