### PR TITLE
refactor(onboarding): use SitemapService for sitemap discovery + add max_urls parameter

### DIFF
--- a/backend/api/onboarding_utils/onboarding_task_scheduler.py
+++ b/backend/api/onboarding_utils/onboarding_task_scheduler.py
@@ -5,6 +5,7 @@ and onboarding_completion_service.py (Step 6).
 All scheduling is non-blocking -- step completion never fails on scheduling errors.
 """
 
+import asyncio
 from typing import Dict, Any, List, Optional
 from datetime import datetime, timedelta, timezone
 from sqlalchemy.orm import Session
@@ -258,6 +259,21 @@ def schedule_step4_tasks(user_id: str, db: Optional[Session] = None):
             _record_task_in_session(db, user_id, "facebook_persona", step=4)
     except Exception as e:
         logger.warning(f"[onboarding_step4] Non-blocking: failed to schedule Facebook persona: {e}")
+
+
+async def _immediate_sif_index(user_id: str, website_url: str):
+    """Fire SIFIntegrationService.sync_user_website_content() right now.
+
+    Best-effort immediate indexing — if it fails, the scheduler's
+    SIFIndexingTask (created by schedule_step2_tasks) still picks it up later.
+    """
+    from services.intelligence.sif_integration import SIFIntegrationService
+    try:
+        sif = SIFIntegrationService(user_id)
+        await sif.sync_user_website_content(website_url)
+        logger.success(f"[SIF] Immediate indexing done for {website_url}")
+    except Exception:
+        logger.warning(f"[SIF] Immediate indexing failed — scheduler still has it")
 
 
 def schedule_step5_tasks(user_id: str, db: Session):

--- a/backend/api/onboarding_utils/step3_routes.py
+++ b/backend/api/onboarding_utils/step3_routes.py
@@ -55,6 +55,10 @@ class CompetitorDiscoveryResponse(BaseModel):
     analysis_timestamp: Optional[str] = None
     api_cost: Optional[float] = None
     error: Optional[str] = None
+    # SIF-enhanced semantic intelligence fields
+    semantic_insights: Optional[Dict[str, Any]] = None
+    content_analysis: Optional[Dict[str, Any]] = None
+    strategic_recommendations: Optional[List[Dict[str, Any]]] = None
 
 class ResearchDataRequest(BaseModel):
     """Request model for retrieving research data."""
@@ -280,6 +284,24 @@ async def discover_competitors(
         if result["success"]:
             logger.info(f"✅ Successfully discovered {result['total_competitors']} competitors for user {clerk_user_id}")
             
+            # SIF-enhanced semantic intelligence (best-effort, non-blocking)
+            sif_insights = None
+            sif_content = None
+            sif_recommendations = None
+            try:
+                from services.sif_onboarding_service import enhance_step3_with_semantic_intelligence
+                sif_result = await enhance_step3_with_semantic_intelligence(
+                    user_id=clerk_user_id,
+                    website_url=request.user_url,
+                    business_info={"description": request.industry_context or "", "industry": request.industry_context or ""}
+                )
+                sif_insights = sif_result.get("semantic_insights")
+                sif_content = sif_result.get("content_analysis")
+                sif_recommendations = sif_insights.get("strategic_recommendations") if sif_insights else None
+                logger.info(f"[SIF] Step 3 enhanced with semantic intelligence for {clerk_user_id}")
+            except Exception as e:
+                logger.warning(f"[SIF] Step 3 enhancement failed (non-blocking): {e}")
+            
             return CompetitorDiscoveryResponse(
                 success=True,
                 message=f"Successfully discovered {result['total_competitors']} competitors and social media accounts",
@@ -292,7 +314,10 @@ async def discover_competitors(
                 total_competitors=result["total_competitors"],
                 industry_context=result["industry_context"],
                 analysis_timestamp=result["analysis_timestamp"],
-                api_cost=result["api_cost"]
+                api_cost=result["api_cost"],
+                semantic_insights=sif_insights,
+                content_analysis=sif_content,
+                strategic_recommendations=sif_recommendations
             )
         else:
             logger.error(f"❌ Competitor discovery failed for user {clerk_user_id}: {result.get('error')}")

--- a/backend/api/onboarding_utils/step_management_service.py
+++ b/backend/api/onboarding_utils/step_management_service.py
@@ -3,6 +3,7 @@ Step Management Service
 Handles onboarding step operations and progress tracking.
 """
 
+import asyncio
 from typing import Dict, Any, List, Optional
 from datetime import datetime
 from fastapi import HTTPException
@@ -736,8 +737,13 @@ class StepManagementService:
                             # Schedule background tasks for Step 2 (non-blocking)
                             website_url = website_data.get('website') or website_data.get('website_url')
                             if website_url:
-                                from api.onboarding_utils.onboarding_task_scheduler import schedule_step2_tasks
+                                from api.onboarding_utils.onboarding_task_scheduler import schedule_step2_tasks, _immediate_sif_index
                                 schedule_step2_tasks(user_id, db, website_url)
