### PR TITLE
fix: production-readiness hardening and TypeScript/ESLint errors

### DIFF
--- a/backend/services/analytics/handlers/gsc_handler.py
+++ b/backend/services/analytics/handlers/gsc_handler.py
@@ -61,12 +61,8 @@ class GSCAnalyticsHandler(BaseAnalyticsHandler):
 
             # logger.info(f"GSC Sites found for user {user_id}: {sites}")
             if not sites:
-                # logger.warning(f"No GSC sites found for user {user_id}")
-                # Return standard empty response instead of error to avoid logs noise
-                return self.create_success_response(
-                    metrics={"clicks": 0, "impressions": 0, "ctr": 0, "position": 0}, 
-                    date_range={'start': start_date, 'end': end_date}
-                )
+                logger.warning(f"No GSC sites found for user {user_id} — failing fast")
+                return self.create_error_response("No Google Search Console sites found for this account. Add a property in Google Search Console first.")
             
             # Select site: Prefer target_url match, otherwise first site
             selected_site = sites[0]
@@ -387,18 +383,7 @@ class GSCAnalyticsHandler(BaseAnalyticsHandler):
             
         except Exception as e:
             logger.error(f"Error processing GSC metrics: {e}")
-            return {
-                'connection_status': 'error',
-                'connected_sites': 0,
-                'total_clicks': 0,
-                'total_impressions': 0,
-                'avg_ctr': 0,
-                'avg_position': 0,
-                'total_queries': 0,
-                'top_queries': [],
-                'top_pages': [],
-                'error': str(e)
-            }
+            raise  # fail fast — let caller create a proper error response
     
     def _extract_query_from_row(self, row: Dict[str, Any]) -> str:
         """Extract query text from GSC API row data"""
@@ -407,13 +392,13 @@ class GSCAnalyticsHandler(BaseAnalyticsHandler):
             if keys and len(keys) > 0:
                 first_key = keys[0]
                 if isinstance(first_key, dict):
-                    return first_key.get('keys', ['Unknown'])[0]
+                    return first_key.get('keys', [''])[0]
                 else:
                     return str(first_key)
-            return 'Unknown'
+            raise ValueError(f"No 'keys' field in GSC row: {row}")
         except Exception as e:
             logger.error(f"Error extracting query from row: {e}")
-            return 'Unknown'
+            raise
 
     def _extract_page_from_row(self, row: Dict[str, Any]) -> str:
         """Extract page URL from GSC API row data"""
@@ -425,7 +410,7 @@ class GSCAnalyticsHandler(BaseAnalyticsHandler):
                     return first_key.get('keys', [''])[0]
                 else:
                     return str(first_key)
-            return ''
+            raise ValueError(f"No 'keys' field in GSC row: {row}")
         except Exception as e:
             logger.error(f"Error extracting page from row: {e}")
-            return ''
+            raise

