### PR TITLE
test: cover writing assistant short sentence search

### DIFF
--- a/backend/tests/services/test_writing_assistant.py
+++ b/backend/tests/services/test_writing_assistant.py
@@ -1,0 +1,36 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.writing_assistant import WritingAssistantService
+
+
+@pytest.mark.anyio
+async def test_search_sources_combines_short_final_sentence_with_previous_sentence():
+    service = WritingAssistantService()
+
+    mock_provider = AsyncMock()
+    mock_provider.simple_search.return_value = [
+        {
+            "title": "Test Source",
+            "url": "https://example.com",
+            "text": "Relevant information",
+            "author": "Test Author",
+            "publishedDate": "2026-01-01",
+            "score": 0.9,
+        }
+    ]
+
+    with patch(
+        "services.blog_writer.research.exa_provider.ExaResearchProvider",
+        return_value=mock_provider,
+    ):
+        await service._search_sources(
+            "Python is widely used for backend development. AI."
+        )
+
+    mock_provider.simple_search.assert_awaited_once_with(
+        query="Python is widely used for backend development. AI.",
+        num_results=3,
+        user_id=None,
+    )


### PR DESCRIPTION
## Summary

Add a regression test for the Writing Assistant's short final sentence search path.

## Problem

The `_search_sources()` method combines the previous two sentences when the final sentence is very short.

A previous implementation referenced an undefined variable (`s`) instead of the `sentences` list, causing a `NameError` when this branch was executed.

## Fix

Added a focused regression test that:

- exercises the short final sentence path
- mocks `ExaResearchProvider` to avoid external API dependencies
- verifies that the previous two sentences are passed to `simple_search()`

## Verification

- `pytest tests/services/test_writing_assistant.py -q` → **1 passed**
- `git diff --check` → clean