### PR TITLE
Add missing backend dependencies (nltk and textstat)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -44,6 +44,8 @@ markdown>=3.5.0
 beautifulsoup4>=4.12.0
 lxml>=4.9.0
 advertools>=0.14.0
+nltk>=3.10.0
+textstat>=0.7.0
 
 # Data processing
 pandas>=2.0.0
@@ -85,3 +87,4 @@ google-auth-oauthlib>=1.0.0
 python-dateutil>=2.8.0
 jinja2>=3.1.0
 pydantic-settings>=2.0.0
+


### PR DESCRIPTION
## Summary

This PR adds the missing Python dependencies `nltk` and `textstat` to `backend/requirements.txt`.

## Why

While setting up the project in a clean GitHub Codespaces environment, the backend failed to start because these packages were imported but not listed in the requirements file.

Observed errors:

- `ModuleNotFoundError: No module named 'nltk'`
- `ModuleNotFoundError: No module named 'textstat'`

Adding these dependencies helps ensure a fresh installation includes all required packages for the backend.