### PR TITLE
docs: add SIF semantic indexing + test-your-indexing pages

### DIFF
--- a/docs-site/docs/features/sif-agents/agent-directory.md
+++ b/docs-site/docs/features/sif-agents/agent-directory.md
@@ -1,0 +1,225 @@
+# Agent Directory
+
+Detailed reference for all 8 specialised agents, plus the orchestrator and supporting components.
+
+## Committee Agents
+
+### Content Strategy Agent
+
+| Property | Value |
+|---|---|
+| Registry Key | `content_strategist` |
+| Agent Type | `content` |
+| Class | `ContentStrategyAgent` |
+| Source | `backend/services/intelligence/agents/specialized/content_strategy.py` |
+| Pillar Focus | `plan` |
+
+**Role:** Identifies content opportunities, strategic gaps, and performance improvement areas. Proposes tasks for content planning, topic cluster development, and content refreshes.
+
+**Data Sources:**
+- Onboarding data (business info, goals, target audience)
+- Content performance metrics
+- SIF semantic analysis
+- Topic cluster graph
+
+**Output:** `TaskProposal` objects with title, description, priority, pillar assignment, and reasoning.
+
+---
+
+### Strategy Architect Agent
+
+| Property | Value |
+|---|---|
+| Registry Key | `strategy_architect` |
+| Agent Type | `strategy` |
+| Class | `StrategyArchitectAgent` |
+| Source | `backend/services/intelligence/agents/specialized/strategy_architect.py` |
+| Pillar Focus | `plan` |
+
+**Role:** Analyses SIF semantic vectors to suggest strategic pivots — topic rebalancing, pillar restructuring, and long-term content roadmap adjustments.
+
+**Data Sources:**
+- SIF vector index (txtai semantic embeddings)
+- Topic clustering output
+- Content gap analysis reports
+- Historical strategy performance
+
+**Output:** `TaskProposal` objects focused on strategic planning tasks.
+
+---
+
+### SEO Optimization Agent
+
+| Property | Value |
+|---|---|
+| Registry Key | `seo_specialist` |
+| Agent Type | `seo` |
+| Class | `SEOOptimizationAgent` |
+| Source | `backend/services/intelligence/agents/specialized/seo_optimization.py` |
+| Pillar Focus | `analyze` |
+
+**Role:** Scans for SEO issues (missing metadata, poor keyword coverage, cannibalisation risks, content freshness gaps) and proposes fixes.
+
+**Data Sources:**
+- SEO audit results (on-page, technical)
+- Keyword performance data
+- Content cannibalisation analysis
+- Internal linking structure
+
+**Output:** `TaskProposal` objects for SEO remediation tasks.
+
+---
+
+### Social Amplification Agent
+
+| Property | Value |
+|---|---|
+| Registry Key | `social_media_manager` |
+| Agent Type | `social` |
+| Class | `SocialAmplificationAgent` |
+| Source | `backend/services/intelligence/agents/specialized/social_amplification.py` |
+| Pillar Focus | `engage` |
+
+**Role:** Recommends social engagement actions — cross-posting, platform-specific content adaptation, engagement timing optimisation, and audience interaction.
+
+**Data Sources:**
+- Social media profiles and accounts
+- Engagement metrics
+- Platform-specific best practices
+- Content calendar items
+
+**Output:** `TaskProposal` objects for social amplification tasks.
+
+---
+
+### Competitor Response Agent
+
+| Property | Value |
+|---|---|
+| Registry Key | `competitor_analyst` |
+| Agent Type | `competitor` |
+| Class | `CompetitorResponseAgent` |
+| Source | `backend/services/intelligence/agents/specialized/competitor_response.py` |
+| Pillar Focus | `analyze` |
+
+**Role:** Monitors competitor content activity and alerts when competitors publish relevant content, launch campaigns, or target overlapping keywords.
+
+**Data Sources:**
+- Competitor domain list (from onboarding)
+- Exa competitor content index
+- SERP ranking changes
+- Content freshness tracking
+
+**Output:** `TaskProposal` objects for competitive response actions.
+
+---
+
+### Content Gap Radar Agent
+
+| Property | Value |
+|---|---|
+| Registry Key | `content_gap_radar` |
+| Agent Type | `content_gap_radar` |
+| Class | `ContentGapRadarAgent` |
+| Source | `backend/services/intelligence/agents/content_gap_radar_agent.py` |
+| Pillar Focus | `generate` |
+
+**Role:** Scores and prioritises content opportunities by combining SIF semantic gap analysis, SERP ranking presence (Google CSE), competitor content deep-dives (Exa), and trend momentum into a single ROI score per topic.
+
+**Pipeline:**
+1. Get topic-level gaps from SIF semantic analysis
+2. Get SERP ranking data per topic
+3. Get Exa competitor content for top topics
+4. Compute ROI score combining gap size, ranking opportunity, competitor coverage, and trend momentum
+
+**Data Sources:**
+- SIF vector index (txtai)
+- Google Custom Search Engine (SERP data)
+- Exa API (competitor content)
+- Google Trends data
+- `SerpGapService`
+- `CompetitorContentService`
+
+**Output:** `TaskProposal` objects for priority content creation.
+
+---
+
+## Independent Agents
+
+### Trend Surfer Agent
+
+| Property | Value |
+|---|---|
+| Registry Key | `trend_surfer` |
+| Agent Type | `trend` |
+| Class | `TrendSurferAgent` |
+| Source | `backend/services/intelligence/agents/trend_surfer_agent.py` |
+
+**Role:** Identifies high-potential market trends and generates timely content angle suggestions. Integrates real-time Google Trends data with internal market signals from `MarketSignalDetector`.
+
+**Pipeline:**
+1. Fetch real-time trending searches from Google Trends
+2. Detect internal market signals (competitor moves, SERP shifts)
+3. Analyse real-time trends and convert actionable ones to signals
+4. Filter for high-impact trends (High/Critical urgency)
+5. Assign content angles, urgency, and ROI projections
+
+**Data Sources:**
+- Google Trends service
+- `MarketSignalDetector` (competitor signals, SERP signals)
+- Historical trend performance
+
+**Output:** Trend opportunity list with impact score, urgency, suggested content angle, and coverage gap context. Logged as `trend_signals` event in the activity feed.
+
+---
+
+### Content Guardian Agent
+
+| Property | Value |
+|---|---|
+| Registry Key | `content_guardian` |
+| Agent Type | `guardian` |
+| Class | `ContentGuardianAgent` |
+| Source | `backend/services/intelligence/agents/specialized/content_guardian.py` |
+
+**Role:** Committee watchdog that audits proposal quality, evaluates agent behaviour, detects coverage gaps and overlaps, and generates alerts for serious faults. *Never proposes daily tasks alongside the committee.*
+
+**Capabilities:**
+- `audit_committee(proposals)` — full committee audit
+- `perform_site_audit(url)` — external site quality analysis
+- `check_cannibalization()` — content cannibalisation detection
+- `style_enforcer(text)` — brand voice compliance
+- `safety_filter(text)` — content safety checks
+
+See [ContentGuardianAgent](content-guardian.md) for full detail.
+
+---
+
+## Orchestrator
+
+### StrategyOrchestratorAgent
+
+| Property | Value |
+|---|---|
+| Class | `StrategyOrchestratorAgent` |
+| Source | `backend/services/intelligence/agents/core_agent_framework.py` |
+
+**Role:** Master coordinator. Receives all agent proposals, selects and prioritises tasks, delegates strategic execution to sub-agents, and synthesises results into a unified daily plan.
+
+**Key Functions:**
+- `run(instruction, task_context)` — execute orchestration cycle
+- `set_sub_agents(agents)` — register the agent team
+- `build_task_prompt(instruction, task_context)` — construct the prompt with agent capabilities
+- Delegates tasks via `task_delegator` tool to specific sub-agents
+
+---
+
+## Supporting Components
+
+| Component | Role |
+|---|---|
+| `MarketSignalDetector` | Detects external market signals (competitor moves, SERP changes, industry shifts) |
+| `SafetyConstraintManager` | Enforces content safety rules, manages rollback and user approval flows |
+| `AgentPerformanceMonitor` | Tracks per-agent execution metrics, success rates, and latency |
+| `LLM (txtai / shared)` | Text generation backbone used by agents for task proposals and reasoning |
+| `TxtaiIntelligenceService` | Semantic search and vector indexing for SIF agents |

