### PR TITLE
fix(linkedin): restore OAuth connect via validate_callback_base

### DIFF
--- a/backend/services/integrations/linkedin_oauth.py
+++ b/backend/services/integrations/linkedin_oauth.py
@@ -1078,6 +1078,41 @@ class LinkedInOAuthService(OAuthProviderBase):
         )
         return "http://localhost:8000"
 
+    def validate_callback_base(self, callback_base: Optional[str]) -> str:
+        """
+        Validate optional frontend-provided backend base URL for OAuth redirects.
+
+        Local dev sends ``callback_base=http://localhost:8000`` so redirects avoid
+        stale ngrok URLs in backend ``.env``. When omitted, uses
+        ``_resolve_public_backend_url()``.
+
+        Returns:
+            Normalized origin ``scheme://host[:port]`` without trailing slash.
+
+        Raises:
+            ValueError: If ``callback_base`` is not a valid http(s) origin.
+        """
+        if not callback_base or not str(callback_base).strip():
+            return self._resolve_public_backend_url()
+
+        raw = str(callback_base).strip().rstrip("/")
+        parsed = urlparse(raw)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError("callback_base must use http or https")
+        if not parsed.netloc:
+            raise ValueError("callback_base must include a valid host")
+
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+        if _is_placeholder_backend_url(origin):
+            logger.warning(
+                f"[LinkedInConnect] Ignoring placeholder callback_base={origin}; "
+                "using resolved public backend URL"
+            )
+            return self._resolve_public_backend_url()
+
+        logger.info(f"[LinkedInConnect] Using client callback_base={origin}")
+        return origin
+
     async def try_sync_unipile_accounts(self, user_id: str) -> bool:
         """
         Best-effort sync from Unipile when credentials exist remotely but not in ALwrity.
@@ -1169,7 +1204,9 @@ class LinkedInOAuthService(OAuthProviderBase):
         )
         return False
 
-    def _get_redirect_uri(self) -> str:
+    def _get_redirect_uri(self, backend_base: Optional[str] = None) -> str:
+        if backend_base:
+            return f"{backend_base.rstrip('/')}/api/linkedin-social/callback"
         configured = os.getenv("LINKEDIN_SOCIAL_REDIRECT_URI")
         if configured and not _is_placeholder_backend_url(configured.strip()):
             return configured.strip()
@@ -1187,27 +1224,36 @@ class LinkedInOAuthService(OAuthProviderBase):
             return None
         return state.split(":", 1)[0]
 
-    def _get_unipile_redirect_urls(self, user_id: str) -> Dict[str, str]:
+    def _get_unipile_redirect_urls(
+        self,
+        user_id: str,
+        backend_url: Optional[str] = None,
+    ) -> Dict[str, str]:
         """Build Unipile redirect URLs for OAuth callback and webhook notification."""
-        backend_url = self._resolve_public_backend_url()
+        backend_url = (backend_url or self._resolve_public_backend_url()).rstrip("/")
         encoded_name = quote(user_id, safe="")
-        callback_base = f"{backend_url}/api/linkedin-social/callback"
+        callback_path = f"{backend_url}/api/linkedin-social/callback"
         return {
             "success": (
-                f"{callback_base}?provider=unipile&status=success&name={encoded_name}"
+                f"{callback_path}?provider=unipile&status=success&name={encoded_name}"
             ),
             "failure": (
-                f"{callback_base}?provider=unipile&status=error&name={encoded_name}"
+                f"{callback_path}?provider=unipile&status=error&name={encoded_name}"
             ),
             "notify": f"{backend_url}/api/unipile/webhook",
         }
 
     async def generate_authorization_url(
-        self, user_id: str, state: Optional[str] = None
+        self,
+        user_id: str,
+        state: Optional[str] = None,
+        *,
+        callback_base: Optional[str] = None,
     ) -> Dict[str, str]:
         """Return OAuth authorization URL for Zernio, Unipile, or native LinkedIn based on LINKEDIN_PROVIDER."""
         provider = os.getenv("LINKEDIN_PROVIDER", "zernio").lower()
         oauth_state = self._build_oauth_state(user_id, state)
+        backend_base = callback_base or self._resolve_public_backend_url()
 
         if provider == "zernio":
             api_key = os.getenv("ZERNIO_API_KEY")
@@ -1221,7 +1267,7 @@ class LinkedInOAuthService(OAuthProviderBase):
                 f"profile_id={profile_id}"
             )
 
-            redirect_uri = self._get_redirect_uri()
+            redirect_uri = self._get_redirect_uri(backend_base)
             redirect_with_state = (
                 f"{redirect_uri}?alwrity_state={quote(oauth_state, safe='')}"
             )
@@ -1252,10 +1298,9 @@ class LinkedInOAuthService(OAuthProviderBase):
             from services.integrations.linkedin.unipile_client import UnipileClient
 
             client = UnipileClient()
-            redirect_urls = self._get_unipile_redirect_urls(user_id)
-            backend_url = self._resolve_public_backend_url()
+            redirect_urls = self._get_unipile_redirect_urls(user_id, backend_base)
             logger.info(
-                f"[LinkedInConnect] Unipile redirect base_url={backend_url} user_id={user_id} "
+                f"[LinkedInConnect] Unipile redirect base_url={backend_base} user_id={user_id} "
                 f"success={redirect_urls['success']}"
             )
 
@@ -1294,7 +1339,7 @@ class LinkedInOAuthService(OAuthProviderBase):
             .decode("utf-8")
             .rstrip("=")
         )
-        redirect_uri = self._get_redirect_uri()
+        redirect_uri = self._get_redirect_uri(backend_base)
         scopes = "r_liteprofile r_emailaddress w_member_social"
         params = urlencode(
             {

--- a/frontend/src/components/ContentPlanningDashboard/components/CalendarGenerationModal/CalendarGenerationModal.tsx
+++ b/frontend/src/components/ContentPlanningDashboard/components/CalendarGenerationModal/CalendarGenerationModal.tsx
@@ -688,7 +688,7 @@ const CalendarGenerationModal: React.FC<CalendarGenerationModalProps> = ({
                 onClick={() => {
                   console.log('Calendar generation completed');
                   const step12Result = currentProgress.stepResults[12];
-                  const step12Data = step12Result?.results || {};
+                  const step12Data = step12Result?.data || {};
                   onComplete({
                     calendar: {
                       id: sessionId,


### PR DESCRIPTION
## Summary
- Add missing `validate_callback_base` on `LinkedInOAuthService` and thread `callback_base` through `generate_authorization_url` and redirect URL helpers.
- Fix `CalendarGenerationModal` compile error by reading step 12 payload from `StepResult.data` (not `results`).

## Problem
`GET /api/linkedin-social/auth/url` calls `validate_callback_base()` and passes `callback_base` into `generate_authorization_url`, but the service method was never added on `main`. This breaks LinkedIn Connect with:

`'LinkedInOAuthService' object has no attribute 'validate_callback_base'`

## Changes
| File | Change |
|------|--------|
| `backend/services/integrations/linkedin_oauth.py` | Add `validate_callback_base`; update `_get_redirect_uri`, `_get_unipile_redirect_urls`, `generate_authorization_url` |
| `frontend/.../CalendarGenerationModal.tsx` | `step12Result?.results` → `step12Result?.data` |
