### PR TITLE
fix: correct content-planning route in dashboard chips

### DIFF
--- a/frontend/src/components/MainDashboard/components/AnalyzePillarChips.tsx
+++ b/frontend/src/components/MainDashboard/components/AnalyzePillarChips.tsx
@@ -35,11 +35,11 @@ const AnalyzePillarChips: React.FC<AnalyzePillarChipsProps> = ({
       priority: 'high' as const,
       estimatedTime: 20,
       actionType: 'navigate' as const,
-      actionUrl: '/content-planning-dashboard',
+      actionUrl: '/content-planning',
       icon: Analytics,
       color: "#9C27B0",
       enabled: true,
-      action: () => navigate('/content-planning-dashboard')
+      action: () => navigate('/content-planning')
     },
     {
       id: "analyze-strategy-alignment",
@@ -50,11 +50,11 @@ const AnalyzePillarChips: React.FC<AnalyzePillarChipsProps> = ({
       priority: 'high' as const,
       estimatedTime: 15,
       actionType: 'navigate' as const,
-      actionUrl: '/content-planning-dashboard',
+      actionUrl: '/content-planning',
       icon: Dashboard,
       color: "#673AB7",
       enabled: true,
-      action: () => navigate('/content-planning-dashboard')
+      action: () => navigate('/content-planning')
     },
     {
       id: "analyze-update-dashboard",
@@ -74,7 +74,7 @@ const AnalyzePillarChips: React.FC<AnalyzePillarChipsProps> = ({
   ];
 
   const handlePlanDashboardClick = () => {
-    navigate('/content-planning-dashboard');
+    navigate('/content-planning');
   };
 
   return (

--- a/frontend/src/components/MainDashboard/components/EngagePillarChips.tsx
+++ b/frontend/src/components/MainDashboard/components/EngagePillarChips.tsx
@@ -36,11 +36,11 @@ const EngagePillarChips: React.FC<EngagePillarChipsProps> = ({
       priority: 'high' as const,
       estimatedTime: 10,
       actionType: 'navigate' as const,
-      actionUrl: '/content-planning-dashboard',
+      actionUrl: '/content-planning',
       icon: Comment,
       color: "#E91E63",
       enabled: true,
-      action: () => navigate('/content-planning-dashboard')
+      action: () => navigate('/content-planning')
     },
     {
       id: "engage-twitter-mention",
@@ -51,11 +51,11 @@ const EngagePillarChips: React.FC<EngagePillarChipsProps> = ({
       priority: 'high' as const,
       estimatedTime: 5,
       actionType: 'navigate' as const,
-      actionUrl: '/content-planning-dashboard',
+      actionUrl: '/content-planning',
       icon: Twitter,
       color: "#1DA1F2",
       enabled: true,
-      action: () => navigate('/content-planning-dashboard')
+      action: () => navigate('/content-planning')
     },
     {
       id: "engage-linkedin-post",


### PR DESCRIPTION
## Problem
The "Analyze" and "Engage" dashboard chips navigate to `/content-planning-dashboard`, which is not registered in App.tsx — only `/content-planning` is defined. This breaks navigation from several task chips on both pillars.

## Fix
Updated all `navigate()` calls and `actionUrl` values in `AnalyzePillarChips.tsx` and `EngagePillarChips.tsx` to use the correct, existing route: `/content-planning`.

## Files changed
- `frontend/src/components/MainDashboard/components/AnalyzePillarChips.tsx`
- `frontend/src/components/MainDashboard/components/EngagePillarChips.tsx`