--- a/docs-site/docs/features/sif-agents/committee-system.md
+++ b/docs-site/docs/features/sif-agents/committee-system.md
@@ -1,0 +1,123 @@
+# Committee System
+
+The agent committee is the core of ALwrity's daily workflow generation. Six specialised agents are polled in parallel to propose tasks across the **6 Content Lifecycle Pillars**.
+
+## The 6 Pillars
+
+| Pillar | Focus | Accepts Tasks From |
+|---|---|---|
+| `plan` | Content strategy & planning | Content Strategy, Strategy Architect |
+| `generate` | Content creation | Content Gap Radar |
+| `publish` | Content distribution | All agents |
+| `analyze` | Performance analysis | SEO Optimization, Competitor Response |
+| `engage` | Social engagement | Social Amplification |
+| `remarket` | Content repurposing | All agents |
+
+## Polling Flow
+
+```
+Today's Workflow Generation
+        │
+        ▼
+1. Build Grounding Context
+   └── Onboarding data + unread agent alerts
+        │
+        ▼
+2. Poll Committee (parallel)
+   ├── Content Strategy Agent
+   ├── Strategy Architect Agent
+   ├── SEO Optimization Agent
+   ├── Social Amplification Agent
+   ├── Competitor Response Agent
+   └── Content Gap Radar Agent
+   └── Each: propose_daily_tasks(context) → List[TaskProposal]
+        │
+        ▼
+3. Deduplication
+   └── Remove exact title+pillar duplicates (priority-based tiebreaking)
+        │
+        ▼
+4. Self-Learning Filter
+   └── TaskMemoryService.filter_redundant_proposals()
+       ├── Remove exact hash matches from last 7 days
+       └── Remove semantically similar (txtai > 0.85) to dismissed tasks
+        │
+        ▼
+5. Pillar Coverage Enforcement
+   └── Backfill missing pillars via LLM-generated tasks
+   └── Controlled fallback if LLM fails (template tasks)
+        │
+        ▼
+6. Committee Watchdog Audit
+   └── ContentGuardianAgent.audit_committee(proposals)
+       ├── Per-agent critique (reasoning, priority, pillar fit, acceptance rate)
+       ├── Coverage gap detection
+       ├── Overlap detection
+       └── Alert generation for serious faults
+        │
+        ▼
+7. LLM Fallback (if committee returns nothing)
+   └── Generate all 6 pillars via llm_text_gen()
+        │
+        ▼
+8. Contextuality Validation
+   └── Each task must have ≥1 evidence link to onboarding or alerts
+   └── Score threshold: 0.65
+        │
+        ▼
+9. SIF Indexing (fire-and-forget)
+   └── Tasks indexed into txtai for semantic search
+```
+
+## Deduplication
+
+When two agents propose the same or similar tasks, the system resolves by priority:
+
+- Same title + same pillar → keep the one with higher priority (high > medium > low)
+- Same title + different pillar → both kept (different execution contexts)
+- Semantic duplicates (txtai similarity > 0.85) within 7 days of a dismissed task → removed
+
+## Pillar Coverage Enforcement
+
+After deduplication, any pillar with zero tasks triggers LLM-based backfill:
+
+```python
+for pid in PILLAR_IDS:
+    if pid not in covered_pillars:
+        llm_task = generate_task_for_pillar(pid, context)
+        if llm_task:
+            tasks.append(llm_task)
+```
+
+If the LLM call fails, hardcoded template tasks are used as a fallback.
+
+## Contextuality Validation
+
+Each task is scored against the grounding context (onboarding data + agent alerts). A task must have **at least one evidence link** — a reference to specific user data or an unread alert — to pass. If the plan's average score is below 0.65, the system regenerates with strict contextuality enforcement.
+
+## Committee Engine Code
+
+The committee logic lives in `backend/services/today_workflow_service.py`:
+
+| Function | Lines | Responsibility |
+|---|---|---|
+| `generate_agent_enhanced_plan()` | 391–607 | Main engine — polls agents, deduplicates, validates, runs audit |
+| `build_grounding_context()` | 341–381 | Aggregates onboarding data + unread alerts |
+| `_ensure_pillar_coverage()` | 305–338 | Backfills missing pillars |
+| `validate_plan_contextuality()` | 197–254 | Scores plan quality against evidence |
+| `_fallback_tasks()` | 50–112 | Hardcoded fallback tasks |
+
+## Agent-to-Pillar Mapping
+
+The committee validates proposals against expected pillar assignments:
+
+| Agent | Expected Pillar Focus |
+|---|---|
+| `ContentStrategyAgent` | `plan` |
+| `StrategyArchitectAgent` | `plan` |
+| `SEOOptimizationAgent` | `analyze` |
+| `SocialAmplificationAgent` | `engage` |
+| `CompetitorResponseAgent` | `analyze` |
+| `ContentGapRadarAgent` | `generate` |
+
+When an agent proposes outside its expected pillar, the ContentGuardianAgent flags it as an "off-pillar" issue.

