### PR TITLE
Remove debug console.log from CopilotKit key update handler

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -128,7 +128,6 @@ const App: React.FC = () => {
     const handleKeyUpdate = (event: CustomEvent) => {
       const newKey = event.detail?.apiKey;
       if (newKey) {
-        console.log('App: CopilotKit key updated, reloading...');
         setCopilotApiKey(newKey);
         setTimeout(() => window.location.reload(), 500);
       }


### PR DESCRIPTION
## Summary

This PR removes a leftover debug `console.log()` statement from the CopilotKit key update event handler in `frontend/src/App.tsx`.

## Changes

- Removed the debug `console.log()` used during CopilotKit API key updates.
- No functional changes were made.

## Testing

- Verified the application continues to function as expected after removing the debug log.
- Confirmed no unintended behavior changes.

Fixes #794