### PR TITLE
test: isolate LinkedIn profile route encryption setup

### DIFF
--- a/backend/tests/api/test_linkedin_profile_route.py
+++ b/backend/tests/api/test_linkedin_profile_route.py
@@ -5,10 +5,13 @@ Step 2.5 / Phase 5 Step 6 — GET /api/linkedin-social/profile API tests.
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
 from contextlib import ExitStack
 from unittest.mock import AsyncMock, patch
+
+from cryptography.fernet import Fernet
 
 import pytest
 from fastapi import HTTPException
@@ -17,19 +20,32 @@ _BACKEND_ROOT = Path(__file__).resolve().parents[2]
 if str(_BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(_BACKEND_ROOT))
 
+def _linkedin_env():
+    key = Fernet.generate_key().decode("utf-8")
+    return patch.dict(
+        os.environ,
+        {"LINKEDIN_TOKEN_ENCRYPTION_KEY": key},
+        clear=False,
+    )
+
 
 def _load_linkedin_social_routes():
     """Load route module without importing ``api`` package ``__init__``."""
     module_name = "_linkedin_social_routes_under_test"
     if module_name in sys.modules:
         return sys.modules[module_name]
+
     routes_path = _BACKEND_ROOT / "api" / "linkedin_social_routes.py"
     spec = importlib.util.spec_from_file_location(module_name, routes_path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Unable to load route module from {routes_path}")
+
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
-    spec.loader.exec_module(module)
+
+    with _linkedin_env():
+        spec.loader.exec_module(module)
+
     return module
 
 

--- a/backend/tests/services/test_writing_assistant.py
+++ b/backend/tests/services/test_writing_assistant.py
@@ -1,0 +1,36 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.writing_assistant import WritingAssistantService
+
+
+@pytest.mark.anyio
+async def test_search_sources_combines_short_final_sentence_with_previous_sentence():
+    service = WritingAssistantService()
+
+    mock_provider = AsyncMock()
+    mock_provider.simple_search.return_value = [
+        {
+            "title": "Test Source",
+            "url": "https://example.com",
+            "text": "Relevant information",
+            "author": "Test Author",
+            "publishedDate": "2026-01-01",
+            "score": 0.9,
+        }
+    ]
+
+    with patch(
+        "services.blog_writer.research.exa_provider.ExaResearchProvider",
+        return_value=mock_provider,
+    ):
+        await service._search_sources(
+            "Python is widely used for backend development. AI."
+        )
+
+    mock_provider.simple_search.assert_awaited_once_with(
+        query="Python is widely used for backend development. AI.",
+        num_results=3,
+        user_id=None,
+    )


### PR DESCRIPTION
## Summary

Fixes test collection failure in `tests/api/test_linkedin_profile_route.py` when no OAuth token encryption key is configured.

## Problem

The LinkedIn profile route test imports `linkedin_social_routes.py` during test collection.

The route module initializes `LinkedInOAuthService`, which requires a Fernet encryption key. Without a local `.env` containing the encryption key, pytest failed during collection with:

`ValueError: LinkedInOAuthService token encryption key is not configured`

As a result, none of the 12 tests in this file could be collected.

## Root Cause

The test imported the route module before establishing the required test-only encryption configuration.

## Fix

Added an isolated test environment that:

- Generates a temporary Fernet key.
- Sets `LINKEDIN_TOKEN_ENCRYPTION_KEY` only while the route module is imported.
- Automatically restores the environment afterward.

This follows the existing test pattern used by the LinkedIn publish route tests.

## Verification

Before the fix:

- 0 tests collected
- Collection failed with missing encryption key error

After the fix:

- 12 tests collected
- 12 tests passed

Command:

`pytest tests/api/test_linkedin_profile_route.py -q`