--- a/docs-site/docs/features/sif-agents/content-guardian.md
+++ b/docs-site/docs/features/sif-agents/content-guardian.md
@@ -1,0 +1,155 @@
+# ContentGuardianAgent
+
+The ContentGuardianAgent is ALwrity's **committee watchdog**. It does not propose daily tasks — instead, it audits the committee's proposals after each generation cycle and reports on agent health, coverage quality, and potential faults.
+
+## Architecture
+
+```
+Committee proposals
+        │
+        ▼
+audit_committee(proposals)
+    ├── _critique_agent(name, proposals)       → per-agent critique
+    ├── _find_coverage_gaps(proposals)         → missing pillars
+    ├── _find_overstuffed_pillars(proposals)   → overloaded pillars
+    ├── _find_overlaps(proposals)              → duplicate proposals
+    ├── _compute_health_score()                → 0–100 health score
+    └── _generate_alerts()                     → alert objects
+        │
+        ▼
+Audit report (logged as quality_audit event)
+    ├── health_score
+    ├── verdict
+    ├── agent_critiques[]
+    ├── coverage_gaps[]
+    ├── overstuffed_pillars[]
+    ├── overlaps[]
+    └── alerts[]
+```
+
+## Per-Agent Critique
+
+Each committee agent receives a detailed critique through `_critique_agent()`:
+
+### Scoring Criteria
+
+| Criterion | Deduction | Detection |
+|---|---|---|
+| Weak reasoning | −15 per instance | Reasoning is short (<50 chars), vague, or lacks keywords like "because", "trend", "data", "competitor", "audience" |
+| Poor priority | −10 per instance | Agent proposed `low` priority for a task in its own core pillar |
+| Off-pillar proposal | −0 (flagged) | Agent proposed outside its expected pillar focus |
+| Low acceptance rate | −20 if <30% | Fewer than 30% of this agent's proposals were accepted by the committee |
+| All rejected | −30 | All proposals rejected (stacks with low acceptance penalty) |
+
+### Reasoning Score Heuristic
+
+```python
+def _reasoning_score(reasoning: str) -> float:
+    if not reasoning or len(reasoning) < 10:
+        return 0.0
+    if len(reasoning) < 25:
+        return 0.2
+    if len(reasoning) < 50:
+        return 0.4
+    # Keyword presence
+    specifics = ["because", "since", "based on", "data", "metric", "trend", 
+                 "observed", "target", "audience", "competitor", "gap", 
+                 "opportunity", "improve", "increase", "reduce", "goal", 
+                 "kpi", "score", "result"]
+    found = sum(1 for s in specifics if s in reasoning.lower())
+    base = min(1.0, 0.4 + found * 0.1)
+    if len(reasoning) > 100:
+        base = min(1.0, base + 0.15)
+    return min(1.0, base)
+```
+
+### Agent Health
+
+| Score Range | Health |
+|---|---|
+| 80–100 | `good` |
+| 50–79 | `warning` |
+| 0–49 | `failing` |
+
+## Committee Health Score
+
+The overall committee health is a 0–100 score computed from all critiques, gaps, and overlaps:
+
+| Factor | Penalty |
+|---|---|
+| Per failing agent | −15 |
+| Per warning agent | −8 |
+| Per uncovered pillar | −10 |
+| Per overlap | −5 |
+
+## Coverage Gap Detection
+
+`_find_coverage_gaps()` checks which of the 6 pillars received zero proposals:
+
+```python
+PILLAR_IDS = {"plan", "generate", "publish", "analyze", "engage", "remarket"}
+for pid in PILLAR_IDS:
+    if pid not in covered:
+        gaps.append({"pillar_id": pid, ...})
+```
+
+## Overlap Detection
+
+`_find_overlaps()` groups proposals by normalised title. If two or more agents propose tasks with the same title, it's flagged as an overlap:
+
+```python
+by_title = group_by_normalised_title(proposals)
+for title, dups in by_title:
+    if len(dups) > 1:
+        overlaps.append({"title": ..., "agents": [...], ...})
+```
+
+## Alert Generation
+
+`_generate_alerts()` creates alert objects for serious findings:
+
+| Alert Type | Severity | Trigger |
+|---|---|---|
+| `agent_failing` | error | Agent health score < 50 |
+| `weak_reasoning` | warning | ≥3 proposals with weak reasoning from one agent |
+| `coverage_gap` | warning | Pillar with zero proposals |
+| `proposal_overlap` | warning | Title proposed by multiple agents |
+
+These alerts are persisted as `AgentAlert` rows in the database (with `dedupe_key` to prevent duplicates across cycles) and surfaced on the Team Activity dashboard.
+
+## Workflow Integration
+
+The guardian runs automatically at the end of every committee generation cycle in `today_workflow_service.py`:
+
+```python
+guardian_agent = orchestrator.agents.get('guardian')
+if guardian_agent and hasattr(guardian_agent, 'audit_committee'):
+    audit_report = await guardian_agent.audit_committee(audit_input)
+    
+    activity.log_event(
+        event_type="quality_audit",
+        message=f"Committee audit: {audit_report['health_score']}/100 — {len(audit_report['alerts'])} findings",
+        payload=audit_report,
+    )
+    
+    for alert in audit_report.get("alerts", []):
+        activity.create_alert(
+            alert_type=f"guardian_{alert['type']}",
+            title=alert["title"],
+            message=alert["message"],
+            severity=alert["severity"],
+            dedupe_key=f"guardian:{alert['type']}:...",
+        )
+```
+
+## Legacy Methods
+
+The agent also retains legacy capabilities from the consolidated implementation:
+
+| Method | Purpose |
+|---|---|
+| `perform_site_audit(website_url)` | Crawl and assess external website content quality |
+| `check_cannibalization()` | Detect duplicate/similar content across the site |
+| `style_enforcer(text)` | Check content against brand voice guidelines |
+| `safety_filter(text)` | Flag content safety violations |
+| `assess_content_quality(data)` | Score content quality from description and title |

