### PR TITLE
docs: update GitHub issues link in contributing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing to ALwrity! 🚀 We welcome contribu
 ## 🤝 How to Contribute
 
 ### 1. **Report Issues**
-- Use our [GitHub Issues](https://github.com/AJaySi/ALwrity/issues) to report bugs or request features
+- Use our [GitHub Issues](https://github.com/ALwrity/ALwrity/issues) to report bugs or request features
 - Check existing issues before creating new ones
 - Provide clear descriptions and steps to reproduce bugs
 


### PR DESCRIPTION
# Pull Request

## 📝 Description
Updated the outdated GitHub Issues link in `.github/CONTRIBUTING.md` so it points to the current official ALwrity repository Issues page.

## 🔄 Type of Change
- [x] 📚 Documentation update

## 🎯 Related Issues
Not related to an existing issue.

## 🧪 Testing
- [x] Manual testing completed

Verified that the updated URL points to the official ALwrity GitHub Issues page.

## 📸 Screenshots
Not applicable — documentation link update only.

## 🏷️ Component/Feature
- [x] Documentation

## 📋 Checklist
- [x] I have performed a self-review of my own changes
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation

## 📚 Documentation
- [x] Documentation updated

## 🚀 Deployment Notes
No deployment or environment variable changes are required.

## 🔗 Additional Context
This pull request updates a stale repository URL in the contribution guide.

---

**Thank you for reviewing my contribution.**