--- a/frontend/src/components/ContentPlanningDashboard/components/CalendarGenerationModal/CalendarGenerationModal.tsx
+++ b/frontend/src/components/ContentPlanningDashboard/components/CalendarGenerationModal/CalendarGenerationModal.tsx
@@ -688,7 +688,7 @@ const CalendarGenerationModal: React.FC<CalendarGenerationModalProps> = ({
                 onClick={() => {
                   console.log('Calendar generation completed');
                   const step12Result = currentProgress.stepResults[12];
-                  const step12Data = step12Result?.results || {};
+                  const step12Data = step12Result?.data || {};
                   onComplete({
                     calendar: {
                       id: sessionId,

--- a/frontend/src/components/LinkedInWriter/components/GrowthEngine/GrowthEnginePanel.tsx
+++ b/frontend/src/components/LinkedInWriter/components/GrowthEngine/GrowthEnginePanel.tsx
@@ -458,7 +458,6 @@ export const GrowthEnginePanel: React.FC<GrowthEnginePanelProps> = ({
   const isStale = oldestMs > 0 && (Date.now() - oldestMs) > 30 * 60 * 1000;
 
   const formatTimeAgo = (dateStr: string | null | undefined): string => {
-    void tick; // reference tick to ensure re-render when interval fires
     if (!dateStr) return '';
     const ms = Date.now() - new Date(dateStr).getTime();
     const min = Math.floor(ms / 60000);

--- a/frontend/src/components/OnboardingWizard/WebsiteStep/components/WebsiteIntegrationsSection.tsx
+++ b/frontend/src/components/OnboardingWizard/WebsiteStep/components/WebsiteIntegrationsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import {
   Box,
   Typography,
@@ -87,9 +87,14 @@ const WebsiteIntegrationsSection: React.FC<WebsiteIntegrationsSectionProps> = ({
     })();
   }, [refreshBingStatus]);
 
+  // Use ref for connectedPlatforms to avoid re-running effect when we update it
+  const connectedRef = useRef(connectedPlatforms);
+  connectedRef.current = connectedPlatforms;
+
   // Consolidate platform sync: WordPress, Bing, and GSC all follow the same pattern
   useEffect(() => {
-    const updated = [...connectedPlatforms];
+    const prev = connectedRef.current;
+    const updated = [...prev];
     let changed = false;
 
     const sync = (platformId: string, isConnected: boolean, hasSites: boolean) => {
@@ -116,7 +121,7 @@ const WebsiteIntegrationsSection: React.FC<WebsiteIntegrationsSectionProps> = ({
     wordpressConnected, wordpressSites,
     bingConnected, bingSites,
     gscInternalPlatforms,
-    connectedPlatforms, setConnectedPlatforms, invalidateAnalyticsCache,
+    setConnectedPlatforms, invalidateAnalyticsCache,
   ]);
 
   useEffect(() => {

--- a/frontend/src/components/SEODashboard/SEODashboard.tsx
+++ b/frontend/src/components/SEODashboard/SEODashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import {
   Box,
@@ -145,6 +145,7 @@ const SEODashboard: React.FC = () => {
 
   // PlatformAnalytics refresh handle
   const platformRefreshRef = useRef<(() => Promise<void>) | null>(null);
+  const analyticsPlatforms = useMemo(() => ['gsc', 'bing'], []);
 
   // Sync dashboard analysis to Copilot store so readables have URL/context
   const setCopilotAnalysisData = useSEOCopilotStore(state => state.setAnalysisData);
@@ -857,12 +858,10 @@ const SEODashboard: React.FC = () => {
                 </Box>
                 
                 <PlatformAnalytics
-                  platforms={['gsc', 'bing']}
+                  platforms={analyticsPlatforms}
                   showSummary={true}
                   refreshInterval={0}
-                  onDataLoaded={(analyticsData) => {
-                    console.log('Real analytics data loaded:', analyticsData);
-                  }}
+                  onDataLoaded={() => {}}
                   onRefreshReady={(fn) => { platformRefreshRef.current = fn; }}
                   onReconnect={(platform) => {
                     if (platform === 'gsc') {

--- a/frontend/src/components/shared/BackgroundJobManager.tsx
+++ b/frontend/src/components/shared/BackgroundJobManager.tsx
@@ -56,7 +56,7 @@ interface BackgroundJobManagerProps {
 }
 
 const BackgroundJobManager: React.FC<BackgroundJobManagerProps> = ({
-  siteUrl = 'https://www.alwrity.com/',
+  siteUrl,
   days = 30,
   onJobCompleted,
 }) => {
@@ -85,6 +85,10 @@ const BackgroundJobManager: React.FC<BackgroundJobManagerProps> = ({
 
   // Create Bing comprehensive insights job
   const createComprehensiveInsightsJob = async () => {
+    if (!siteUrl) {
+      alert('Cannot create job: no site URL configured');
+      return;
+    }
     setLoading(true);
     try {
       const response = await apiClient.post(
@@ -111,6 +115,10 @@ const BackgroundJobManager: React.FC<BackgroundJobManagerProps> = ({
 
   // Create Bing data collection job
   const createDataCollectionJob = async () => {
+    if (!siteUrl) {
+      alert('Cannot create job: no site URL configured');
+      return;
+    }
     setLoading(true);
     try {
       const response = await apiClient.post(

--- a/frontend/src/components/shared/BingInsightsCard.tsx
+++ b/frontend/src/components/shared/BingInsightsCard.tsx
@@ -168,7 +168,7 @@ interface Recommendations {
 }
 
 const BingInsightsCard: React.FC<BingInsightsCardProps> = ({
-  siteUrl = 'https://www.alwrity.com/',
+  siteUrl,
   days = 30,
   onInsightsLoaded,
   insights: propInsights,
@@ -194,7 +194,14 @@ const BingInsightsCard: React.FC<BingInsightsCardProps> = ({
   const loadInsights = useCallback(async () => {
     // Only load if we don't have insights passed as props
     if (propInsights) return;
-    
+
+    // Fail fast: require a real siteUrl
+    if (!siteUrl) {
+      setInternalError('No site URL provided for Bing insights');
+      setInternalLoading(false);
+      return;
+    }
+
     // Clear any existing timeout
     if (debounceTimeoutRef.current) {
       clearTimeout(debounceTimeoutRef.current);


### PR DESCRIPTION
## Summary
Production-readiness fixes and resolution of two TypeScript/ESLint errors that were previously masked by an older, monolithic PlatformAnalytics.

## Changes

### Backend - gsc_handler.py
- Fail fast when no GSC sites are found (returns user-actionable error instead of success with zeros)
- Re-raise in process_gsc_metrics exception handler (was returning sanitized error dict)
- _extract_query_from_row and _extract_page_from_row now raise ValueError on missing keys

### Frontend - Bug fixes
- **CalendarGenerationModal.tsx**: step12Result.data not step12Result.results (the local StepResult in types.ts is unused; the polling hook's StepResult uses data)
- **GrowthEnginePanel.tsx**: Remove void tick no-unused-expression (tick already drives re-renders via the interval effect)

### Frontend - Production-readiness hardening
- **WebsiteIntegrationsSection.tsx**: Use useRef for connectedPlatforms to avoid stale closure / infinite re-render
- **SEODashboard.tsx**: useMemo analyticsPlatforms to avoid re-creating array; remove debug console.log
- **BackgroundJobManager.tsx**: Remove hardcoded alwrity.com default for siteUrl; add fail-fast guard
- **BingInsightsCard.tsx**: Remove hardcoded alwrity.com default for siteUrl; add fail-fast guard