+                                # Fire immediate SIF indexing (best-effort, non-blocking)
+                                try:
+                                    asyncio.create_task(_immediate_sif_index(user_id, website_url))
+                                except Exception:
+                                    logger.warning("[SIF] Failed to fire immediate indexing task")
                     except Exception as e:
                         logger.error(f" BLOCKING ERROR: Failed to save website analysis: {str(e)}")
                         raise HTTPException(

--- a/backend/services/scheduler/executors/onboarding_full_website_analysis_executor.py
+++ b/backend/services/scheduler/executors/onboarding_full_website_analysis_executor.py
@@ -2,7 +2,7 @@ import asyncio
 import time
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Set
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 
 import aiohttp
 from bs4 import BeautifulSoup
@@ -25,6 +25,7 @@ from services.seo_analyzer.analyzers import (
     AccessibilityAnalyzer,
     UserExperienceAnalyzer
 )
+from services.seo_tools.sitemap_service import SitemapService
 
 
 class OnboardingFullWebsiteAnalysisExecutor(TaskExecutor):
@@ -152,93 +153,38 @@ class OnboardingFullWebsiteAnalysisExecutor(TaskExecutor):
 
     async def _discover_urls(self, website_url: str, max_urls: int) -> List[str]:
         base = self._normalize_url(website_url)
-        parsed = urlparse(base)
-        root = f"{parsed.scheme}://{parsed.netloc}"
 
-        sitemap_urls: List[str] = []
+        sitemap_service = SitemapService()
+        sitemap_url = await sitemap_service.discover_sitemap_url(base)
+        if not sitemap_url:
+            return [base]
 
-        robots = await self._fetch_text(urljoin(root, "/robots.txt"))
-        if robots:
-            for line in robots.splitlines():
-                if line.lower().startswith("sitemap:"):
-                    sitemap_urls.append(line.split(":", 1)[1].strip())
-
-        if not sitemap_urls:
-            candidates = [
-                urljoin(root, "/sitemap.xml"),
-                urljoin(root, "/sitemap_index.xml"),
-                urljoin(root, "/wp-sitemap.xml"),
-            ]
-            sitemap_urls.extend(candidates)
+        sitemap_data = await sitemap_service.analyze_sitemap(
+            sitemap_url,
+            analyze_content_trends=False,
+            analyze_publishing_patterns=False,
+            include_ai_insights=False,
+            max_urls=max_urls
+        )
 
         discovered: List[str] = []
         seen: Set[str] = set()
 
-        for sm in sitemap_urls:
-            if len(discovered) >= max_urls:
-                break
-            urls_from_sm = await self._parse_sitemap(sm, max_urls=max_urls - len(discovered))
-            for u in urls_from_sm:
-                n = self._normalize_url(u)
-                if n not in seen and self._same_site(root, n):
-                    seen.add(n)
-                    discovered.append(n)
-                    if len(discovered) >= max_urls:
-                        break
+        for u in sitemap_data.get("urls", []):
+            loc = (u.get("loc") or "").strip()
+            if not loc:
+                continue
+            n = self._normalize_url(loc)
+            if n not in seen and self._same_site(base, n):
+                seen.add(n)
+                discovered.append(n)
+                if len(discovered) >= max_urls:
+                    break
 
         if not discovered:
             discovered.append(base)
 
         return discovered
-
-    async def _parse_sitemap(self, sitemap_url: str, max_urls: int) -> List[str]:
-        xml_text = await self._fetch_text(sitemap_url)
-        if not xml_text:
-            return []
-
-        try:
-            import xml.etree.ElementTree as ET
-            root = ET.fromstring(xml_text)
-        except Exception:
-            return []
-
-        ns = ""
-        if root.tag.startswith("{"):
-            ns = root.tag.split("}", 1)[0] + "}"
-
-        urls: List[str] = []
-
-        if root.tag.endswith("sitemapindex"):
-            locs = root.findall(f".//{ns}sitemap/{ns}loc")
-            for loc in locs:
-                if len(urls) >= max_urls:
-                    break
-                child_url = (loc.text or "").strip()
-                if not child_url:
-                    continue
-                child_urls = await self._parse_sitemap(child_url, max_urls=max_urls - len(urls))
-                urls.extend(child_urls)
-        else:
-            locs = root.findall(f".//{ns}url/{ns}loc")
-            for loc in locs:
-                if len(urls) >= max_urls:
-                    break
-                u = (loc.text or "").strip()
-                if u:
-                    urls.append(u)
-
-        return urls
-
-    async def _fetch_text(self, url: str) -> Optional[str]:
-        try:
-            timeout = aiohttp.ClientTimeout(total=self.http_timeout_seconds)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get(url, allow_redirects=True, headers={"User-Agent": "ALwrity-SEO-Audit/1.0"}) as resp:
-                    if resp.status >= 400:
-                        return None
-                    return await resp.text(errors="ignore")
-        except Exception:
-            return None
 
     async def _audit_urls(self, user_id: str, website_url: str, urls: List[str], db: Session) -> Dict[str, Any]:
         timeout = aiohttp.ClientTimeout(total=self.http_timeout_seconds)

--- a/backend/services/seo_tools/sitemap_service.py
+++ b/backend/services/seo_tools/sitemap_service.py
@@ -87,7 +87,8 @@ class SitemapService:
         analyze_content_trends: bool = True,
         analyze_publishing_patterns: bool = True,
         include_ai_insights: bool = True,
-        user_id: Optional[str] = None
+        user_id: Optional[str] = None,
+        max_urls: Optional[int] = None
     ) -> Dict[str, Any]:
         """
         Analyze website sitemap for structure and patterns
@@ -96,6 +97,8 @@ class SitemapService:
             sitemap_url: URL of the sitemap to analyze
             analyze_content_trends: Whether to analyze content trends
             analyze_publishing_patterns: Whether to analyze publishing patterns
+            max_urls: Maximum number of URLs to collect from the sitemap (helps
+                      avoid parsing the entire sitemap when only a subset is needed)
             
         Returns:
             Dictionary containing sitemap analysis and AI insights
@@ -109,7 +112,7 @@ class SitemapService:
             logger.info(f"Analyzing sitemap: {sitemap_url}")
             
             # Fetch and parse sitemap data
-            sitemap_data = await self._fetch_sitemap_data(sitemap_url)
+            sitemap_data = await self._fetch_sitemap_data(sitemap_url, max_urls=max_urls)
             
             if not sitemap_data:
                 raise Exception("Failed to fetch sitemap data")
@@ -265,7 +268,7 @@ class SitemapService:
         assert last_exc is not None
         raise last_exc
 
-    async def _fetch_sitemap_data(self, sitemap_url: str, depth: int = 0, session: aiohttp.ClientSession = None) -> Dict[str, Any]:
+    async def _fetch_sitemap_data(self, sitemap_url: str, depth: int = 0, session: aiohttp.ClientSession = None, max_urls: Optional[int] = None) -> Dict[str, Any]:
         """Fetch and parse sitemap data"""
         
         # Reduced max depth from 3 to 2 to prevent infinite recursion/hanging on massive sites
@@ -367,8 +370,14 @@ class SitemapService:
                         # Fetch and parse nested sitemaps in parallel
                         nested_tasks = []
                         # Reduced nested limit from 10 to 5 to prevent fan-out explosion
-                        for nested_url in sitemaps[:5]: 
-                            nested_tasks.append(self._fetch_sitemap_data(nested_url, depth + 1, session))
+                        # If max_urls is set, we may need fewer nested sitemaps
+                        nested_limit = 5
+                        if max_urls is not None:
+                            # Only fetch enough sitemaps to cover max_urls (estimate ~10 URLs each)
+                            nested_limit = min(5, max(1, (max_urls + 9) // 10))
+                        for nested_url in sitemaps[:nested_limit]: 
+                            remaining = max_urls - len(urls) if max_urls is not None else None
+                            nested_tasks.append(self._fetch_sitemap_data(nested_url, depth + 1, session, max_urls=remaining))
                         
                         if nested_tasks:
                             nested_results = await asyncio.gather(*nested_tasks, return_exceptions=True)
@@ -377,13 +386,18 @@ class SitemapService:
                                     logger.warning(f"Failed to fetch nested sitemap: {res}")
                                 elif isinstance(res, dict):
                                     urls.extend(res.get("urls", []))
+                                    if max_urls is not None and len(urls) >= max_urls:
+                                        urls = urls[:max_urls]
+                                        break
                     
                     else:
                         # Regular sitemap with URLs
                         # Limit to first 10k URLs per sitemap file to prevent memory issues
+                        # If max_urls is set, use it instead (but cap at 10k to prevent abuse)
+                        per_file_limit = min(max_urls, 10000) if max_urls is not None else 10000
                         url_count = 0
                         for url_element in root:
-                            if url_count >= 10000:
+                            if url_count >= per_file_limit:
                                 break
                                 
                             if url_element.tag.endswith('url'):

--- a/frontend/src/components/OnboardingWizard/CompetitorAnalysisStep.tsx
+++ b/frontend/src/components/OnboardingWizard/CompetitorAnalysisStep.tsx
@@ -86,6 +86,9 @@ const CompetitorAnalysisStep: React.FC<CompetitorAnalysisStepProps> = ({
   const [socialMediaAccounts, setSocialMediaAccounts] = useState<any>({});
   const [, setSocialMediaCitations] = useState<any[]>([]);
   const [researchSummary, setResearchSummary] = useState<ResearchSummary | null>(null);
+  const [sifInsights, setSifInsights] = useState<any>(null);
+  const [sifContentAnalysis, setSifContentAnalysis] = useState<any>(null);
+  const [sifRecommendations, setSifRecommendations] = useState<any[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showProgressModal, setShowProgressModal] = useState(false);
   const [showHighlightsModal, setShowHighlightsModal] = useState(false);
@@ -190,6 +193,9 @@ const CompetitorAnalysisStep: React.FC<CompetitorAnalysisStepProps> = ({
             setSocialMediaAccounts(parsedData.social_media_accounts || {});
             setSocialMediaCitations(parsedData.social_media_citations || []);
             setResearchSummary(parsedData.research_summary || null);
+            setSifInsights(parsedData.semantic_insights || null);
+            setSifContentAnalysis(parsedData.content_analysis || null);
+            setSifRecommendations(parsedData.strategic_recommendations || null);
             setSitemapAnalysis(parsedData.sitemap_analysis || null);
             setUsingCachedData(true);
             
@@ -347,10 +353,24 @@ const CompetitorAnalysisStep: React.FC<CompetitorAnalysisStepProps> = ({
         setSocialMediaAccounts(mergedAccounts);
         setSocialMediaCitations(analysisData.social_media_citations);
         setResearchSummary(analysisData.research_summary);
+
+        // SIF-enhanced semantic intelligence insights
+        const sifInsightsData = result.semantic_insights || null;
+        const sifContentData = result.content_analysis || null;
+        const sifRecommendationsData = result.strategic_recommendations || null;
+        setSifInsights(sifInsightsData);
+        setSifContentAnalysis(sifContentData);
+        setSifRecommendations(sifRecommendationsData);
         
         // Cache the analysis results with merged data
         try {
-          localStorage.setItem('competitor_analysis_data', JSON.stringify({ ...analysisData, social_media_accounts: mergedAccounts }));
+          localStorage.setItem('competitor_analysis_data', JSON.stringify({
+            ...analysisData,
+            social_media_accounts: mergedAccounts,
+            semantic_insights: sifInsightsData,
+            content_analysis: sifContentData,
+            strategic_recommendations: sifRecommendationsData
+          }));
           localStorage.setItem('competitor_analysis_url', finalUserUrl);
           localStorage.setItem('competitor_analysis_timestamp', Date.now().toString());
           console.log('CompetitorAnalysisStep: Cached competitor analysis for future use');
@@ -788,6 +808,168 @@ const CompetitorAnalysisStep: React.FC<CompetitorAnalysisStepProps> = ({
         onRemoveCompetitor={handleRemoveCompetitor}
         onAddCompetitor={handleAddCompetitor}
       />
+
+      {/* SIF Semantic Intelligence Section */}
+      {sifInsights && (
+        <Box mt={6} mb={4}>
+          <Typography variant="h5" fontWeight={600} sx={{ color: '#1a202c !important', display: 'flex', alignItems: 'center', mb: 3 }}>
+            <AutoFixHighIcon sx={{ mr: 1, color: '#7C3AED' }} />
+            AI Semantic Insights
+          </Typography>
+          <Grid container spacing={3}>
+            {/* Content Pillars */}
+            {sifInsights.content_pillars?.length > 0 && (
+              <Grid item xs={12} md={4}>
+                <Card sx={{ height: '100%', bgcolor: '#f5f3ff', border: '1px solid #ddd6fe' }}>
+                  <CardContent>
+                    <Typography variant="subtitle1" fontWeight={600} sx={{ color: '#5b21b6', mb: 1 }}>
+                      Your Content Pillars
+                    </Typography>
+                    <Typography variant="caption" sx={{ color: '#7c3aed', mb: 1.5, display: 'block' }}>
+                      Topics your site strongly covers — your competitive strengths.
+                    </Typography>
+                    <Box display="flex" flexDirection="column" gap={1}>
+                      {sifInsights.content_pillars.slice(0, 5).map((pillar: any, i: number) => (
+                        <Paper key={i} variant="outlined" sx={{ p: 1.5, bgcolor: 'white', borderColor: '#ddd6fe' }}>
+                          <Typography variant="body2" fontWeight={500} color="#4c1d95">
+                            {pillar.name || pillar.topic || pillar.title || `Pillar ${i + 1}`}
+                          </Typography>
+                          {pillar.confidence && (
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
+                              <Box sx={{ flex: 1, height: 4, borderRadius: 2, bgcolor: '#e9d5ff' }}>
+                                <Box sx={{ width: `${Math.round(pillar.confidence * 100)}%`, height: 4, borderRadius: 2, bgcolor: '#7c3aed' }} />
+                              </Box>
+                              <Typography variant="caption" color="#6b7280">{Math.round(pillar.confidence * 100)}%</Typography>
+                            </Box>
+                          )}
+                        </Paper>
+                      ))}
+                    </Box>
+                  </CardContent>
+                </Card>
+              </Grid>
+            )}
+
+            {/* Semantic Gaps */}
+            {sifInsights.semantic_gaps?.length > 0 && (
+              <Grid item xs={12} md={4}>
+                <Card sx={{ height: '100%', bgcolor: '#fffbeb', border: '1px solid #fde68a' }}>
+                  <CardContent>
+                    <Typography variant="subtitle1" fontWeight={600} sx={{ color: '#92400e', mb: 1 }}>
+                      Content Gaps & Opportunities
+                    </Typography>
+                    <Typography variant="caption" sx={{ color: '#b45309', mb: 1.5, display: 'block' }}>
+                      Topics competitors cover that you don't — prime content opportunities.
+                    </Typography>
+                    <Box display="flex" flexDirection="column" gap={1}>
+                      {sifInsights.semantic_gaps.slice(0, 5).map((gap: any, i: number) => (
+                        <Paper key={i} variant="outlined" sx={{ p: 1.5, bgcolor: 'white', borderColor: '#fde68a' }}>
+                          <Box display="flex" justifyContent="space-between" alignItems="flex-start">
+                            <Typography variant="body2" fontWeight={500} color="#92400e">
+                              {gap.topic || gap.gap || `Gap ${i + 1}`}
+                            </Typography>
+                            {gap.priority && (
+                              <Chip
+                                label={gap.priority}
+                                size="small"
+                                sx={{
+                                  fontSize: '0.65rem',
+                                  fontWeight: 600,
+                                  bgcolor: gap.priority === 'high' ? '#fef2f2' : '#fffbeb',
+                                  color: gap.priority === 'high' ? '#991b1b' : '#92400e',
+                                  border: `1px solid ${gap.priority === 'high' ? '#fecaca' : '#fde68a'}`
+                                }}
+                              />
+                            )}
+                          </Box>
+                          {gap.reason && (
+                            <Typography variant="caption" color="#78716c" sx={{ mt: 0.5, display: 'block' }}>
+                              {gap.reason}
+                            </Typography>
+                          )}
+                          {gap.confidence && (
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
+                              <Box sx={{ flex: 1, height: 4, borderRadius: 2, bgcolor: '#fef3c7' }}>
+                                <Box sx={{ width: `${Math.round(gap.confidence * 100)}%`, height: 4, borderRadius: 2, bgcolor: '#d97706' }} />
+                              </Box>
+                              <Typography variant="caption" color="#6b7280">{Math.round(gap.confidence * 100)}%</Typography>
+                            </Box>
+                          )}
+                        </Paper>
+                      ))}
+                    </Box>
+                  </CardContent>
+                </Card>
+              </Grid>
+            )}
+
+            {/* Strategic Recommendations */}
+            {sifRecommendations && sifRecommendations.length > 0 && (
+              <Grid item xs={12} md={4}>
+                <Card sx={{ height: '100%', bgcolor: '#f0fdf4', border: '1px solid #bbf7d0' }}>
+                  <CardContent>
+                    <Typography variant="subtitle1" fontWeight={600} sx={{ color: '#166534', mb: 1 }}>
+                      Recommended Actions
+                    </Typography>
+                    <Typography variant="caption" sx={{ color: '#16a34a', mb: 1.5, display: 'block' }}>
+                      Prioritized steps to strengthen your content strategy.
+                    </Typography>
+                    <Box display="flex" flexDirection="column" gap={1}>
+                      {sifRecommendations.slice(0, 5).map((rec: any, i: number) => (
+                        <Paper key={i} variant="outlined" sx={{ p: 1.5, bgcolor: 'white', borderColor: '#bbf7d0' }}>
+                          <Box display="flex" alignItems="flex-start" gap={1}>
+                            <Box sx={{ width: 20, height: 20, borderRadius: '50%', bgcolor: '#22c55e', color: 'white', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 11, fontWeight: 700, flexShrink: 0, mt: 0.25 }}>
+                              {i + 1}
+                            </Box>
+                            <Box>
+                              <Typography variant="body2" fontWeight={500} color="#166534">
+                                {rec.title || `Recommendation ${i + 1}`}
+                              </Typography>
+                              {rec.description && (
+                                <Typography variant="caption" color="#6b7280" sx={{ mt: 0.25, display: 'block' }}>
+                                  {rec.description}
+                                </Typography>
+                              )}
+                              {rec.action_items?.length > 0 && (
+                                <Box component="ul" sx={{ mt: 0.5, mb: 0, pl: 1.5 }}>
+                                  {rec.action_items.slice(0, 3).map((action: string, j: number) => (
+                                    <Box component="li" key={j} sx={{ typography: 'caption', color: '#78716c', '&::marker': { color: '#86efac' } }}>
+                                      {action}
+                                    </Box>
+                                  ))}
+                                </Box>
+                              )}
+                            </Box>
+                          </Box>
+                          {rec.priority && (
+                            <Chip
+                              label={rec.priority}
+                              size="small"
+                              sx={{ mt: 0.5, fontSize: '0.65rem', fontWeight: 600, bgcolor: rec.priority === 'high' ? '#fef2f2' : rec.priority === 'medium' ? '#fffbeb' : '#f0fdf4', color: rec.priority === 'high' ? '#991b1b' : rec.priority === 'medium' ? '#92400e' : '#166534' }}
+                            />
+                          )}
+                        </Paper>
+                      ))}
+                    </Box>
+                  </CardContent>
+                </Card>
+              </Grid>
+            )}
+          </Grid>
+
+          {/* Content Analysis Stats Footer */}
+          {sifContentAnalysis && (
+            <Box mt={2} sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, justifyContent: 'center' }}>
+              {sifContentAnalysis.user_pages_analyzed > 0 && (
+                <Chip icon={<AutoFixHighIcon fontSize="small" />} label={`${sifContentAnalysis.user_pages_analyzed} user pages analyzed`} size="small" variant="outlined" sx={{ color: '#6b7280', borderColor: '#d1d5db' }} />
+              )}
+              {sifContentAnalysis.competitor_pages_analyzed > 0 && (
+                <Chip icon={<SearchIcon fontSize="small" />} label={`${sifContentAnalysis.competitor_pages_analyzed} competitor pages analyzed`} size="small" variant="outlined" sx={{ color: '#6b7280', borderColor: '#d1d5db' }} />
+              )}
+            </Box>
+          )}
+        </Box>
+      )}
 
       {/* Strategic Content Opportunities Section */}
       {(sitemapAnalysis || isAnalyzingSitemap) && (

--- a/frontend/src/components/OnboardingWizard/WebsiteStep.tsx
+++ b/frontend/src/components/OnboardingWizard/WebsiteStep.tsx
@@ -12,7 +12,8 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  DialogContentText
+  DialogContentText,
+  Fade
 } from '@mui/material';
 import {
   Analytics as AnalyticsIcon,
@@ -26,6 +27,7 @@ import { AnalysisResultsDisplay, AnalysisProgressDisplay, WebsiteIntegrationsSec
 import type { StyleAnalysis } from './WebsiteStep/components/AnalysisResultsDisplay';
 import PlatformSection from './common/PlatformSection';
 import EmailSection from './common/EmailSection';
+import PlatformAnalytics from '../shared/PlatformAnalytics';
 
 // Import API client for saving
 import { apiClient } from '../../api/client';
@@ -627,6 +629,18 @@ const WebsiteStep: React.FC<WebsiteStepProps> = ({ onContinue, updateHeaderConte
             connectedPlatforms={connectedPlatforms}
             setConnectedPlatforms={setConnectedPlatforms}
           />
+
+          {(connectedPlatforms.includes('gsc') || connectedPlatforms.includes('bing')) && (
+            <Fade in timeout={800}>
+              <Box sx={{ mt: 3 }}>
+                <PlatformAnalytics
+                  platforms={['gsc', 'bing']}
+                  showSummary
+                  refreshInterval={0}
+                />
+              </Box>
+            </Fade>
+          )}
         </>
       )}
 

--- a/frontend/src/components/OnboardingWizard/WebsiteStep/components/AnalysisProgressDisplay.tsx
+++ b/frontend/src/components/OnboardingWizard/WebsiteStep/components/AnalysisProgressDisplay.tsx
@@ -229,7 +229,7 @@ const AnalysisProgressDisplay: React.FC<AnalysisProgressDisplayProps> = ({
             }}
           />
           <Typography variant="caption" sx={{ color: '#166534', fontWeight: 500, lineHeight: 1.4 }}>
-            Deep analysis started in background — SEO audit, market trends, and competitive intelligence
+            Deep analysis started in background — SEO audit, market trends, competitive intelligence, and website content indexing for AI insights
             are now running while you continue setup. Check back on your dashboard for results.
           </Typography>
         </Box>

--- a/frontend/src/components/shared/AIInsightsPanel.tsx
+++ b/frontend/src/components/shared/AIInsightsPanel.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Tooltip,
+  Alert,
+  List,
+  ListItem,
+  ListItemText,
+  Chip,
+} from '@mui/material';
+import Info from '@mui/icons-material/Info';
+
+interface Finding {
+  title: string;
+  evidence: string;
+  actions?: string[];
+}
+
+interface AIInsightsPanelProps {
+  aiError: string | null;
+  aiInsights: {
+    quick_summary?: string;
+    prioritized_findings?: Finding[];
+  } | null;
+}
+
+const AIInsightsPanel: React.FC<AIInsightsPanelProps> = ({ aiError, aiInsights }) => {
+  if (!aiError && !aiInsights) return null;
+
+  return (
+    <Box sx={{ mt: 2.5 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+        <Typography variant="subtitle2">AI Insights</Typography>
+        <Tooltip title="Summarizes all panels into simple recommendations for creators.">
+          <Info fontSize="small" color="action" />
+        </Tooltip>
+      </Box>
+      {aiError && <Alert severity="error" sx={{ mb: 1 }}>{aiError}</Alert>}
+      {aiInsights && (
+        <Box>
+          <Typography variant="body2" sx={{ mb: 1 }}>{aiInsights.quick_summary}</Typography>
+          {Array.isArray(aiInsights.prioritized_findings) && aiInsights.prioritized_findings.length > 0 && (
+            <List dense>
+              {aiInsights.prioritized_findings.slice(0, 3).map((f: Finding, i: number) => (
+                <ListItem key={`ai-find-${i}`} sx={{ px: 0, alignItems: 'flex-start' }}>
+                  <ListItemText
+                    primary={f.title}
+                    secondary={
+                      <Box sx={{ mt: 0.5 }}>
+                        <Typography variant="caption" sx={{ color: '#6b7280', display: 'block' }}>{f.evidence}</Typography>
+                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
+                          {(f.actions || []).slice(0, 2).map((a: string, idx: number) => (
+                            <Chip key={`act-${idx}`} label={a} size="small" />
+                          ))}
+                        </Box>
+                      </Box>
+                    }
+                    primaryTypographyProps={{ variant: 'body2' }}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default AIInsightsPanel;

--- a/frontend/src/components/shared/BingToolbar.tsx
+++ b/frontend/src/components/shared/BingToolbar.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { TextField, Button } from '@mui/material';
+import { PlatformConnectionStatus } from '../../api/analytics';
+import { apiClient } from '../../api/client';
+
+interface BingToolbarProps {
+  siteUrl: string;
+  onSiteUrlChange: (url: string) => void;
+  collectMsg: string | null;
+  onCollectMsgChange: (msg: string | null) => void;
+  rangeDays: number;
+  bingStatus: PlatformConnectionStatus | undefined;
+  metrics: any;
+  onForceRefresh: () => Promise<void>;
+}
+
+const BingToolbar: React.FC<BingToolbarProps> = ({
+  siteUrl,
+  onSiteUrlChange,
+  collectMsg,
+  onCollectMsgChange,
+  rangeDays,
+  bingStatus,
+  metrics,
+  onForceRefresh,
+}) => {
+  const [collecting, setCollecting] = useState<boolean>(false);
+
+  return (
+    <>
+      <TextField
+        size="small"
+        placeholder="https://www.example.com/"
+        value={siteUrl}
+        onChange={(e) => onSiteUrlChange(e.target.value)}
+        sx={{ minWidth: 280 }}
+        label="Bing Site URL"
+      />
+      <Button
+        variant="outlined"
+        size="small"
+        disabled={collecting}
+        onClick={async () => {
+          try {
+            onCollectMsgChange(null);
+            setCollecting(true);
+            const statusSites: any[] = Array.isArray(bingStatus?.sites) ? bingStatus!.sites : [];
+            const metricsSites: any[] = Array.isArray(metrics?.sites) ? metrics.sites : [];
+            const candidates = [...statusSites, ...metricsSites];
+            let resolvedUrl: string =
+              (candidates.find(s => typeof s?.Url === 'string')?.Url) ||
+              (candidates.find(s => typeof s?.url === 'string')?.url) ||
+              '';
+            if (siteUrl && typeof siteUrl === 'string') {
+              resolvedUrl = siteUrl.trim();
+            }
+            if (!resolvedUrl) {
+              onCollectMsgChange('No Bing site found to collect.');
+              return;
+            }
+            await apiClient.post('/bing-analytics/collect-data', null, {
+              params: { site_url: resolvedUrl, days_back: Math.max(7, Math.min(90, rangeDays)) }
+            });
+            onCollectMsgChange('Bing storage refresh started…');
+            setTimeout(() => {
+              onForceRefresh().catch(() => {});
+            }, 3500);
+          } catch (e: any) {
+            onCollectMsgChange(e?.message || 'Failed to start Bing collection');
+          } finally {
+            setCollecting(false);
+          }
+        }}
+        sx={{ textTransform: 'none' }}
+      >
+        {collecting ? 'Refreshing…' : 'Refresh Bing Storage'}
+      </Button>
+    </>
+  );
+};
+
+export default BingToolbar;

--- a/frontend/src/components/shared/CannibalizationAlertsPanel.tsx
+++ b/frontend/src/components/shared/CannibalizationAlertsPanel.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Chip,
+  Alert,
+  List,
+  ListItem,
+  ListItemText,
+  Tooltip,
+  Button,
+} from '@mui/material';
+import MouseOutlined from '@mui/icons-material/MouseOutlined';
+import Info from '@mui/icons-material/Info';
+import ChipLegend from './ChipLegend';
+
+interface CannibalizationPage {
+  page: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+}
+
+interface CannibalizationAlert {
+  query: string;
+  total_clicks: number;
+  recommended_target_page?: string;
+  pages?: CannibalizationPage[];
+}
+
+interface CannibalizationAlertsPanelProps {
+  alerts: CannibalizationAlert[];
+  formatNumber: (n: number) => string;
+  isValidHttpUrl: (url: string) => boolean;
+  onOpenBrief: (page: string, query: string, totalClicks: number) => void;
+}
+
+const CannibalizationAlertsPanel: React.FC<CannibalizationAlertsPanelProps> = ({
+  alerts,
+  formatNumber,
+  isValidHttpUrl,
+  onOpenBrief,
+}) => {
+  return (
+    <Card sx={{ mt: 2, bgcolor: '#ffffff !important', color: '#1f2937 !important', border: '1px solid #e5e7eb !important', boxShadow: '0 1px 3px 0 rgba(0,0,0,0.1) !important' }}>
+      <CardContent>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography variant="subtitle1">Cannibalization Alerts</Typography>
+            <Tooltip title="The same search query points to multiple pages on your site, splitting clicks. Choose one target page and consolidate overlapping pages or add internal links.">
+              <Info fontSize="small" color="action" />
+            </Tooltip>
+          </Box>
+          <Typography variant="caption" color="text.secondary">Queries competing across pages</Typography>
+        </Box>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+          {"\u201C"}No cannibalization{"\u201D"} is normal for tightly targeted sites or low‑traffic windows. For demos we can relax sensitivity.
+        </Typography>
+        <ChipLegend
+          items={[
+            {
+              label: 'Competing page',
+              icon: <MouseOutlined fontSize="small" />,
+              tooltip: 'Each chip is a page that shares the same query. Text shows URL • clicks • impressions • CTR.',
+              sx: {
+                backgroundImage: 'linear-gradient(135deg, #e2e8f0 0%, #f8fafc 100%)',
+                color: '#0f172a',
+                border: '1px solid #cbd5e1',
+                boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
+                fontWeight: 700,
+              },
+            },
+            {
+              label: 'Higher CTR',
+              tooltip: 'Greener backgrounds mean this page converts searchers relatively well.',
+              sx: {
+                backgroundImage: 'linear-gradient(135deg, #d1fae5 0%, #ecfdf5 100%)',
+                color: '#065f46',
+                border: '1px solid #86efac',
+                boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
+                fontWeight: 700,
+              },
+            },
+            {
+              label: 'Weaker CTR',
+              tooltip: 'Redder backgrounds flag pages that may need consolidation or updates.',
+              sx: {
+                backgroundImage: 'linear-gradient(135deg, #fee2e2 0%, #fff1f2 100%)',
+                color: '#7f1d1d',
+                border: '1px solid #fecdd3',
+                boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
+                fontWeight: 700,
+              },
+            },
+          ]}
+        />
+        {(!alerts || alerts.length === 0) ? (
+          <Alert severity="info">No cannibalization detected for this window.</Alert>
+        ) : (
+          <List dense>
+            {alerts.slice(0, 10).map((a, idx) => (
+              <ListItem key={`${a.query}-${idx}`} sx={{ px: 0, alignItems: 'flex-start' }}>
+                <ListItemText
+                  primary={a.query}
+                  secondary={
+                    <Box sx={{ mt: 0.5 }}>
+                      <Typography variant="caption" sx={{ color: '#6b7280', display: 'block', mb: 0.5 }}>
+                        Total clicks: {formatNumber(a.total_clicks || 0)} • Target: {a.recommended_target_page || 'N/A'}
+                      </Typography>
+                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                        {(a.pages || []).map((p, i) => {
+                          const clicks = Number(p.clicks || 0);
+                          const impressions = Number(p.impressions || 0);
+                          const ctr = Number(p.ctr || 0);
+                          const ctrColor = ctr >= 3 ? '#065f46' : ctr >= 1 ? '#92400e' : '#7f1d1d';
+                          const ctrBg = ctr >= 3
+                            ? 'linear-gradient(135deg, #d1fae5 0%, #ecfdf5 100%)'
+                            : ctr >= 1
+                            ? 'linear-gradient(135deg, #fef3c7 0%, #fffbeb 100%)'
+                            : 'linear-gradient(135deg, #fee2e2 0%, #fff1f2 100%)';
+                          const label = `${String(p.page || '').replace(/^https?:\/\//, '').slice(0, 40)} • ${formatNumber(clicks)}c/${formatNumber(impressions)}i • ${ctr.toFixed(1)}%`;
+                          return (
+                            <Tooltip
+                              key={`${p.page}-${i}`}
+                              title={`Clicks ${clicks}, impressions ${impressions}, CTR ${ctr.toFixed(1)}% for this page`}
+                            >
+                              <Chip
+                                label={label}
+                                size="small"
+                                sx={{
+                                  backgroundImage: ctrBg,
+                                  color: ctrColor,
+                                  border: '1px solid rgba(0,0,0,0.06)',
+                                  boxShadow: '0 1px 2px rgba(0,0,0,0.04)',
+                                  fontWeight: 700,
+                                  maxWidth: 260,
+                                }}
+                              />
+                            </Tooltip>
+                          );
+                        })}
+                      </Box>
+                    </Box>
+                  }
+                  primaryTypographyProps={{ variant: 'body2' }}
+                />
+                <Button
+                  size="small"
+                  variant="outlined"
+                  sx={{ mr: 1, textTransform: 'none' }}
+                  disabled={!a.recommended_target_page || !isValidHttpUrl(String(a.recommended_target_page))}
+                  onClick={() => {
+                    if (a.recommended_target_page && isValidHttpUrl(String(a.recommended_target_page))) {
+                      window.open(String(a.recommended_target_page), '_blank');
+                    }
+                  }}
+                >
+                  Open Target Page
+                </Button>
+                <Button
+                  size="small"
+                  variant="contained"
+                  sx={{ textTransform: 'none' }}
+                  onClick={() => {
+                    const page = String(a.recommended_target_page || '');
+                    onOpenBrief(page, a.query, a.total_clicks || 0);
+                  }}
+                >
+                  Create Brief
+                </Button>
+              </ListItem>
+            ))}
+          </List>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CannibalizationAlertsPanel;

--- a/frontend/src/components/shared/ContentBriefDialog.tsx
+++ b/frontend/src/components/shared/ContentBriefDialog.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+interface BriefQuery {
+  query: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+}
+
+interface ContentBriefDialogProps {
+  open: boolean;
+  onClose: () => void;
+  briefData: { page: string; queries: BriefQuery[] } | null;
+}
+
+const ContentBriefDialog: React.FC<ContentBriefDialogProps> = ({ open, onClose, briefData }) => {
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Create Content Brief</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2}>
+          <TextField
+            label="Page URL"
+            value={briefData?.page || ''}
+            InputProps={{ readOnly: true }}
+            fullWidth
+            size="small"
+          />
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>Recent queries pointing to this page</Typography>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+              {(briefData?.queries || []).slice(0, 10).map((q, i) => (
+                <Chip
+                  key={`${q.query}-${i}`}
+                  label={`${q.query} • ${q.clicks}c/${q.impressions}i • ${q.ctr.toFixed(1)}%`}
+                  size="small"
+                />
+              ))}
+              {(briefData?.queries || []).length === 0 && (
+                <Typography variant="caption" color="text.secondary">No query mappings available for this window.</Typography>
+              )}
+            </Box>
+          </Box>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={() => {
+            try {
+              const prefill = {
+                page: briefData?.page || '',
+                queries: briefData?.queries || [],
+                created_at: new Date().toISOString(),
+                source: 'platform_analytics_top_pages',
+              };
+              localStorage.setItem('alwrity_brief_prefill', JSON.stringify(prefill));
+            } catch {}
+            onClose();
+          }}
+        >
+          Start Brief
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ContentBriefDialog;

--- a/frontend/src/components/shared/MetricsCard.tsx
+++ b/frontend/src/components/shared/MetricsCard.tsx
@@ -1,0 +1,263 @@
+import React from 'react';
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Grid,
+  Chip,
+  LinearProgress,
+  Alert,
+  List,
+  ListItem,
+  ListItemIcon,
+  Tooltip,
+  Paper,
+  Button,
+} from '@mui/material';
+import Visibility from '@mui/icons-material/Visibility';
+import MouseOutlined from '@mui/icons-material/MouseOutlined';
+import TrendingUp from '@mui/icons-material/TrendingUp';
+import { PlatformAnalytics as PlatformAnalyticsType, PlatformConnectionStatus } from '../../api/analytics';
+import BingToolbar from './BingToolbar';
+
+interface MetricsCardProps {
+  platform: string;
+  data: PlatformAnalyticsType;
+  formatNumber: (n: number) => string;
+  getPlatformIcon: (platform: string) => React.ReactNode;
+  getStatusColor: (status: string) => string;
+  getStatusIcon: (status: string) => React.ReactNode;
+  bingSiteUrl: string;
+  onBingSiteUrlChange: (url: string) => void;
+  bingCollectMsg: string | null;
+  onBingCollectMsgChange: (msg: string | null) => void;
+  rangeDays: number;
+  bingStatus: PlatformConnectionStatus | undefined;
+  onForceRefresh: () => Promise<void>;
+  onReconnect?: (platform: string) => void;
+  risingQueries: Array<{ query: string; deltaClicks: number; deltaImpressions: number }>;
+}
+
+const MetricsCard: React.FC<MetricsCardProps> = ({
+  platform,
+  data,
+  formatNumber,
+  getPlatformIcon,
+  getStatusColor,
+  getStatusIcon,
+  bingSiteUrl,
+  onBingSiteUrlChange,
+  bingCollectMsg,
+  onBingCollectMsgChange,
+  rangeDays,
+  bingStatus,
+  onForceRefresh,
+  onReconnect,
+  risingQueries,
+}) => {
+  const metrics = data.metrics;
+
+  return (
+    <Card sx={{ height: '100%', bgcolor: '#ffffff', color: '#1f2937', border: '1px solid #e5e7eb', boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1)' }}>
+      <CardContent>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            {getPlatformIcon(platform)}
+            <Typography variant="h6" component="div">
+              {platform.toUpperCase()}
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            {getStatusIcon(data.status)}
+            <Chip 
+              label={data.status} 
+              color={getStatusColor(data.status) as any}
+              size="small"
+            />
+            {platform === 'bing' && (
+              <BingToolbar
+                siteUrl={bingSiteUrl}
+                onSiteUrlChange={onBingSiteUrlChange}
+                collectMsg={bingCollectMsg}
+                onCollectMsgChange={onBingCollectMsgChange}
+                rangeDays={rangeDays}
+                bingStatus={bingStatus}
+                metrics={(data as any)?.metrics}
+                onForceRefresh={onForceRefresh}
+              />
+            )}
+          </Box>
+        </Box>
+
+        {data.status === 'success' && (
+          <>
+            <Grid container spacing={2}>
+              {metrics.total_clicks !== undefined && (
+                <Grid item xs={6}>
+                  <Box sx={{ textAlign: 'center' }}>
+                    <MouseOutlined color="primary" sx={{ fontSize: 32, mb: 1 }} />
+                    <Typography variant="h4" color="primary">
+                      {formatNumber(metrics.total_clicks)}
+                    </Typography>
+                    <Typography variant="caption" sx={{ color: '#6b7280' }}>
+                      Clicks
+                    </Typography>
+                  </Box>
+                </Grid>
+              )}
+              
+              {metrics.total_impressions !== undefined && (
+                <Grid item xs={6}>
+                  <Box sx={{ textAlign: 'center' }}>
+                    <Visibility color="secondary" sx={{ fontSize: 32, mb: 1 }} />
+                    <Typography variant="h4" color="secondary">
+                      {formatNumber(metrics.total_impressions)}
+                    </Typography>
+                    <Typography variant="caption" sx={{ color: '#6b7280' }}>
+                      Impressions
+                    </Typography>
+                  </Box>
+                </Grid>
+              )}
+            </Grid>
+
+            {metrics.avg_ctr !== undefined && (
+              <Box sx={{ mt: 2 }}>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                  <Typography variant="body2">CTR</Typography>
+                  <Typography variant="body2" fontWeight="bold">
+                    {metrics.avg_ctr}%
+                  </Typography>
+                </Box>
+                <LinearProgress 
+                  variant="determinate" 
+                  value={Math.min(metrics.avg_ctr * 10, 100)} 
+                  sx={{ height: 8, borderRadius: 4 }}
+                />
+              </Box>
+            )}
+
+            {metrics.avg_position !== undefined && (
+              <Box sx={{ mt: 1 }}>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                  <Typography variant="body2">Avg Position</Typography>
+                  <Typography variant="body2" fontWeight="bold">
+                    {metrics.avg_position.toFixed(1)}
+                  </Typography>
+                </Box>
+                <LinearProgress 
+                  variant="determinate" 
+                  value={Math.max(0, 100 - (metrics.avg_position - 1) * 5)} 
+                  color="secondary"
+                  sx={{ height: 6, borderRadius: 4 }}
+                />
+              </Box>
+            )}
+
+            {metrics.top_queries && metrics.top_queries.length > 0 && (
+              <Box sx={{ mt: 2 }}>
+                <Typography variant="subtitle2" gutterBottom>
+                  Top Queries
+                </Typography>
+                <List dense>
+                  {metrics.top_queries.slice(0, 3).map((q: any, index: number) => {
+                    const clicks = Number(q.clicks || 0);
+                    const impressions = Number(q.impressions || 0);
+                    const ctr = Number(q.ctr || 0);
+                    const ctrColor = ctr >= 3 ? '#065f46' : ctr >= 1 ? '#92400e' : '#7f1d1d';
+                    const ctrBg = ctr >= 3 ? 'linear-gradient(135deg, #d1fae5 0%, #ecfdf5 100%)' : ctr >= 1 ? 'linear-gradient(135deg, #fef3c7 0%, #fffbeb 100%)' : 'linear-gradient(135deg, #fee2e2 0%, #fff1f2 100%)';
+                    const risingSet = new Set(risingQueries.map(r => String(r.query || '').toLowerCase()));
+                    const isTrending = risingSet.has(String(q.query || '').toLowerCase());
+                    return (
+                      <ListItem key={index} sx={{ px: 0, py: 0.5 }}>
+                        <Paper elevation={0} sx={{ px: 1, py: 0.75, width: '100%', borderRadius: 2, border: '1px solid #e5e7eb', background: 'linear-gradient(180deg, #ffffff 0%, #f8fafc 100%)' }}>
+                        <ListItemIcon sx={{ minWidth: 28 }}>
+                          <Typography variant="caption" sx={{ color: '#6b7280' }}>
+                            {index + 1}
+                          </Typography>
+                        </ListItemIcon>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.2, width: '100%', justifyContent: 'space-between' }}>
+                          <Box sx={{ minWidth: 0, flex: 1 }}>
+                            <Tooltip title={`${q.query}`}>
+                              <Typography variant="body2" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                {q.query}
+                              </Typography>
+                            </Tooltip>
+                            {isTrending && (
+                              <Chip
+                                icon={<TrendingUp fontSize="small" />}
+                                label="Trending"
+                                size="small"
+                                sx={{ mt: 0.5, backgroundImage: 'linear-gradient(135deg, #ecfdf5 0%, #ffffff 100%)', color: '#065f46', border: '1px solid #a7f3d0', boxShadow: '0 1px 2px rgba(0,0,0,0.04)', fontWeight: 700 }}
+                              />
+                            )}
+                          </Box>
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.2, flexShrink: 0 }}>
+                            <Tooltip title="Total clicks across the selected date range. Higher is better.">
+                              <Chip icon={<MouseOutlined fontSize="small" />} label={`${formatNumber(clicks)}`} size="small" sx={{ backgroundImage: 'linear-gradient(135deg, #dbeafe 0%, #eef2ff 100%)', color: '#1e3a8a', border: '1px solid #c7d2fe', boxShadow: '0 1px 2px rgba(0,0,0,0.05)', fontWeight: 700 }} />
+                            </Tooltip>
+                            <Tooltip title="Total impressions across the selected date range. Indicates visibility in search results.">
+                              <Chip icon={<Visibility fontSize="small" />} label={`${formatNumber(impressions)}`} size="small" sx={{ backgroundImage: 'linear-gradient(135deg, #e2e8f0 0%, #f8fafc 100%)', color: '#0f172a', border: '1px solid #cbd5e1', boxShadow: '0 1px 2px rgba(0,0,0,0.05)', fontWeight: 700 }} />
+                            </Tooltip>
+                            <Tooltip title="Click-through rate. Higher indicates titles/meta attract clicks for given impressions.">
+                              <Chip label={`${ctr.toFixed(1)}%`} size="small" sx={{ backgroundImage: ctrBg, color: ctrColor, border: '1px solid rgba(0,0,0,0.06)', boxShadow: '0 1px 2px rgba(0,0,0,0.04)', fontWeight: 700 }} />
+                            </Tooltip>
+                          </Box>
+                        </Box>
+                        </Paper>
+                      </ListItem>
+                    );
+                  })}
+                </List>
+              </Box>
+            )}
+          </>
+        )}
+
+        {data.status === 'error' && (
+          <Box sx={{ mt: 1 }}>
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {data.error_message || 'Failed to load analytics data'}
+            </Alert>
+            {platform === 'bing' && bingCollectMsg && (
+              <Alert severity="info" sx={{ mb: 2 }}>{bingCollectMsg}</Alert>
+            )}
+            {onReconnect && (
+              <Button
+                variant="outlined"
+                color="error"
+                size="small"
+                onClick={() => onReconnect(platform)}
+                sx={{ 
+                  textTransform: 'none',
+                  fontWeight: 600,
+                  borderColor: '#f44336',
+                  color: '#f44336',
+                  '&:hover': {
+                    borderColor: '#d32f2f',
+                    backgroundColor: 'rgba(244, 67, 54, 0.04)'
+                  }
+                }}
+              >
+                Reconnect {platform.toUpperCase()}
+              </Button>
+            )}
+          </Box>
+        )}
+
+        {data.status === 'partial' && (
+          <Alert severity="warning" sx={{ mt: 1 }}>
+            {data.error_message || 'Limited analytics data available'}
+          </Alert>
+        )}
+
+        <Typography variant="caption" sx={{ display: 'block', mt: 1, color: '#6b7280' }}>
+          Last updated: {data.last_updated ? new Date(data.last_updated).toLocaleString() : 'Never'}
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default MetricsCard;

--- a/frontend/src/components/shared/PlatformAnalytics.tsx
+++ b/frontend/src/components/shared/PlatformAnalytics.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useCallback, useRef, Suspense } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { keyframes } from '@emotion/react';
 import {
   Box,
   Card,
@@ -6,7 +7,6 @@ import {
   Typography,
   Grid,
   Chip,
-  LinearProgress,
   Alert,
   CircularProgress,
   IconButton,
@@ -14,18 +14,6 @@ import {
   InputLabel,
   Select,
   MenuItem,
-  List,
-  ListItem,
-  ListItemText,
-  ListItemIcon,
-  Tooltip,
-  Paper,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  TextField,
-  Stack,
 } from '@mui/material';
 import Visibility from '@mui/icons-material/Visibility';
 import MouseOutlined from '@mui/icons-material/MouseOutlined';
@@ -46,182 +34,20 @@ import TopPagesInsightsPanel from './TopPagesInsightsPanel';
 import GscSuggestionsPanel from './GscSuggestionsPanel';
 import RefreshQueuePanel from './RefreshQueuePanel';
 import ChipLegend from './ChipLegend';
-import { apiClient } from '../../api/client';
-import {
-  LazyBarChart,
-  LazyLineChart,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip as RechartsTooltip,
-  ResponsiveContainer,
-  Bar,
-  Line,
-  ChartLoadingFallback,
-} from '../../utils/lazyRecharts';
+import CannibalizationAlertsPanel from './CannibalizationAlertsPanel';
+import SummaryCharts from './SummaryCharts';
+import ContentBriefDialog from './ContentBriefDialog';
+import AIInsightsPanel from './AIInsightsPanel';
+import BingToolbar from './BingToolbar';
+import MetricsCard from './MetricsCard';
 
-interface CannibalizationPage {
-  page: string;
-  clicks: number;
-  impressions: number;
-  ctr: number;
-}
+const shimmerBg = keyframes`
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+`;
 
-interface CannibalizationAlert {
-  query: string;
-  total_clicks: number;
-  recommended_target_page?: string;
-  pages?: CannibalizationPage[];
-}
-
-interface CannibalizationAlertsPanelProps {
-  alerts: CannibalizationAlert[];
-  formatNumber: (n: number) => string;
-  isValidHttpUrl: (url: string) => boolean;
-  onOpenBrief: (page: string, query: string, totalClicks: number) => void;
-}
-
-const CannibalizationAlertsPanel: React.FC<CannibalizationAlertsPanelProps> = ({
-  alerts,
-  formatNumber,
-  isValidHttpUrl,
-  onOpenBrief,
-}) => {
-  return (
-    <Card sx={{ mt: 2, bgcolor: '#ffffff !important', color: '#1f2937 !important', border: '1px solid #e5e7eb !important', boxShadow: '0 1px 3px 0 rgba(0,0,0,0.1) !important' }}>
-      <CardContent>
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Typography variant="subtitle1">Cannibalization Alerts</Typography>
-            <Tooltip title="The same search query points to multiple pages on your site, splitting clicks. Choose one target page and consolidate overlapping pages or add internal links.">
-              <Info fontSize="small" color="action" />
-            </Tooltip>
-          </Box>
-          <Typography variant="caption" color="text.secondary">Queries competing across pages</Typography>
-        </Box>
-        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
-          “No cannibalization” is normal for tightly targeted sites or low‑traffic windows. For demos we can relax sensitivity.
-        </Typography>
-        <ChipLegend
-          items={[
-            {
-              label: 'Competing page',
-              icon: <MouseOutlined fontSize="small" />,
-              tooltip: 'Each chip is a page that shares the same query. Text shows URL • clicks • impressions • CTR.',
-              sx: {
-                backgroundImage: 'linear-gradient(135deg, #e2e8f0 0%, #f8fafc 100%)',
-                color: '#0f172a',
-                border: '1px solid #cbd5e1',
-                boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
-                fontWeight: 700,
-              },
-            },
-            {
-              label: 'Higher CTR',
-              tooltip: 'Greener backgrounds mean this page converts searchers relatively well.',
-              sx: {
-                backgroundImage: 'linear-gradient(135deg, #d1fae5 0%, #ecfdf5 100%)',
-                color: '#065f46',
-                border: '1px solid #86efac',
-                boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
-                fontWeight: 700,
-              },
-            },
-            {
-              label: 'Weaker CTR',
-              tooltip: 'Redder backgrounds flag pages that may need consolidation or updates.',
-              sx: {
-                backgroundImage: 'linear-gradient(135deg, #fee2e2 0%, #fff1f2 100%)',
-                color: '#7f1d1d',
-                border: '1px solid #fecdd3',
-                boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
-                fontWeight: 700,
-              },
-            },
-          ]}
-        />
-        {(!alerts || alerts.length === 0) ? (
-          <Alert severity="info">No cannibalization detected for this window.</Alert>
-        ) : (
-          <List dense>
-            {alerts.slice(0, 10).map((a, idx) => (
-              <ListItem key={`${a.query}-${idx}`} sx={{ px: 0, alignItems: 'flex-start' }}>
-                <ListItemText
-                  primary={a.query}
-                  secondary={
-                    <Box sx={{ mt: 0.5 }}>
-                      <Typography variant="caption" sx={{ color: '#6b7280', display: 'block', mb: 0.5 }}>
-                        Total clicks: {formatNumber(a.total_clicks || 0)} • Target: {a.recommended_target_page || 'N/A'}
-                      </Typography>
-                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                        {(a.pages || []).map((p, i) => {
-                          const clicks = Number(p.clicks || 0);
-                          const impressions = Number(p.impressions || 0);
-                          const ctr = Number(p.ctr || 0);
-                          const ctrColor = ctr >= 3 ? '#065f46' : ctr >= 1 ? '#92400e' : '#7f1d1d';
-                          const ctrBg = ctr >= 3
-                            ? 'linear-gradient(135deg, #d1fae5 0%, #ecfdf5 100%)'
-                            : ctr >= 1
-                            ? 'linear-gradient(135deg, #fef3c7 0%, #fffbeb 100%)'
-                            : 'linear-gradient(135deg, #fee2e2 0%, #fff1f2 100%)';
-                          const label = `${String(p.page || '').replace(/^https?:\/\//, '').slice(0, 40)} • ${formatNumber(clicks)}c/${formatNumber(impressions)}i • ${ctr.toFixed(1)}%`;
-                          return (
-                            <Tooltip
-                              key={`${p.page}-${i}`}
-                              title={`Clicks ${clicks}, impressions ${impressions}, CTR ${ctr.toFixed(1)}% for this page`}
-                            >
-                              <Chip
-                                label={label}
-                                size="small"
-                                sx={{
-                                  backgroundImage: ctrBg,
-                                  color: ctrColor,
-                                  border: '1px solid rgba(0,0,0,0.06)',
-                                  boxShadow: '0 1px 2px rgba(0,0,0,0.04)',
-                                  fontWeight: 700,
-                                  maxWidth: 260,
-                                }}
-                              />
-                            </Tooltip>
-                          );
-                        })}
-                      </Box>
-                    </Box>
-                  }
-                  primaryTypographyProps={{ variant: 'body2' }}
-                />
-                <Button
-                  size="small"
-                  variant="outlined"
-                  sx={{ mr: 1, textTransform: 'none' }}
-                  disabled={!a.recommended_target_page || !isValidHttpUrl(String(a.recommended_target_page))}
-                  onClick={() => {
-                    if (a.recommended_target_page && isValidHttpUrl(String(a.recommended_target_page))) {
-                      window.open(String(a.recommended_target_page), '_blank');
-                    }
-                  }}
-                >
-                  Open Target Page
-                </Button>
-                <Button
-                  size="small"
-                  variant="contained"
-                  sx={{ textTransform: 'none' }}
-                  onClick={() => {
-                    const page = String(a.recommended_target_page || '');
-                    onOpenBrief(page, a.query, a.total_clicks || 0);
-                  }}
-                >
-                  Create Brief
-                </Button>
-              </ListItem>
-            ))}
-          </List>
-        )}
-      </CardContent>
-    </Card>
-  );
-};
+// CannibalizationPage, CannibalizationAlert, CannibalizationAlertsPanelProps, CannibalizationAlertsPanel moved to CannibalizationAlertsPanel.tsx
 
 interface PlatformAnalyticsComponentProps {
   platforms?: string[];
@@ -262,7 +88,6 @@ const PlatformAnalytics: React.FC<PlatformAnalyticsComponentProps> = ({
   const [aiError, setAiError] = useState<string | null>(null);
   const [aiInsights, setAiInsights] = useState<any | null>(null);
   const [resyncAttempted, setResyncAttempted] = useState<boolean>(false);
-  const [bingCollecting, setBingCollecting] = useState<boolean>(false);
   const [bingCollectMsg, setBingCollectMsg] = useState<string | null>(null);
   const [bingSiteUrl, setBingSiteUrl] = useState<string>('');
   const [showLegend, setShowLegend] = useState<boolean>(false);
@@ -451,6 +276,7 @@ const PlatformAnalytics: React.FC<PlatformAnalyticsComponentProps> = ({
       const prevQueries = (prevGSC?.metrics as any)?.top_queries || [];
       const prevMap: Record<string, { clicks: number; impressions: number }> = {};
       prevQueries.forEach((q: any) => {
+        if (!q) return;
         const key = String(q.query || '').toLowerCase();
         prevMap[key] = { clicks: Number(q.clicks || 0), impressions: Number(q.impressions || 0) };
       });
@@ -461,6 +287,7 @@ const PlatformAnalytics: React.FC<PlatformAnalyticsComponentProps> = ({
       const dropClicksThresh = -riseClicksThresh;
       const dropImprThresh = -riseImprThresh;
       currQueries.forEach((q: any) => {
+        if (!q) return;
         const key = String(q.query || '').toLowerCase();
         const prev = prevMap[key] || { clicks: 0, impressions: 0 };
         const deltaClicks = Number(q.clicks || 0) - prev.clicks;
@@ -478,6 +305,7 @@ const PlatformAnalytics: React.FC<PlatformAnalyticsComponentProps> = ({
       if (rising.length === 0 && declining.length === 0) {
         const deltas: Array<{ query: string; deltaClicks: number; deltaImpressions: number; score: number }> = [];
         currQueries.forEach((q: any) => {
+          if (!q) return;
           const key = String(q.query || '').toLowerCase();
           const prev = prevMap[key] || { clicks: 0, impressions: 0 };
           const dC = Number(q.clicks || 0) - prev.clicks;
@@ -737,253 +565,25 @@ const PlatformAnalytics: React.FC<PlatformAnalyticsComponentProps> = ({
     });
   }, [summary, computedSummary, analyticsData, priorityPlatform, platformStatus]);
 
-  const renderMetricsCard = (platform: string, data: PlatformAnalyticsType) => {
-    const metrics = data.metrics;
-    
-    return (
-      <Card key={platform} sx={{ height: '100%', bgcolor: '#ffffff', color: '#1f2937', border: '1px solid #e5e7eb', boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1)' }}>
-        <CardContent>
-          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              {getPlatformIcon(platform)}
-              <Typography variant="h6" component="div">
-                {platform.toUpperCase()}
-              </Typography>
-            </Box>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              {getStatusIcon(data.status)}
-              <Chip 
-                label={data.status} 
-                color={getStatusColor(data.status) as any}
-                size="small"
-              />
-              {platform === 'bing' && (
-                <>
-                  <TextField
-                    size="small"
-                    placeholder="https://www.example.com/"
-                    value={bingSiteUrl}
-                    onChange={(e) => setBingSiteUrl(e.target.value)}
-                    sx={{ minWidth: 280 }}
-                    label="Bing Site URL"
-                  />
-                <Button
-                  variant="outlined"
-                  size="small"
-                  disabled={bingCollecting}
-                  onClick={async () => {
-                    try {
-                      setBingCollectMsg(null);
-                      setBingCollecting(true);
-                      // Derive a site URL from platform status first, then metrics fallback
-                      const bingStatus = platformStatus?.['bing'];
-                      const statusSites: any[] = Array.isArray(bingStatus?.sites) ? bingStatus!.sites : [];
-                      const metricsSites: any[] = Array.isArray((data as any)?.metrics?.sites) ? (data as any).metrics.sites : [];
-                      const candidates = [...statusSites, ...metricsSites];
-                      let siteUrl: string =
-                        (candidates.find(s => typeof s?.Url === 'string')?.Url) ||
-                        (candidates.find(s => typeof s?.url === 'string')?.url) ||
-                        '';
-                      // If user entered a site URL, prefer it
-                      if (bingSiteUrl && typeof bingSiteUrl === 'string') {
-                        siteUrl = bingSiteUrl.trim();
-                      }
-                      if (!siteUrl) {
-                        setBingCollectMsg('No Bing site found to collect.');
-                        return;
-                      }
-                      await apiClient.post('/bing-analytics/collect-data', null, {
-                        params: { site_url: siteUrl, days_back: Math.max(7, Math.min(90, rangeDays)) }
-                      });
-                      setBingCollectMsg('Bing storage refresh started…');
-                      // Soft refresh after a short delay to reflect any quick writes
-                      setTimeout(() => {
-                        forceRefresh().catch(() => {});
-                      }, 3500);
-                    } catch (e: any) {
-                      setBingCollectMsg(e?.message || 'Failed to start Bing collection');
-                    } finally {
-                      setBingCollecting(false);
-                    }
-                  }}
-                  sx={{ textTransform: 'none' }}
-                >
-                  {bingCollecting ? 'Refreshing…' : 'Refresh Bing Storage'}
-                </Button>
-                </>
-              )}
-            </Box>
-          </Box>
-
-          {data.status === 'success' && (
-            <>
-              <Grid container spacing={2}>
-                {metrics.total_clicks !== undefined && (
-                  <Grid item xs={6}>
-                    <Box sx={{ textAlign: 'center' }}>
-                      <MouseOutlined color="primary" sx={{ fontSize: 32, mb: 1 }} />
-                      <Typography variant="h4" color="primary">
-                        {formatNumber(metrics.total_clicks)}
-                      </Typography>
-                      <Typography variant="caption" sx={{ color: '#6b7280' }}>
-                        Clicks
-                      </Typography>
-                    </Box>
-                  </Grid>
-                )}
-                
-                {metrics.total_impressions !== undefined && (
-                  <Grid item xs={6}>
-                    <Box sx={{ textAlign: 'center' }}>
-                      <Visibility color="secondary" sx={{ fontSize: 32, mb: 1 }} />
-                      <Typography variant="h4" color="secondary">
-                        {formatNumber(metrics.total_impressions)}
-                      </Typography>
-                      <Typography variant="caption" sx={{ color: '#6b7280' }}>
-                        Impressions
-                      </Typography>
-                    </Box>
-                  </Grid>
-                )}
-              </Grid>
-
-              {metrics.avg_ctr !== undefined && (
-                <Box sx={{ mt: 2 }}>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                    <Typography variant="body2">CTR</Typography>
-                    <Typography variant="body2" fontWeight="bold">
-                      {metrics.avg_ctr}%
-                    </Typography>
-                  </Box>
-                  <LinearProgress 
-                    variant="determinate" 
-                    value={Math.min(metrics.avg_ctr * 10, 100)} 
-                    sx={{ height: 8, borderRadius: 4 }}
-                  />
-                </Box>
-              )}
-
-              {metrics.avg_position !== undefined && (
-                <Box sx={{ mt: 1 }}>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                    <Typography variant="body2">Avg Position</Typography>
-                    <Typography variant="body2" fontWeight="bold">
-                      {metrics.avg_position.toFixed(1)}
-                    </Typography>
-                  </Box>
-                  <LinearProgress 
-                    variant="determinate" 
-                    value={Math.max(0, 100 - (metrics.avg_position - 1) * 5)} 
-                    color="secondary"
-                    sx={{ height: 6, borderRadius: 4 }}
-                  />
-                </Box>
-              )}
-
-              {metrics.top_queries && metrics.top_queries.length > 0 && (
-                <Box sx={{ mt: 2 }}>
-                  <Typography variant="subtitle2" gutterBottom>
-                    Top Queries
-                  </Typography>
-                  <List dense>
-                    {metrics.top_queries.slice(0, 3).map((q: any, index: number) => {
-                      const clicks = Number(q.clicks || 0);
-                      const impressions = Number(q.impressions || 0);
-                      const ctr = Number(q.ctr || 0);
-                      const ctrColor = ctr >= 3 ? '#065f46' : ctr >= 1 ? '#92400e' : '#7f1d1d';
-                      const ctrBg = ctr >= 3 ? 'linear-gradient(135deg, #d1fae5 0%, #ecfdf5 100%)' : ctr >= 1 ? 'linear-gradient(135deg, #fef3c7 0%, #fffbeb 100%)' : 'linear-gradient(135deg, #fee2e2 0%, #fff1f2 100%)';
-                      const risingSet = new Set((refreshQueue?.risingQueries || []).map(r => String(r.query || '').toLowerCase()));
-                      const isTrending = risingSet.has(String(q.query || '').toLowerCase());
-                      return (
-                        <ListItem key={index} sx={{ px: 0, py: 0.5 }}>
-                          <Paper elevation={0} sx={{ px: 1, py: 0.75, width: '100%', borderRadius: 2, border: '1px solid #e5e7eb', background: 'linear-gradient(180deg, #ffffff 0%, #f8fafc 100%)' }}>
-                          <ListItemIcon sx={{ minWidth: 28 }}>
-                            <Typography variant="caption" sx={{ color: '#6b7280' }}>
-                              {index + 1}
-                            </Typography>
-                          </ListItemIcon>
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.2, width: '100%', justifyContent: 'space-between' }}>
-                            <Box sx={{ minWidth: 0, flex: 1 }}>
-                              <Tooltip title={`${q.query}`}>
-                                <Typography variant="body2" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                  {q.query}
-                                </Typography>
-                              </Tooltip>
-                              {isTrending && (
-                                <Chip
-                                  icon={<TrendingUp fontSize="small" />}
-                                  label="Trending"
-                                  size="small"
-                                  sx={{ mt: 0.5, backgroundImage: 'linear-gradient(135deg, #ecfdf5 0%, #ffffff 100%)', color: '#065f46', border: '1px solid #a7f3d0', boxShadow: '0 1px 2px rgba(0,0,0,0.04)', fontWeight: 700 }}
-                                />
-                              )}
-                            </Box>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.2, flexShrink: 0 }}>
-                              <Tooltip title="Total clicks across the selected date range. Higher is better.">
-                                <Chip icon={<MouseOutlined fontSize="small" />} label={`${formatNumber(clicks)}`} size="small" sx={{ backgroundImage: 'linear-gradient(135deg, #dbeafe 0%, #eef2ff 100%)', color: '#1e3a8a', border: '1px solid #c7d2fe', boxShadow: '0 1px 2px rgba(0,0,0,0.05)', fontWeight: 700 }} />
-                              </Tooltip>
-                              <Tooltip title="Total impressions across the selected date range. Indicates visibility in search results.">
-                                <Chip icon={<Visibility fontSize="small" />} label={`${formatNumber(impressions)}`} size="small" sx={{ backgroundImage: 'linear-gradient(135deg, #e2e8f0 0%, #f8fafc 100%)', color: '#0f172a', border: '1px solid #cbd5e1', boxShadow: '0 1px 2px rgba(0,0,0,0.05)', fontWeight: 700 }} />
-                              </Tooltip>
-                              <Tooltip title="Click-through rate. Higher indicates titles/meta attract clicks for given impressions.">
-                                <Chip label={`${ctr.toFixed(1)}%`} size="small" sx={{ backgroundImage: ctrBg, color: ctrColor, border: '1px solid rgba(0,0,0,0.06)', boxShadow: '0 1px 2px rgba(0,0,0,0.04)', fontWeight: 700 }} />
-                              </Tooltip>
-                            </Box>
-                          </Box>
-                          </Paper>
-                        </ListItem>
-                      );
-                    })}
-                  </List>
-                </Box>
-              )}
-            </>
-          )}
-
-          {data.status === 'error' && (
-            <Box sx={{ mt: 1 }}>
-              <Alert severity="error" sx={{ mb: 2 }}>
-                {data.error_message || 'Failed to load analytics data'}
-              </Alert>
-              {platform === 'bing' && bingCollectMsg && (
-                <Alert severity="info" sx={{ mb: 2 }}>{bingCollectMsg}</Alert>
-              )}
-              {onReconnect && (
-                <Button
-                  variant="outlined"
-                  color="error"
-                  size="small"
-                  onClick={() => onReconnect(platform)}
-                  sx={{ 
-                    textTransform: 'none',
-                    fontWeight: 600,
-                    borderColor: '#f44336',
-                    color: '#f44336',
-                    '&:hover': {
-                      borderColor: '#d32f2f',
-                      backgroundColor: 'rgba(244, 67, 54, 0.04)'
-                    }
-                  }}
-                >
-                  Reconnect {platform.toUpperCase()}
-                </Button>
-              )}
-            </Box>
-          )}
-
-          {data.status === 'partial' && (
-            <Alert severity="warning" sx={{ mt: 1 }}>
-              {data.error_message || 'Limited analytics data available'}
-            </Alert>
-          )}
-
-          <Typography variant="caption" sx={{ display: 'block', mt: 1, color: '#6b7280' }}>
-            Last updated: {data.last_updated ? new Date(data.last_updated).toLocaleString() : 'Never'}
-          </Typography>
-        </CardContent>
-      </Card>
-    );
-  };
+  const renderMetricsCard = (platform: string, data: PlatformAnalyticsType) => (
+    <MetricsCard
+      platform={platform}
+      data={data}
+      formatNumber={formatNumber}
+      getPlatformIcon={getPlatformIcon}
+      getStatusColor={getStatusColor}
+      getStatusIcon={getStatusIcon}
+      bingSiteUrl={bingSiteUrl}
+      onBingSiteUrlChange={setBingSiteUrl}
+      bingCollectMsg={bingCollectMsg}
+      onBingCollectMsgChange={setBingCollectMsg}
+      rangeDays={rangeDays}
+      bingStatus={platformStatus?.['bing']}
+      onForceRefresh={forceRefresh}
+      onReconnect={onReconnect}
+      risingQueries={refreshQueue?.risingQueries || []}
+    />
+  );
 
   const renderSummaryCard = () => {
     if (!summary) return null;
@@ -1140,123 +740,11 @@ const PlatformAnalytics: React.FC<PlatformAnalyticsComponentProps> = ({
             </Alert>
           )}
 
-          {(topPagesChart.length > 0 || ctrPositionData.length > 0) && (
-            <Box sx={{ mt: 2.5 }}>
-              <Grid container spacing={2}>
-                {topPagesChart.length > 0 && (
-                  <Grid item xs={12} md={6}>
-                    <Typography variant="subtitle2" sx={{ mb: 0.25 }}>Top pages impact</Typography>
-                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
-                      Where most of your clicks are concentrated in this window.
-                    </Typography>
-                    <Box sx={{ height: 180, bgcolor: '#020617', borderRadius: 2, p: 1.5, border: '1px solid rgba(148, 163, 184, 0.4)' }}>
-                      <Suspense fallback={<ChartLoadingFallback />}>
-                        <ResponsiveContainer width="100%" height="100%">
-                          <LazyBarChart
-                            data={topPagesChart}
-                            layout="vertical"
-                            margin={{ top: 8, right: 12, bottom: 8, left: 0 }}
-                          >
-                            <CartesianGrid strokeDasharray="3 3" stroke="#475569" opacity={0.25} />
-                            <XAxis type="number" hide />
-                            <YAxis
-                              type="category"
-                              dataKey="label"
-                              width={130}
-                              tick={{ fill: '#e5e7eb', fontSize: 11 }}
-                            />
-                            <RechartsTooltip
-                              contentStyle={{
-                                backgroundColor: '#020617',
-                                borderRadius: 8,
-                                border: '1px solid #4b5563',
-                                padding: 8,
-                              }}
-                              formatter={(value: any, name: any, props: any) => {
-                                if (name === 'clicks') {
-                                  return [formatNumber(Number(value || 0)), 'Clicks'];
-                                }
-                                if (name === 'impressions') {
-                                  return [formatNumber(Number(value || 0)), 'Impressions'];
-                                }
-                                if (name === 'ctr') {
-                                  return [`${Number(value || 0).toFixed(2)}%`, 'CTR'];
-                                }
-                                return [value, name];
-                              }}
-                              labelFormatter={(label: any, payload: any) => {
-                                const full = payload && payload[0] && (payload[0].payload as any)?.fullUrl;
-                                return full || String(label || '');
-                              }}
-                            />
-                            <Bar dataKey="clicks" fill="#38bdf8" radius={[0, 6, 6, 0]} />
-                          </LazyBarChart>
-                        </ResponsiveContainer>
-                      </Suspense>
-                    </Box>
-                  </Grid>
-                )}
-                {ctrPositionData.length > 0 && (
-                  <Grid item xs={12} md={6}>
-                    <Typography variant="subtitle2" sx={{ mb: 0.25 }}>CTR vs average position</Typography>
-                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
-                      How click‑through rate changes as your queries move up and down.
-                    </Typography>
-                    <Box sx={{ height: 180, bgcolor: '#020617', borderRadius: 2, p: 1.5, border: '1px solid rgba(148, 163, 184, 0.4)' }}>
-                      <Suspense fallback={<ChartLoadingFallback />}>
-                        <ResponsiveContainer width="100%" height="100%">
-                          <LazyLineChart
-                            data={ctrPositionData}
-                            margin={{ top: 8, right: 12, bottom: 8, left: -10 }}
-                          >
-                            <CartesianGrid strokeDasharray="3 3" stroke="#475569" opacity={0.25} />
-                            <XAxis
-                              type="number"
-                              dataKey="position"
-                              domain={[1, 'dataMax']}
-                              tick={{ fill: '#e5e7eb', fontSize: 11 }}
-                              tickLine={false}
-                            />
-                            <YAxis
-                              tick={{ fill: '#e5e7eb', fontSize: 11 }}
-                              tickFormatter={(v) => `${v}%`}
-                              tickLine={false}
-                            />
-                            <RechartsTooltip
-                              contentStyle={{
-                                backgroundColor: '#020617',
-                                borderRadius: 8,
-                                border: '1px solid #4b5563',
-                                padding: 8,
-                              }}
-                              formatter={(value: any, name: any, props: any) => {
-                                if (name === 'ctr') {
-                                  return [`${Number(value || 0).toFixed(2)}%`, 'CTR'];
-                                }
-                                return [value, name];
-                              }}
-                              labelFormatter={(label: any, payload: any) => {
-                                const q = payload && payload[0] && (payload[0].payload as any)?.query;
-                                return `Position ${label}${q ? ` • ${q}` : ''}`;
-                              }}
-                            />
-                            <Line
-                              type="monotone"
-                              dataKey="ctr"
-                              stroke="#a855f7"
-                              strokeWidth={2.2}
-                              dot={{ r: 3, fill: '#a855f7', strokeWidth: 0 }}
-                              activeDot={{ r: 5 }}
-                            />
-                          </LazyLineChart>
-                        </ResponsiveContainer>
-                      </Suspense>
-                    </Box>
-                  </Grid>
-                )}
-              </Grid>
-            </Box>
-          )}
+          <SummaryCharts
+            topPagesChart={topPagesChart}
+            ctrPositionData={ctrPositionData}
+            formatNumber={formatNumber}
+          />
 
           <Box
             sx={{
@@ -1283,12 +771,7 @@ const PlatformAnalytics: React.FC<PlatformAnalyticsComponentProps> = ({
                 color: '#f9fafb',
                 boxShadow: '0 0 18px rgba(34, 197, 94, 0.45)',
                 transition: 'transform 0.15s ease-out, box-shadow 0.15s ease-out, background-position 0.3s ease-out',
-                '@keyframes shimmerLegend': {
-                  '0%': { backgroundPosition: '0% 50%' },
-                  '50%': { backgroundPosition: '100% 50%' },
-                  '100%': { backgroundPosition: '0% 50%' },
-                },
-                animation: 'shimmerLegend 7s ease infinite',
+                animation: `${shimmerBg} 7s ease infinite`,
                 '&:hover': {
                   boxShadow: '0 0 26px rgba(34, 197, 94, 0.85)',
                   transform: 'translateY(-1px)',
@@ -1335,12 +818,7 @@ const PlatformAnalytics: React.FC<PlatformAnalyticsComponentProps> = ({
                 color: '#f9fafb',
                 boxShadow: '0 0 22px rgba(129, 140, 248, 0.6)',
                 transition: 'transform 0.15s ease-out, box-shadow 0.15s ease-out, background-position 0.3s ease-out',
-                '@keyframes shimmerAI': {
-                  '0%': { backgroundPosition: '0% 50%' },
-                  '50%': { backgroundPosition: '100% 50%' },
-                  '100%': { backgroundPosition: '0% 50%' },
-                },
-                animation: 'shimmerAI 6s ease infinite',
+                animation: `${shimmerBg} 6s ease infinite`,
                 '&:hover': {
                   boxShadow: '0 0 30px rgba(129, 140, 248, 0.95)',
                   transform: 'translateY(-1px)',
@@ -1403,44 +881,7 @@ const PlatformAnalytics: React.FC<PlatformAnalyticsComponentProps> = ({
             </Box>
           )}
 
-          {(aiError || aiInsights) && (
-            <Box sx={{ mt: 2.5 }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
-                <Typography variant="subtitle2">AI Insights</Typography>
-                <Tooltip title="Summarizes all panels into simple recommendations for creators.">
-                  <Info fontSize="small" color="action" />
-                </Tooltip>
-              </Box>
-              {aiError && <Alert severity="error" sx={{ mb: 1 }}>{aiError}</Alert>}
-              {aiInsights && (
-                <Box>
-                  <Typography variant="body2" sx={{ mb: 1 }}>{aiInsights.quick_summary}</Typography>
-                  {Array.isArray(aiInsights.prioritized_findings) && aiInsights.prioritized_findings.length > 0 && (
-                    <List dense>
-                      {aiInsights.prioritized_findings.slice(0, 3).map((f: any, i: number) => (
-                        <ListItem key={`ai-find-${i}`} sx={{ px: 0, alignItems: 'flex-start' }}>
-                          <ListItemText
-                            primary={f.title}
-                            secondary={
-                              <Box sx={{ mt: 0.5 }}>
-                                <Typography variant="caption" sx={{ color: '#6b7280', display: 'block' }}>{f.evidence}</Typography>
-                                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
-                                  {(f.actions || []).slice(0, 2).map((a: string, idx: number) => (
-                                    <Chip key={`act-${idx}`} label={a} size="small" />
-                                  ))}
-                                </Box>
-                              </Box>
-                            }
-                            primaryTypographyProps={{ variant: 'body2' }}
-                          />
-                        </ListItem>
-                      ))}
-                    </List>
-                  )}
-                </Box>
-              )}
-            </Box>
-          )}
+          <AIInsightsPanel aiError={aiError} aiInsights={aiInsights} />
         </CardContent>
       </Card>
     );
@@ -1499,57 +940,11 @@ const PlatformAnalytics: React.FC<PlatformAnalyticsComponentProps> = ({
         );
       })()}
 
-      <Dialog open={briefOpen} onClose={() => setBriefOpen(false)} fullWidth maxWidth="sm">
-        <DialogTitle>Create Content Brief</DialogTitle>
-        <DialogContent dividers>
-          <Stack spacing={2}>
-            <TextField
-              label="Page URL"
-              value={briefData?.page || ''}
-              InputProps={{ readOnly: true }}
-              fullWidth
-              size="small"
-            />
-            <Box>
-              <Typography variant="subtitle2" gutterBottom>Recent queries pointing to this page</Typography>
-              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                {(briefData?.queries || []).slice(0, 10).map((q, i) => (
-                  <Chip
-                    key={`${q.query}-${i}`}
-                    label={`${q.query} • ${q.clicks}c/${q.impressions}i • ${q.ctr.toFixed(1)}%`}
-                    size="small"
-                  />
-                ))}
-                {(briefData?.queries || []).length === 0 && (
-                  <Typography variant="caption" color="text.secondary">No query mappings available for this window.</Typography>
-                )}
-              </Box>
-            </Box>
-          </Stack>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setBriefOpen(false)}>Cancel</Button>
-          <Button
-            variant="contained"
-            onClick={() => {
-              try {
-                const prefill = {
-                  page: briefData?.page || '',
-                  queries: briefData?.queries || [],
-                  created_at: new Date().toISOString(),
-                  source: 'platform_analytics_top_pages',
-                };
-                localStorage.setItem('alwrity_brief_prefill', JSON.stringify(prefill));
-              } catch {}
-              setBriefOpen(false);
-              // Optional: navigate to writer; keeping simple and non-disruptive
-              // window.location.href = '/blog-writer';
-            }}
-          >
-            Start Brief
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <ContentBriefDialog
+        open={briefOpen}
+        onClose={() => setBriefOpen(false)}
+        briefData={briefData}
+      />
 
       {showBackgroundJobs && (
         <RefreshQueuePanel

--- a/frontend/src/components/shared/SummaryCharts.tsx
+++ b/frontend/src/components/shared/SummaryCharts.tsx
@@ -1,0 +1,158 @@
+import React, { Suspense } from 'react';
+import { Box, Grid, Typography } from '@mui/material';
+import {
+  LazyBarChart,
+  LazyLineChart,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as RechartsTooltip,
+  ResponsiveContainer,
+  Bar,
+  Line,
+  ChartLoadingFallback,
+} from '../../utils/lazyRecharts';
+
+interface TopPageChartItem {
+  label: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  fullUrl: string;
+}
+
+interface CTRPositionItem {
+  query: string;
+  position: number;
+  ctr: number;
+}
+
+interface SummaryChartsProps {
+  topPagesChart: TopPageChartItem[];
+  ctrPositionData: CTRPositionItem[];
+  formatNumber: (n: number) => string;
+}
+
+const SummaryCharts: React.FC<SummaryChartsProps> = ({ topPagesChart, ctrPositionData, formatNumber }) => {
+  if (topPagesChart.length === 0 && ctrPositionData.length === 0) return null;
+
+  return (
+    <Box sx={{ mt: 2.5 }}>
+      <Grid container spacing={2}>
+        {topPagesChart.length > 0 && (
+          <Grid item xs={12} md={6}>
+            <Typography variant="subtitle2" sx={{ mb: 0.25 }}>Top pages impact</Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+              Where most of your clicks are concentrated in this window.
+            </Typography>
+            <Box sx={{ height: 180, bgcolor: '#020617', borderRadius: 2, p: 1.5, border: '1px solid rgba(148, 163, 184, 0.4)' }}>
+              <Suspense fallback={<ChartLoadingFallback />}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <LazyBarChart
+                    data={topPagesChart}
+                    layout="vertical"
+                    margin={{ top: 8, right: 12, bottom: 8, left: 0 }}
+                  >
+                    <CartesianGrid strokeDasharray="3 3" stroke="#475569" opacity={0.25} />
+                    <XAxis type="number" hide />
+                    <YAxis
+                      type="category"
+                      dataKey="label"
+                      width={130}
+                      tick={{ fill: '#e5e7eb', fontSize: 11 }}
+                    />
+                    <RechartsTooltip
+                      contentStyle={{
+                        backgroundColor: '#020617',
+                        borderRadius: 8,
+                        border: '1px solid #4b5563',
+                        padding: 8,
+                      }}
+                      formatter={(value: any, name: any, props: any) => {
+                        if (name === 'clicks') {
+                          return [formatNumber(Number(value || 0)), 'Clicks'];
+                        }
+                        if (name === 'impressions') {
+                          return [formatNumber(Number(value || 0)), 'Impressions'];
+                        }
+                        if (name === 'ctr') {
+                          return [`${Number(value || 0).toFixed(2)}%`, 'CTR'];
+                        }
+                        return [value, name];
+                      }}
+                      labelFormatter={(label: any, payload: any) => {
+                        const full = payload && payload[0] && (payload[0].payload as any)?.fullUrl;
+                        return full || String(label || '');
+                      }}
+                    />
+                    <Bar dataKey="clicks" fill="#38bdf8" radius={[0, 6, 6, 0]} />
+                  </LazyBarChart>
+                </ResponsiveContainer>
+              </Suspense>
+            </Box>
+          </Grid>
+        )}
+        {ctrPositionData.length > 0 && (
+          <Grid item xs={12} md={6}>
+            <Typography variant="subtitle2" sx={{ mb: 0.25 }}>CTR vs average position</Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+              How click‑through rate changes as your queries move up and down.
+            </Typography>
+            <Box sx={{ height: 180, bgcolor: '#020617', borderRadius: 2, p: 1.5, border: '1px solid rgba(148, 163, 184, 0.4)' }}>
+              <Suspense fallback={<ChartLoadingFallback />}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <LazyLineChart
+                    data={ctrPositionData}
+                    margin={{ top: 8, right: 12, bottom: 8, left: -10 }}
+                  >
+                    <CartesianGrid strokeDasharray="3 3" stroke="#475569" opacity={0.25} />
+                    <XAxis
+                      type="number"
+                      dataKey="position"
+                      domain={[1, 'dataMax']}
+                      tick={{ fill: '#e5e7eb', fontSize: 11 }}
+                      tickLine={false}
+                    />
+                    <YAxis
+                      tick={{ fill: '#e5e7eb', fontSize: 11 }}
+                      tickFormatter={(v) => `${v}%`}
+                      tickLine={false}
+                    />
+                    <RechartsTooltip
+                      contentStyle={{
+                        backgroundColor: '#020617',
+                        borderRadius: 8,
+                        border: '1px solid #4b5563',
+                        padding: 8,
+                      }}
+                      formatter={(value: any, name: any, props: any) => {
+                        if (name === 'ctr') {
+                          return [`${Number(value || 0).toFixed(2)}%`, 'CTR'];
+                        }
+                        return [value, name];
+                      }}
+                      labelFormatter={(label: any, payload: any) => {
+                        const q = payload && payload[0] && (payload[0].payload as any)?.query;
+                        return `Position ${label}${q ? ` • ${q}` : ''}`;
+                      }}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="ctr"
+                      stroke="#a855f7"
+                      strokeWidth={2.2}
+                      dot={{ r: 3, fill: '#a855f7', strokeWidth: 0 }}
+                      activeDot={{ r: 5 }}
+                    />
+                  </LazyLineChart>
+                </ResponsiveContainer>
+              </Suspense>
+            </Box>
+          </Grid>
+        )}
+      </Grid>
+    </Box>
+  );
+};
+
+export default SummaryCharts;


### PR DESCRIPTION
## Summary

Replace \OnboardingFullWebsiteAnalysisExecutor\'s own sitemap discovery and XML parsing with \SitemapService\, gaining retry logic, gzip support, content-type validation, and 16+ candidate sitemap paths.

### Changes

**\sitemap_service.py\** — Added \max_urls: Optional[int] = None\ parameter to \nalyze_sitemap()\ and \_fetch_sitemap_data()\. When set, parsing stops early instead of processing all sitemap URLs:

- **urlset**: caps at \min(max_urls, 10000)\ per file (was always 10000)
- **sitemapindex**: reduces nested fan-out proportionally, passes remaining budget to recursive calls, slices result early once limit is reached

This is backward-compatible — all existing callers pass \max_urls=None\ and see no change.

**\onboarding_full_website_analysis_executor.py\** — Replaced \_discover_urls\, \_parse_sitemap\, \_fetch_text\ (~87 lines) with a \~30-line version delegating to \SitemapService\. Passes \max_urls=max_urls\ so only 500 URLs are parsed (not up to 50k).

### Impact

- **Per-file URLs parsed**: 10,000 → 500 (20× reduction at default \max_urls=500\)
- **Total parsed worst case**: ~50,000 → ~2,500 (20× reduction)
- **Net code**: −84 lines, +44 lines