--- a/docs-site/docs/features/sif-agents/overview.md
+++ b/docs-site/docs/features/sif-agents/overview.md
@@ -1,0 +1,97 @@
+---
+description: ALwrity SIF Agent System - Intelligent AI agents for content quality, task management, and workflow automation.
+---
+
+# SIF & AI Agents Overview
+
+The **Synthetic Intelligence Framework (SIF)** is ALwrity's agent orchestration system — a team of specialised AI agents that collaborate to plan, execute, and audit your daily content marketing operations.
+
+## The Agent Ecosystem
+
+ALwrity runs **8 specialised agents** grouped into two tiers:
+
+### Committee Agents (6)
+
+These agents are polled every day to **propose tasks** for the daily workflow. They are the engine that generates your actionable task list.
+
+| Agent | Registry Key | Role |
+|---|---|---|
+| Content Strategy Agent | `content_strategist` | Identifies content opportunities and strategy gaps |
+| Strategy Architect Agent | `strategy_architect` | Suggests strategic pivots from SIF semantic analysis |
+| SEO Optimization Agent | `seo_specialist` | Flags SEO issues and optimisation opportunities |
+| Social Amplification Agent | `social_media_manager` | Recommends social engagement and distribution actions |
+| Competitor Response Agent | `competitor_analyst` | Alerts on competitor content moves and gaps |
+| Content Gap Radar Agent | `content_gap_radar` | Scores content opportunities by combining SERP data, competitor deep-dives, and trend momentum |
+
+### Independent Agents (2)
+
+These agents are **not polled for daily tasks** — they operate alongside the committee to monitor, audit, and provide specialised signals.
+
+| Agent | Registry Key | Role |
+|---|---|---|
+| Trend Surfer Agent | `trend_surfer` | Identifies emerging market trends and suggests timely content angles |
+| Content Guardian Agent | `content_guardian` | Watchdog that audits committee proposals, evaluates agent behaviour, and flags coverage gaps |
+
+### Orchestrator
+
+The **StrategyOrchestratorAgent** is the master coordinator. It receives the agents' proposals, runs deduplication, enforces pillar coverage, and delegates strategic execution tasks back to sub-agents when needed.
+
+## How Agents Are Initialised
+
+Agents are created per-user by the `ALwrityAgentOrchestrator` when a user completes onboarding. Each agent can be individually enabled or disabled via `AgentProfile` settings:
+
+```python
+profiles = db.query(AgentProfile).filter(AgentProfile.user_id == user_id).all()
+enabled = {p.agent_key: bool(p.enabled) for p in profiles}
+```
+
+If a profile is missing or `enabled` is `None`, the agent defaults to active.
+
+## Data Flow
+
+```
+Onboarding Complete
+        │
+        ▼
+Orchestrator Initialised
+    ┌───┴───┐
+    │       │
+    ▼       ▼
+Committee    Independent
+Agents (6)   Agents (2)
+    │           │
+    │           ├─ Trend Surfer → trend_signals event
+    │           └─ Content Guardian → quality_audit event
+    │
+    ▼
+Daily Workflow
+  ┌── Proposal Phase (parallel)
+  ├── Deduplication
+  ├── Pillar Coverage
+  ├── LLM Fallback
+  ├── Contextuality Validation
+  └── SIF Indexing
+```
+
+## Agent Activity Feed
+
+Every agent action — proposals, audits, errors, initialisations — is logged to the **AgentActivity** event feed. This powers the real-time Team Activity dashboard and enables persistent alert tracking.
+
+## Related Features
+
+- **[Semantic Indexing](semantic-indexing.md)** — How ALwrity indexes your website content
+- **[Test Your Indexing](test-your-indexing.md)** — Verify ALwrity understands your website
+- **[Team Activity](../team-activity/overview.md)** — Real-time agent activity dashboard
+- **[Content Guardian](content-guardian.md)** — AI quality audits for your content
+- **[Today's Workflow](../todays-workflow/overview.md)** — Agent-driven daily task management
+- **[Persona System](../persona/overview.md)** — Persona-aware agent behavior
+
+## Key Design Principles
+
+| Principle | Description |
+|---|---|
+| **Separation of concerns** | Committee agents *propose*; independents *audit*. ContentGuardianAgent never proposes daily tasks alongside the committee. |
+| **Deterministic scoring** | Audit scoring uses heuristics (keyword presence, length, ratios), not LLM calls — fast, deterministic, and predictable. |
+| **Parallel execution** | Committee proposals run concurrently via `asyncio.gather`. |
+| **Per-user enable/disable** | Each agent can be toggled independently through `AgentProfile` settings. |
+| **No cross-agent prompt pollution** | Agents do not receive each other's outputs in their prompts. The ContentGuardianAgent's audit is stored separately and never fed back into committee prompts. |

--- a/docs-site/docs/features/sif-agents/semantic-indexing.md
+++ b/docs-site/docs/features/sif-agents/semantic-indexing.md
@@ -1,0 +1,76 @@
+---
+description: ALwrity SIF Semantic Indexing - How ALwrity indexes your website content into a semantic memory that powers AI features and search.
+---
+
+# SIF Semantic Indexing
+
+**Semantic Indexing** is how ALwrity builds a memory of *your* website. Once your content is indexed, ALwrity's AI features — content planning, persona generation, SEO insights, and the agent team — can retrieve and reason about *your* business rather than generic marketing advice.
+
+## What gets indexed
+
+When you complete the **Research** step of onboarding, ALwrity indexes:
+
+| Content | What it captures |
+|---|---|
+| **Your website pages** | The text from your most important pages (homepage, product, pricing, features, use cases). |
+| **Sitemap URLs** | Your `sitemap.xml` is used to discover which pages exist and prioritise them. |
+| **Website analysis** | Brand voice, SEO issues, and social presence discovered during onboarding. |
+| **Competitor analysis** | Summaries of the competitors you identified. |
+
+## How indexing works
+
+Indexing is a **semantic** process, not keyword matching. Each page is converted into a mathematical representation (an *embedding*) that captures its *meaning*, so ALwrity can find related content even when exact words differ.
+
+```mermaid
+flowchart LR
+    A[Your Website] --> B[Sitemap discovery]
+    B --> C[Harvest page text]
+    C --> D[Embed content]
+    D --> E[Semantic Index]
+    E --> F[AI features + Test your indexing]
+```
+
+Indexing is **cost-free** — ALwrity reads your pages directly (no external search APIs) and respects your site by pausing between requests.
+
+## How many pages are indexed?
+
+ALwrity indexes a limited number of pages per run, prioritising your most important ones (homepage first, then shallower, more central pages). Higher subscription tiers index more pages. The SIF panel shows both numbers side by side:
+
+- **Pages indexed** — how many of your pages are actually in the semantic index.
+- **Sitemap URLs found** — how many total URLs your sitemap lists.
+
+If "Pages indexed" is much lower than "Sitemap URLs found", only a subset was indexed — which is expected, but worth knowing when evaluating answer quality.
+
+## When does indexing run?
+
+- **Automatically** during onboarding's Research step.
+- **Incrementally on re-runs** — only *new* pages are added; pages that are already indexed are skipped (no duplicate work, no re-crawling).
+- **On demand** — the **"Retry Analysis"** button re-runs indexing any time (for example, after you publish new content).
+
+## The SIF panel
+
+After indexing, the SIF panel on the Research step shows:
+
+| Stat | Meaning |
+|---|---|
+| **Pages indexed** | How many pages are in your semantic index. |
+| **Sitemap URLs found** | How many URLs your sitemap lists. |
+| **Pillars found** | The content topic clusters ALwrity detected on your site. |
+| **Last indexed** | When your index was last refreshed (date and time). |
+| **Activity log** | A step-by-step record of the last indexing run. |
+| **Test your indexing** | Sample questions to validate your index — see [Test Your Indexing](test-your-indexing.md). |
+
+## Where the index is used
+
+Your semantic index powers several ALwrity features behind the scenes:
+
+- **Content Strategy** — understands your existing topics and finds gaps.
+- **Persona System** — grounds personas in your real brand voice.
+- **SEO insights** — connects your content to your competitors and search data.
+- **AI Agents** — the committee agents query your index when proposing daily tasks.
+
+## Related pages
+
+- **[Test Your Indexing](test-your-indexing.md)** — verify your index is working correctly.
+- **[SIF & AI Agents Overview](overview.md)** — the agent team that consumes the index.
+- **[Onboarding System](../onboarding/overview.md)** — where indexing is triggered.

--- a/docs-site/docs/features/sif-agents/test-your-indexing.md
+++ b/docs-site/docs/features/sif-agents/test-your-indexing.md
@@ -1,0 +1,82 @@
+---
+description: ALwrity Test Your Indexing - Verify ALwrity understands your website by asking questions and reading the semantic search results.
+---
+
+# Test Your Indexing
+
+Once ALwrity has finished indexing your website, you'll see a **"Test your indexing"** section with sample questions like *"What is the main product?"* or *"List the pricing plans."* This page explains what that feature is doing, how to read its results, and how to tell if it's working correctly.
+
+## What "Test your indexing" actually does
+
+When you click a sample question, ALwrity runs a **semantic search** across your indexed pages and returns the most relevant passages. Two things matter here:
+
+1. **It retrieves, it doesn't generate.** The answers are real snippets copied word-for-word from your own pages. There is no "made-up" content — every answer traces back to a URL you actually indexed.
+2. **It matches meaning, not exact words.** A question like *"How does the platform work?"* can find a page that describes your product's workflow even if it never uses the phrase "how it works."
+
+## How to read a result
+
+Each answer is displayed in three parts:
+
+```
+#1 · score 0.82
+https://www.yoursite.com/pricing
+Start with a free plan that includes 10 projects…
+```
+
+- **`#1`** — the ranking. Results are ordered from most to least relevant.
+- **`score 0.82`** — a relevance (similarity) score from 0 to 1. Higher = closer match.
+- **The URL** — the exact page on your site the snippet came from.
+- **The snippet** — the matching passage from that page.
+
+## How to tell if it's working correctly
+
+Run a few questions and check these three things:
+
+| Check | What good looks like |
+|---|---|
+| **Right page** | The top URL is a *relevant* page — "pricing" should return your pricing page, not the homepage. |
+| **Confident score** | The top hit scores roughly **0.7 or higher**; weaker matches score lower. |
+| **Different answers** | Different questions return *different* top pages. If every question returns the homepage, the index is too shallow. |
+
+## Understanding the relevance score
+
+| Score | Meaning |
+|---|---|
+| **0.7 – 1.0** | Strong match — the page is clearly about what you asked. |
+| **0.5 – 0.7** | Moderate match — related content, but not a perfect answer. |
+| **Below 0.5** | Weak match — the closest thing in the index, not necessarily on-topic. |
+
+A low score doesn't mean the feature is broken — it usually means the specific topic simply isn't well covered by the pages that were indexed.
+
+## Why are some answers weaker than others?
+
+The precision of your answers depends mostly on **how much of your site was indexed**. ALwrity indexes a limited number of pages per run (based on your subscription tier), prioritising the most important ones. If a niche question returns a loose match, it's often because the page that would answer it perfectly wasn't included in the index yet.
+
+To improve results:
+
+- Make sure your site has a working `sitemap.xml` so ALwrity can discover all your pages.
+- Keep your most important pages (pricing, features, use cases) accessible and clearly written.
+- Re-run indexing after you publish significant new content.
+
+## Common questions
+
+**Are the answers AI-generated and could they be wrong?**
+
+No. "Test your indexing" only retrieves existing text from your pages — it never invents content. You can always click through to the source URL to confirm the snippet really exists on your page.
+
+**Why does clicking a question take a moment?**
+
+ALwrity is computing the semantic match between your question and every indexed page.
+
+**What if I see "No results found"?**
+
+Your content hasn't been indexed yet, or the index is empty. Wait for indexing to complete, or retry it from the SIF panel.
+
+**Can I ask my own question instead of the samples?**
+
+The sample questions are a quick way to validate the index. The same underlying search powers ALwrity's other AI features, so a healthy index here means the rest of the platform understands your business too.
+
+## Related pages
+
+- **[SIF Semantic Indexing](semantic-indexing.md)** — how your content gets indexed.
+- **[SIF & AI Agents Overview](overview.md)** — the agent team that uses the index.

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -229,6 +229,8 @@ nav:
       - API Reference: features/todays-workflow/api-reference.md
     - SIF & AI Agents:
       - Overview: features/sif-agents/overview.md
+      - Semantic Indexing: features/sif-agents/semantic-indexing.md
+      - Test Your Indexing: features/sif-agents/test-your-indexing.md
       - Agent Directory: features/sif-agents/agent-directory.md
       - Committee System: features/sif-agents/committee-system.md
       - ContentGuardianAgent: features/sif-agents/content-guardian.md


### PR DESCRIPTION
## Summary
Adds the missing SIF documentation to the GitHub Pages site, plus two new pages: **Semantic Indexing** and **Test Your Indexing**.

## Changes
- Adds the missing eatures/sif-agents/ pages: overview, gent-directory, committee-system, content-guardian.
- New pages: semantic-indexing.md (how your website gets indexed) and 	est-your-indexing.md (how to verify the index with sample questions).
- Adds the two new pages to the SIF & AI Agents nav section.

Scope is limited to SIF docs only — no other doc sections were changed.