### PR TITLE
feat(llm-providers): add OrcaRouter as a named text generation provider

### DIFF
--- a/backend/alwrity_utils/environment_setup.py
+++ b/backend/alwrity_utils/environment_setup.py
@@ -105,6 +105,7 @@ class EnvironmentSetup:
 # GEMINI_API_KEY=your_gemini_api_key_here
 # ANTHROPIC_API_KEY=your_anthropic_api_key_here
 # MISTRAL_API_KEY=your_mistral_api_key_here
+# ORCAROUTER_API_KEY=your_orcarouter_api_key_here
 
 # Research API Keys (Optional)
 # TAVILY_API_KEY=your_tavily_api_key_here

--- a/backend/api/onboarding_utils/onboarding_completion_service.py
+++ b/backend/api/onboarding_utils/onboarding_completion_service.py
@@ -256,9 +256,10 @@ class OnboardingCompletionService:
                     if step_num == 1:
                         api_keys_data = integrated_data.get('api_keys_data', {})
                         step_completed = bool(
-                            api_keys_data.get('openai_api_key') or 
-                            api_keys_data.get('anthropic_api_key') or 
-                            api_keys_data.get('google_api_key')
+                            api_keys_data.get('openai_api_key') or
+                            api_keys_data.get('anthropic_api_key') or
+                            api_keys_data.get('google_api_key') or
+                            api_keys_data.get('orcarouter_api_key')
                         )
                         if not step_completed:
                             has_global_providers = bool(
@@ -266,7 +267,8 @@ class OnboardingCompletionService:
                                 os.getenv("GEMINI_API_KEY") or
                                 os.getenv("OPENAI_API_KEY") or
                                 os.getenv("ANTHROPIC_API_KEY") or
-                                os.getenv("GOOGLE_API_KEY")
+                                os.getenv("GOOGLE_API_KEY") or
+                                os.getenv("ORCAROUTER_API_KEY")
                             )
                             if has_global_providers:
                                 step_completed = True

--- a/backend/api/onboarding_utils/onboarding_config_service.py
+++ b/backend/api/onboarding_utils/onboarding_config_service.py
@@ -26,7 +26,7 @@ class OnboardingConfigService:
                     "title": "AI LLM Providers",
                     "description": "Configure AI language model providers",
                     "required": True,
-                    "providers": ["openai", "gemini", "anthropic"]
+                    "providers": ["openai", "gemini", "anthropic", "orcarouter"]
                 },
                 {
                     "number": 2,
@@ -62,7 +62,7 @@ class OnboardingConfigService:
             "requirements": {
                 "min_api_keys": 1,
                 "required_providers": ["openai"],
-                "optional_providers": ["gemini", "anthropic"]
+                "optional_providers": ["gemini", "anthropic", "orcarouter"]
             }
         }
     
@@ -99,6 +99,13 @@ class OnboardingConfigService:
                 "name": "Anthropic",
                 "description": "Claude models for sophisticated content generation",
                 "setup_url": "https://console.anthropic.com/",
+                "required_fields": ["api_key"],
+                "optional_fields": []
+            },
+            "orcarouter": {
+                "name": "OrcaRouter",
+                "description": "Unified gateway to 200+ models (OpenAI, Anthropic, Google, Meta and more) through one OpenAI-compatible endpoint",
+                "setup_url": "https://www.orcarouter.ai",
                 "required_fields": ["api_key"],
                 "optional_fields": []
             }

--- a/backend/env_template.txt
+++ b/backend/env_template.txt
@@ -5,6 +5,7 @@
 GEMINI_API_KEY=your_gemini_api_key_here
 # ANTHROPIC_API_KEY=your_anthropic_api_key_here
 # MISTRAL_API_KEY=your_mistral_api_key_here
+# ORCAROUTER_API_KEY=your_orcarouter_api_key_here
 
 # Research API Keys (Optional)
 # TAVILY_API_KEY=your_tavily_api_key_here

--- a/backend/middleware/api_key_injection_middleware.py
+++ b/backend/middleware/api_key_injection_middleware.py
@@ -133,6 +133,7 @@ class APIKeyInjectionMiddleware:
                 'copilotkit': 'COPILOTKIT_API_KEY',
                 'openai': 'OPENAI_API_KEY',
                 'anthropic': 'ANTHROPIC_API_KEY',
+                'orcarouter': 'ORCAROUTER_API_KEY',
                 'tavily': 'TAVILY_API_KEY',
                 'serper': 'SERPER_API_KEY',
                 'firecrawl': 'FIRECRAWL_API_KEY',

--- a/backend/services/llm_providers/__init__.py
+++ b/backend/services/llm_providers/__init__.py
@@ -7,12 +7,18 @@ migrated from the legacy lib/gpt_providers functionality.
 from services.llm_providers.main_text_generation import llm_text_gen
 from services.llm_providers.gemini_provider import gemini_text_response, gemini_structured_json_response
 from services.llm_providers.huggingface_provider import huggingface_text_response, huggingface_structured_json_response
+from services.llm_providers.orcarouter_provider import (
+    orcarouter_text_response,
+    orcarouter_structured_json_response,
+)
 
 
 __all__ = [
     "llm_text_gen",
-    "gemini_text_response", 
+    "gemini_text_response",
     "gemini_structured_json_response",
     "huggingface_text_response",
-    "huggingface_structured_json_response"
-] 
+    "huggingface_structured_json_response",
+    "orcarouter_text_response",
+    "orcarouter_structured_json_response",
+]

--- a/backend/services/llm_providers/main_text_generation.py
+++ b/backend/services/llm_providers/main_text_generation.py
@@ -106,6 +106,9 @@ def llm_text_gen(
             elif primary_provider in ['hf_response_api', 'huggingface', 'hf']:
                 gpt_provider = "huggingface"
                 model = "openai/gpt-oss-120b:cerebras"
+            elif primary_provider in ['orcarouter', 'orca']:
+                gpt_provider = "orcarouter"
+                model = os.getenv('ORCAROUTER_MODEL', 'orcarouter/auto')
             elif primary_provider in ['openai', 'gpt']:
                 gpt_provider = "openai"
                 model = os.getenv('OPENAI_MODEL', 'gpt-4o-mini')
@@ -117,6 +120,9 @@ def llm_text_gen(
             if preferred_provider in ['wavespeed', 'wave']:
                 gpt_provider = "wavespeed"
                 model = os.getenv('WAVESPEED_TEXT_MODEL', 'openai/gpt-oss-120b')
+            elif preferred_provider in ['orcarouter', 'orca']:
+                gpt_provider = "orcarouter"
+                model = os.getenv('ORCAROUTER_MODEL', 'orcarouter/auto')
             elif preferred_provider in ['openai', 'gpt']:
                 gpt_provider = "openai"
                 model = os.getenv('OPENAI_MODEL', 'gpt-4o-mini')
@@ -142,6 +148,9 @@ def llm_text_gen(
             elif selected_provider == "huggingface":
                 gpt_provider = "huggingface"
                 model = provider_cfg.model_policy.get("default_model") or "openai/gpt-oss-120b:cerebras"
+            elif selected_provider in ["orcarouter", "orca"]:
+                gpt_provider = "orcarouter"
+                model = provider_cfg.model_policy.get("default_model") or "orcarouter/auto"
         
         # Map short model names to full paths for HF
         if model_list and gpt_provider == "huggingface":
@@ -170,6 +179,8 @@ def llm_text_gen(
             available_providers.append("huggingface")
         if api_key_manager.get_api_key("wavespeed"):
             available_providers.append("wavespeed")
+        if api_key_manager.get_api_key("orcarouter"):
+            available_providers.append("orcarouter")
         
         logger.warning(
             f"[llm_text_gen][{flow_tag}] Provider preflight: env_provider='{env_provider or 'auto'}', "
@@ -197,6 +208,8 @@ def llm_text_gen(
             os.environ.setdefault("GOOGLE_API_KEY", resolved_key)
         elif gpt_provider == "huggingface" and resolved_key:
             os.environ["HF_TOKEN"] = resolved_key
+        elif gpt_provider == "orcarouter" and resolved_key:
+            os.environ["ORCAROUTER_API_KEY"] = resolved_key
 
         if gpt_provider == "huggingface" and preferred_hf_models:
             model = preferred_hf_models[0]
@@ -221,6 +234,11 @@ def llm_text_gen(
         elif gpt_provider == "openai":
             provider_enum = APIProvider.OPENAI
             actual_provider_name = "openai"
+        elif gpt_provider == "orcarouter":
+            # OrcaRouter is an OpenAI-compatible gateway; reuse the OPENAI enum for
+            # subscription/usage tracking (same pattern as HuggingFace -> MISTRAL).
+            provider_enum = APIProvider.OPENAI
+            actual_provider_name = "orcarouter"
         
         if not provider_enum:
             # For unknown providers, try to proceed without subscription tracking
@@ -406,9 +424,32 @@ def llm_text_gen(
                 api_took_ms = (time.time() - t1) * 1000
                 total_ms = (time.time() - t0) * 1000
                 logger.warning(f"[llm_text_gen][{flow_tag}] wavespeed: user={user_id} import_took={(t1-t0)*1000:.0f}ms api_took={api_took_ms:.0f}ms total={total_ms:.0f}ms")
+            elif gpt_provider == "orcarouter":
+                from services.llm_providers.orcarouter_provider import (
+                    orcarouter_text_response,
+                    orcarouter_structured_json_response,
+                )
+                if json_struct:
+                    response_text = orcarouter_structured_json_response(
+                        prompt=prompt,
+                        schema=json_struct,
+                        model=model or "orcarouter/auto",
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        system_prompt=system_instructions
+                    )
+                else:
+                    response_text = orcarouter_text_response(
+                        prompt=prompt,
+                        model=model or "orcarouter/auto",
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        top_p=top_p,
+                        system_prompt=system_instructions
+                    )
             else:
                 logger.error(f"[llm_text_gen] Unknown provider: {gpt_provider}")
-                raise RuntimeError(f"Unknown LLM provider: {gpt_provider}. Supported providers: google, huggingface, wavespeed")
+                raise RuntimeError(f"Unknown LLM provider: {gpt_provider}. Supported providers: google, huggingface, wavespeed, orcarouter")
             
             # TRACK USAGE after successful API call
             if response_text:
@@ -593,7 +634,8 @@ def get_api_key(gpt_provider: str, user_id: Optional[str] = None) -> Optional[st
     try:
         provider_mapping = {
             "google": "gemini",
-            "huggingface": "huggingface"
+            "huggingface": "huggingface",
+            "orcarouter": "orcarouter"
         }
         mapped_provider = provider_mapping.get(gpt_provider, gpt_provider)
         key, _source = tenant_provider_config_resolver.resolve_provider_key(mapped_provider, user_id=user_id)

--- a/backend/services/llm_providers/orcarouter_provider.py
+++ b/backend/services/llm_providers/orcarouter_provider.py
@@ -1,0 +1,488 @@
+"""
+OrcaRouter LLM Provider Module for ALwrity
+
+This module provides functions for interacting with OrcaRouter's LLM API
+using the OpenAI-compatible interface for text generation.
+
+Key Features:
+- Text response generation with retry logic
+- Structured JSON response generation with schema validation
+- Comprehensive error handling and logging
+- Automatic API key management
+- Support for 200+ models through a single OpenAI-compatible endpoint
+
+Best Practices:
+1. Use appropriate temperature for your use case (0.7 for creative, 0.1-0.3 for factual)
+2. Set max_tokens based on expected response length
+3. Use system_prompt to guide model behavior
+4. Handle errors gracefully in calling functions
+
+Usage Examples:
+    # Text response
+    result = orcarouter_text_response(prompt, temperature=0.7, max_tokens=2048)
+
+    # Structured JSON response
+    schema = {"type": "object", "properties": {"title": {"type": "string"}}}
+    result = orcarouter_structured_json_response(prompt, schema, temperature=0.2, max_tokens=8192)
+
+Dependencies:
+- openai (for OrcaRouter OpenAI-compatible API)
+- tenacity (for retry logic)
+- logging (for debugging)
+- json (for fallback parsing)
+
+Author: ALwrity Team
+Version: 1.0
+Last Updated: August 2026
+"""
+
+import os
+import sys
+import time as _time
+from pathlib import Path
+import json
+import re
+from typing import Optional, Dict, Any, List
+
+from dotenv import load_dotenv
+
+# Fix the environment loading path - load from backend directory
+_mod_start = _time.time()
+current_dir = Path(__file__).parent.parent  # services directory
+backend_dir = current_dir.parent  # backend directory
+env_path = backend_dir / '.env'
+
+if env_path.exists():
+    load_dotenv(env_path)
+    _dotenv_ms = (_time.time() - _mod_start) * 1000
+    print(f"Loaded .env from: {env_path} (took {_dotenv_ms:.0f}ms)")
+else:
+    load_dotenv()
+    print(f"No .env found at {env_path}, using current directory")
+
+from loguru import logger
+from utils.logger_utils import get_service_logger
+
+# Use service-specific logger to avoid conflicts
+logger = get_service_logger("orcarouter_provider")
+
+_import_start = _time.time()
+from tenacity import (
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_random_exponential,
+)
+
+try:
+    from openai import OpenAI
+    from openai import NotFoundError
+    OPENAI_AVAILABLE = True
+except ImportError:
+    OPENAI_AVAILABLE = False
+    NotFoundError = Exception
+    logger.warn("OpenAI library not available. Install with: pip install openai")
+
+logger.warning(f"[orcarouter_provider] Module import completed in {(_time.time()-_import_start)*1000:.0f}ms (openai_available={OPENAI_AVAILABLE})")
+
+# OrcaRouter API base URL and default model
+ORCAROUTER_BASE_URL = os.getenv("ORCAROUTER_BASE_URL", "https://api.orcarouter.ai/v1")
+ORCAROUTER_DEFAULT_MODEL = os.getenv("ORCAROUTER_DEFAULT_MODEL", "orcarouter/auto")
+
+# Default OrcaRouter models for fallback
+ORCAROUTER_FALLBACK_MODELS = [
+    "orcarouter/auto",
+    "openai/gpt-4o-mini",
+    "anthropic/claude-sonnet-4.5",
+]
+
+
+def get_orcarouter_api_key() -> str:
+    """Get OrcaRouter API key with proper error handling."""
+    api_key = os.getenv('ORCAROUTER_API_KEY')
+    if not api_key:
+        error_msg = "ORCAROUTER_API_KEY environment variable is not set. Please set it in your .env file."
+        logger.error(error_msg)
+        raise ValueError(error_msg)
+
+    # Validate API key format (basic check)
+    if not api_key.startswith('sk-orca-'):
+        error_msg = "ORCAROUTER_API_KEY appears to be invalid. It should start with 'sk-orca-'."
+        logger.error(error_msg)
+        raise ValueError(error_msg)
+
+    return api_key
+
+
+def _is_non_retryable_orcarouter_error(exc: Exception) -> bool:
+    """Skip retries for deterministic OrcaRouter failures (e.g., unknown model ids, billing)."""
+    msg = str(exc).lower()
+    status = getattr(exc, "status_code", None)
+
+    # Non-retryable errors
+    if isinstance(exc, NotFoundError) or "not found" in msg or "404" in msg:
+        return True
+    if status == 402 or "402" in msg or "depleted" in msg or "credits" in msg:
+        return True
+    if status == 401 or "unauthorized" in msg or "401" in msg:
+        return True
+    if status == 403 or "forbidden" in msg or "403" in msg:
+        return True
+
+    return False
+
+
+def _should_retry_orcarouter_error(exc: Exception) -> bool:
+    return not _is_non_retryable_orcarouter_error(exc)
+
+
+def _classify_orcarouter_error(exc: Exception) -> str:
+    """Classify OrcaRouter failures for actionable logs."""
+    msg = str(exc).lower()
+    if any(token in msg for token in ["insufficient", "balance", "quota", "billing", "payment", "402"]):
+        return "billing_or_quota"
+    if "unauthorized" in msg or "forbidden" in msg or "401" in msg or "403" in msg:
+        return "auth_or_permission"
+    if "not found" in msg or "404" in msg:
+        return "model_not_found"
+    return "unknown"
+
+
+def _orcarouter_error_details(exc: Exception) -> str:
+    """Return compact, actionable exception details for logs."""
+    status = getattr(exc, "status_code", None)
+    err_type = type(exc).__name__
+    message = str(exc)
+    raw_body = getattr(exc, "body", None)
+    details = f"type={err_type}"
+    if status is not None:
+        details += f", status={status}"
+    if message:
+        details += f", message={message}"
+    if raw_body:
+        details += f", body={raw_body}"
+    details += f", repr={repr(exc)}"
+    return details
+
+
+@retry(
+    retry=retry_if_exception(_should_retry_orcarouter_error),
+    wait=wait_random_exponential(min=1, max=60),
+    stop=stop_after_attempt(6),
+)
+def orcarouter_text_response(
+    prompt: str,
+    model: str = ORCAROUTER_DEFAULT_MODEL,
+    temperature: float = 0.7,
+    max_tokens: int = 2048,
+    top_p: float = 0.9,
+    system_prompt: Optional[str] = None
+) -> str:
+    """
+    Generate text response using OrcaRouter LLM API.
+
+    This function uses the OrcaRouter OpenAI-compatible API for text generation
+    with built-in retry logic and error handling.
+
+    Args:
+        prompt (str): The input prompt for the AI model
+        model (str): OrcaRouter model identifier (default: "orcarouter/auto")
+        temperature (float): Controls randomness (0.0-1.0)
+        max_tokens (int): Maximum tokens in response
+        top_p (float): Nucleus sampling parameter (0.0-1.0)
+        system_prompt (str, optional): System instruction for the model
+
+    Returns:
+        str: Generated text response
+
+    Raises:
+        Exception: If API key is missing or API call fails
+
+    Example:
+        result = orcarouter_text_response(
+            prompt="Write a blog post about AI",
+            model="orcarouter/auto",
+            temperature=0.7,
+            max_tokens=2048,
+            system_prompt="You are a professional content writer."
+        )
+    """
+    try:
+        if not OPENAI_AVAILABLE:
+            raise ImportError("OpenAI library not available. Install with: pip install openai")
+
+        # Get API key with proper error handling
+        api_key = get_orcarouter_api_key()
+        logger.info(f"🔑 OrcaRouter API key loaded: {bool(api_key)} (length: {len(api_key) if api_key else 0})")
+
+        if not api_key:
+            raise Exception("ORCAROUTER_API_KEY not found in environment variables")
+
+        _t0 = _time.time()
+        # Initialize OrcaRouter client
+        client = OpenAI(
+            base_url=ORCAROUTER_BASE_URL,
+            api_key=api_key,
+        )
+        logger.warning(f"[orcarouter_text_response] OpenAI client init took {(_time.time()-_t0)*1000:.0f}ms")
+
+        # Prepare input for the API
+        messages = []
+
+        # Add system prompt if provided
+        if system_prompt:
+            messages.append({
+                "role": "system",
+                "content": system_prompt
+            })
+
+        # Add user prompt
+        messages.append({
+            "role": "user",
+            "content": prompt
+        })
+
+        # Add debugging for API call
+        logger.info(
+            "OrcaRouter text call | model={} | prompt_len={} | temp={} | top_p={} | max_tokens={}",
+            model,
+            len(prompt) if isinstance(prompt, str) else '<non-str>',
+            temperature,
+            top_p,
+            max_tokens,
+        )
+
+        logger.info("🚀 Making OrcaRouter API call (chat completion)...")
+
+        _api_t0 = _time.time()
+        # Call exactly the requested model
+        response = client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens
+        )
+        logger.warning(f"[orcarouter_text_response] API call took {(_time.time()-_api_t0)*1000:.0f}ms")
+
+        # Extract text from response
+        generated_text = response.choices[0].message.content
+
+        # Clean up the response
+        if generated_text:
+            # Remove any markdown formatting if present
+            generated_text = re.sub(r'```[a-zA-Z]*\n?', '', generated_text)
+            generated_text = re.sub(r'```\n?', '', generated_text)
+            generated_text = generated_text.strip()
+
+        logger.info(f"✅ OrcaRouter text response generated successfully (length: {len(generated_text)})")
+        return generated_text
+
+    except Exception as e:
+        error_class = _classify_orcarouter_error(e)
+        error_details = _orcarouter_error_details(e)
+        logger.error(f"❌ OrcaRouter text generation failed: {error_details}")
+
+        # Extra diagnostics: try to capture raw response if available
+        if hasattr(e, 'response') and e.response is not None:
+            logger.error(f"🔍 OrcaRouter Error Diagnostics:")
+            logger.error(f"  - Status: {e.response.status_code}")
+            logger.error(f"  - Headers: {dict(e.response.headers)}")
+            try:
+                body_json = e.response.json()
+                logger.error(f"  - Body JSON: {json.dumps(body_json, indent=2)}")
+            except Exception:
+                logger.error(f"  - Body Raw: {e.response.text[:1000]}")
+        else:
+            logger.error(f"🔍 No HTTP response attached to exception object.")
+
+        raise Exception(f"OrcaRouter text generation failed: {str(e)}")
+
+
+@retry(
+    retry=retry_if_exception(_should_retry_orcarouter_error),
+    wait=wait_random_exponential(min=1, max=60),
+    stop=stop_after_attempt(6),
+)
+def orcarouter_structured_json_response(
+    prompt: str,
+    schema: Dict[str, Any],
+    model: str = ORCAROUTER_DEFAULT_MODEL,
+    temperature: float = 0.7,
+    max_tokens: int = 8192,
+    system_prompt: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    Generate structured JSON response using OrcaRouter LLM API.
+
+    This function uses the OrcaRouter OpenAI-compatible API with structured output support
+    to generate JSON responses that match a provided schema.
+
+    Args:
+        prompt (str): The input prompt for the AI model
+        schema (dict): JSON schema defining the expected output structure
+        model (str): OrcaRouter model identifier (default: "orcarouter/auto")
+        temperature (float): Controls randomness (0.0-1.0). Use 0.1-0.3 for structured output
+        max_tokens (int): Maximum tokens in response. Use 8192 for complex outputs
+        system_prompt (str, optional): System instruction for the model
+
+    Returns:
+        dict: Parsed JSON response matching the provided schema
+
+    Raises:
+        Exception: If API key is missing or API call fails
+
+    Example:
+        schema = {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "summary": {"type": "string"}
+            }
+        }
+        result = orcarouter_structured_json_response(prompt, schema, temperature=0.2, max_tokens=8192)
+    """
+    try:
+        if not OPENAI_AVAILABLE:
+            raise ImportError("OpenAI library not available. Install with: pip install openai")
+
+        # Get API key with proper error handling
+        api_key = get_orcarouter_api_key()
+        logger.info(f"🔑 OrcaRouter API key loaded: {bool(api_key)} (length: {len(api_key) if api_key else 0})")
+
+        if not api_key:
+            raise Exception("ORCAROUTER_API_KEY not found in environment variables")
+
+        _fn_start = _time.time()
+        # Initialize OpenAI client with OrcaRouter base URL
+        client = OpenAI(
+            base_url=ORCAROUTER_BASE_URL,
+            api_key=api_key,
+        )
+        _client_init_ms = (_time.time() - _fn_start) * 1000
+        logger.warning(f"[orcarouter_structured_json_response] OpenAI client init took {_client_init_ms:.0f}ms")
+
+        # Prepare input for the API
+        messages = []
+
+        # Add system prompt if provided
+        if system_prompt:
+            messages.append({
+                "role": "system",
+                "content": system_prompt
+            })
+
+        # Add user prompt with JSON instruction
+        json_instruction = "Please respond with valid JSON that matches the provided schema."
+        messages.append({
+            "role": "user",
+            "content": f"{prompt}\n\n{json_instruction}"
+        })
+
+        # Add JSON schema to prompt for guidance
+        json_schema_str = json.dumps(schema, indent=2)
+        messages[-1]["content"] += f"\n\nJSON Schema:\n{json_schema_str}"
+
+        # Add debugging for API call
+        logger.info(
+            "OrcaRouter structured call | model={} | prompt_len={} | schema_kind={} | temp={} | max_tokens={}",
+            model,
+            len(prompt) if isinstance(prompt, str) else '<non-str>',
+            type(schema).__name__,
+            temperature,
+            max_tokens,
+        )
+
+        logger.info("🚀 Making OrcaRouter structured API call...")
+
+        _api_start = _time.time()
+        try:
+            response = client.chat.completions.create(
+                model=model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                response_format={"type": "json_object"}  # Try to enforce JSON mode if supported
+            )
+            _api_ms = (_time.time() - _api_start) * 1000
+            logger.warning(f"[orcarouter_structured_json_response] First API call completed in {_api_ms:.0f}ms (model={model})")
+        except Exception as e:
+            logger.error(f"❌ OrcaRouter API call failed: {e}")
+            # If 422 Unprocessable Entity (often due to response_format not supported), retry without it
+            if "422" in str(e) or "not supported" in str(e).lower():
+                logger.info("Retrying without response_format...")
+                response = client.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens
+                )
+            else:
+                raise e
+
+        response_text = response.choices[0].message.content
+        response_text = response_text.strip() if response_text else ""
+
+        # If response_format returned empty content, retry without it
+        if not response_text:
+            logger.warning("OrcaRouter structured call returned empty content with response_format, retrying without it...")
+            response = client.chat.completions.create(
+                model=model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens
+            )
+            response_text = response.choices[0].message.content
+            response_text = response_text.strip() if response_text else ""
+
+        # Clean up response text if needed
+        if response_text.startswith("```json"):
+            response_text = response_text[7:]
+        if response_text.startswith("```"):
+            response_text = response_text[3:]
+        if response_text.endswith("```"):
+            response_text = response_text[:-3]
+        response_text = response_text.strip()
+
+        try:
+            parsed_json = json.loads(response_text) if response_text else None
+            if parsed_json is not None:
+                logger.info("✅ OrcaRouter structured JSON response parsed successfully")
+                return parsed_json
+        except json.JSONDecodeError as json_err:
+            logger.error(f"❌ JSON parsing failed: {json_err}")
+
+        # Try to extract JSON from the response using regex
+        if response_text:
+            json_match = re.search(r'\{.*\}', response_text, re.DOTALL)
+            if json_match:
+                try:
+                    extracted_json = json.loads(json_match.group())
+                    logger.info("✅ JSON extracted using regex fallback")
+                    return extracted_json
+                except json.JSONDecodeError:
+                    pass
+
+        return {"error": "Failed to parse JSON response", "raw_response": response_text}
+
+    except Exception as e:
+        error_msg = str(e) if str(e) else repr(e)
+        error_type = type(e).__name__
+        logger.error(f"❌ OrcaRouter structured JSON generation failed [{error_type}]: {error_msg}")
+
+        # Surface balance/quota errors as HTTPException so upstream can show user-friendly messages
+        from fastapi import HTTPException
+        if "balance_not_enough" in error_msg or "403" in error_msg or "PermissionDenied" in error_type:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "insufficient_balance",
+                    "message": "OrcaRouter API balance is insufficient. Please top up your account or switch to a different provider.",
+                    "usage_info": {
+                        "error_type": "insufficient_balance",
+                        "provider": "orcarouter",
+                        "suggestion": "Set GPT_PROVIDER=google in your environment to use Gemini instead."
+                    }
+                }
+            )
+        raise Exception(f"OrcaRouter structured JSON generation failed: {error_msg}")

--- a/backend/services/llm_providers/tenant_provider_config.py
+++ b/backend/services/llm_providers/tenant_provider_config.py
@@ -31,6 +31,7 @@ class TenantProviderConfigResolver:
         "stability": ("stability", "stability_api_key"),
         "wavespeed": ("wavespeed", "wavespeed_api_key"),
         "openai": ("openai", "openai_api_key"),
+        "orcarouter": ("orcarouter", "orca", "orcarouter_api_key"),
     }
 
     _ENV_VARS: Dict[str, Tuple[str, ...]] = {
@@ -39,6 +40,7 @@ class TenantProviderConfigResolver:
         "stability": ("STABILITY_API_KEY",),
         "wavespeed": ("WAVESPEED_API_KEY",),
         "openai": ("OPENAI_API_KEY",),
+        "orcarouter": ("ORCAROUTER_API_KEY",),
     }
 
     _ENV_PROVIDER_DEFAULTS: Dict[str, str] = {
@@ -51,6 +53,7 @@ class TenantProviderConfigResolver:
     _DEFAULT_MODELS: Dict[Tuple[str, str], str] = {
         ("text", "google"): "gemini-2.0-flash-001",
         ("text", "huggingface"): "mistralai/Mistral-7B-Instruct-v0.3:groq",
+        ("text", "orcarouter"): "orcarouter/auto",
         ("image", "wavespeed"): "flux-kontext-pro",
         ("image", "huggingface"): "black-forest-labs/FLUX.1-Krea-dev",
         ("video", "huggingface"): "tencent/HunyuanVideo",
@@ -121,6 +124,8 @@ class TenantProviderConfigResolver:
             return "gemini"
         if provider_l in ("hf", "huggingface", "hf_response_api"):
             return "huggingface"
+        if provider_l in ("orcarouter", "orca"):
+            return "orcarouter"
         return provider_l
 
     def _get_tenant_key_from_db(self, user_id: Optional[str], provider: str) -> Optional[str]:

--- a/backend/services/onboarding/api_key_manager.py
+++ b/backend/services/onboarding/api_key_manager.py
@@ -575,6 +575,7 @@ class APIKeyManager:
             'FIRECRAWL_API_KEY',
             'STABILITY_API_KEY',
             'WAVESPEED_API_KEY',
+            'ORCAROUTER_API_KEY',
         ]
         
         for provider in providers:

--- a/backend/services/validation.py
+++ b/backend/services/validation.py
@@ -43,9 +43,10 @@ def check_all_api_keys(api_manager) -> Dict[str, Any]:
         logger.info("Checking AI provider API keys...")
         ai_providers = [
             'OPENAI_API_KEY',
-            'GEMINI_API_KEY', 
+            'GEMINI_API_KEY',
             'ANTHROPIC_API_KEY',
-            'MISTRAL_API_KEY'
+            'MISTRAL_API_KEY',
+            'ORCAROUTER_API_KEY'
         ]
         
         ai_provider_results = {}
@@ -220,7 +221,13 @@ def validate_api_key(provider: str, api_key: str) -> Dict[str, Any]:
                 return {'valid': False, 'error': 'Mistral API key must start with "mistral-"'}
             if len(api_key) < 20:
                 return {'valid': False, 'error': 'Mistral API key seems too short'}
-        
+
+        elif provider == "orcarouter":
+            if not api_key.startswith("sk-orca-"):
+                return {'valid': False, 'error': 'OrcaRouter API key must start with "sk-orca-"'}
+            if len(api_key) < 20:
+                return {'valid': False, 'error': 'OrcaRouter API key seems too short'}
+
         elif provider == "tavily":
             if len(api_key) < 10:
                 return {'valid': False, 'error': 'Tavily API key seems too short'}
@@ -447,6 +454,9 @@ def validate_api_key_format(provider: str, api_key: str) -> bool:
         return False
     
     if provider == "mistral" and not api_key.startswith("mistral-"):
+        return False
+
+    if provider == "orcarouter" and not api_key.startswith("sk-orca-"):
         return False
     
     return True 

--- a/backend/tests/test_orcarouter_provider.py
+++ b/backend/tests/test_orcarouter_provider.py
@@ -1,0 +1,60 @@
+"""Tests for the OrcaRouter LLM provider integration.
+
+These tests cover the provider registration surface without making network calls:
+- tenant_provider_config_resolver: OrcaRouter alias normalization and env var lookup
+- orcarouter_provider module: base URL, default model, and API key format validation
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+class TestTenantProviderConfigOrcaRouter:
+    """Provider resolver recognizes orcarouter as a first-class text provider."""
+
+    def test_normalize_orcarouter_alias(self):
+        from services.llm_providers.tenant_provider_config import tenant_provider_config_resolver
+
+        assert tenant_provider_config_resolver._normalize_provider("orcarouter") == "orcarouter"
+        assert tenant_provider_config_resolver._normalize_provider("orca") == "orcarouter"
+        assert tenant_provider_config_resolver._normalize_provider("ORCAROUTER") == "orcarouter"
+
+    def test_orcarouter_env_var_resolution(self):
+        from services.llm_providers.tenant_provider_config import tenant_provider_config_resolver
+
+        with patch.dict(os.environ, {"ORCAROUTER_API_KEY": "sk-orca-test-1234567890"}):
+            key, source = tenant_provider_config_resolver.resolve_provider_key("orcarouter", user_id=None)
+            assert key == "sk-orca-test-1234567890"
+            assert source == "env_default"
+
+    def test_orcarouter_text_default_model(self):
+        from services.llm_providers.tenant_provider_config import tenant_provider_config_resolver
+
+        cfg = tenant_provider_config_resolver.resolve(modality="text", user_id=None, explicit_provider="orcarouter")
+        assert cfg.selected_providers == ["orcarouter"]
+        assert cfg.model_policy["default_model"] == "orcarouter/auto"
+
+
+class TestOrcaRouterProviderModule:
+    """orcarouter_provider module constants and key validation."""
+
+    def test_base_url_and_default_model(self):
+        import services.llm_providers.orcarouter_provider as mod
+
+        assert mod.ORCAROUTER_BASE_URL == "https://api.orcarouter.ai/v1"
+        assert mod.ORCAROUTER_DEFAULT_MODEL == "orcarouter/auto"
+
+    def test_api_key_format_validation(self):
+        from services.llm_providers.orcarouter_provider import get_orcarouter_api_key
+
+        with patch.dict(os.environ, {"ORCAROUTER_API_KEY": "sk-orca-1234567890abcdef"}):
+            assert get_orcarouter_api_key() == "sk-orca-1234567890abcdef"
+
+    def test_api_key_format_rejects_bad_prefix(self):
+        from services.llm_providers.orcarouter_provider import get_orcarouter_api_key
+
+        with patch.dict(os.environ, {"ORCAROUTER_API_KEY": "sk-bad-1234567890"}):
+            with pytest.raises(ValueError, match="sk-orca-"):
+                get_orcarouter_api_key()

--- a/docs-site/docs/getting-started/configuration.md
+++ b/docs-site/docs/getting-started/configuration.md
@@ -29,6 +29,9 @@ OPENAI_API_KEY=your_openai_api_key_here
 
 # Anthropic API - Claude AI service
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# OrcaRouter API - Unified gateway to 200+ models
+ORCAROUTER_API_KEY=your_orcarouter_api_key_here
 ```
 
 #### Database Configuration
@@ -194,6 +197,21 @@ REACT_APP_GA_TRACKING_ID=your_ga_tracking_id_here
 3. Navigate to API Keys
 4. Create a new API key
 5. Add to `ANTHROPIC_API_KEY` in backend `.env`
+
+### 3b. OrcaRouter API
+
+**Purpose**: Unified gateway to 200+ models (OpenAI, Anthropic, Google, Meta and more) through a single OpenAI-compatible endpoint
+
+**Setup Steps**:
+1. Visit [OrcaRouter](https://www.orcarouter.ai)
+2. Sign in to your account
+3. Generate an API key (starts with `sk-orca-`)
+4. Add to `ORCAROUTER_API_KEY` in backend `.env`
+5. Optional: set `GPT_PROVIDER=orcarouter` in backend `.env` to route text generation through OrcaRouter
+
+**Usage Limits**:
+- Pay-per-use model
+- Single key gives access to models from multiple leading providers
 
 ### 4. Tavily API
 

--- a/docs/SIF_and_AI_Tools_model_LLM_choices.md
+++ b/docs/SIF_and_AI_Tools_model_LLM_choices.md
@@ -27,6 +27,7 @@ Use remote premium API path by default.
   - `hf`
   - `hf_response_api`
   - `wavespeed` (alias mapping for premium remote route)
+- **OrcaRouter**: `GPT_PROVIDER=orcarouter` routes text generation through the [OrcaRouter](https://www.orcarouter.ai) OpenAI-compatible gateway (`https://api.orcarouter.ai/v1`, default model `orcarouter/auto`). It is a first-class named provider implemented in [orcarouter_provider.py](../backend/services/llm_providers/orcarouter_provider.py) and is treated as an OpenAI-compatible route.
 
 Fallback policy for premium tools:
 

--- a/docs/llm_gateway/Architecture.md
+++ b/docs/llm_gateway/Architecture.md
@@ -35,6 +35,7 @@ ALwrity’s LLM Gateway lives under [llm_providers](file:///C:/Users/diksha%20ra
 - **Provider Implementations**:
   - Gemini text: [gemini_provider.py](file:///C:/Users/diksha%20rawat/Desktop/ALwrity/backend/services/llm_providers/gemini_provider.py)
   - Hugging Face text: [huggingface_provider.py](file:///C:/Users/diksha%20rawat/Desktop/ALwrity/backend/services/llm_providers/huggingface_provider.py)
+  - OrcaRouter text: [orcarouter_provider.py](file:///C:/Users/diksha%20rawat/Desktop/ALwrity/backend/services/llm_providers/orcarouter_provider.py)
   - Hugging Face image: [hf_provider.py](file:///C:/Users/diksha%20rawat/Desktop/ALwrity/backend/services/llm_providers/image_generation/hf_provider.py)
   - WaveSpeed video: [wavespeed_provider.py](file:///C:/Users/diksha%20rawat/Desktop/ALwrity/backend/services/llm_providers/video_generation/wavespeed_provider.py)
 
@@ -60,6 +61,8 @@ These contracts ensure consistent options/result types so downstream UI and logg
   - Loaded and validated in [gemini_provider.py](file:///C:/Users/diksha%20rawat/Desktop/ALwrity/backend/services/llm_providers/gemini_provider.py#L101-L116)
 - Hugging Face: HF_TOKEN
   - Loaded and validated in [huggingface_provider.py](file:///C:/Users/diksha%20rawat/Desktop/ALwrity/backend/services/llm_providers/huggingface_provider.py#L90-L105)
+- OrcaRouter: ORCAROUTER_API_KEY
+  - Loaded and validated in [orcarouter_provider.py](file:///C:/Users/diksha%20rawat/Desktop/ALwrity/backend/services/llm_providers/orcarouter_provider.py#L80-L95)
 - Hugging Face image defaults: HF_IMAGE_MODEL
   - Used in [image_generation/hf_provider.py](file:///C:/Users/diksha%20rawat/Desktop/ALwrity/backend/services/llm_providers/image_generation/hf_provider.py#L17-L21)
 - Provider clients must never log secrets; logs are provider‑scoped via get_service_logger.


### PR DESCRIPTION
## Description

Add **OrcaRouter** as a first-class named LLM provider for text generation in ALwrity's backend LLM gateway.

[OrcaRouter](https://www.orcarouter.ai) is a unified AI gateway that exposes 200+ models from OpenAI, Anthropic, Google, Meta and more through a single OpenAI-compatible endpoint (`https://api.orcarouter.ai/v1`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

This PR mirrors the existing OpenAI-compatible provider pattern (WaveSpeed / Hugging Face) and registers OrcaRouter across all provider surfaces:

### Backend
- **New `orcarouter_provider.py`** — OpenAI-compatible client against `https://api.orcarouter.ai/v1`, `ORCAROUTER_API_KEY` (`sk-orca-` prefix), default model `orcarouter/auto`, with `orcarouter_text_response` and `orcarouter_structured_json_response`, tenacity retry/error handling.
- **`main_text_generation.py`** — `GPT_PROVIDER=orcarouter` / `preferred_provider=orcarouter` selection, availability preflight, key injection, dispatch, and usage tracking (mapped to the OpenAI billing enum — same pattern as HuggingFace → MISTRAL, so no DB migration needed).
- **`tenant_provider_config.py`** — orcarouter alias / env var / default model registration.
- **`APIKeyManager`, `validation.py`, `api_key_injection_middleware.py`** — `ORCAROUTER_API_KEY` loading, format validation (`sk-orca-`), and production per-user key injection.
- **`onboarding_config_service.py` / `onboarding_completion_service.py`** — OrcaRouter in the named provider list and onboarding completion gating.
- **`env_template.txt` / `environment_setup.py`** — `ORCAROUTER_API_KEY` env entry.

### Docs
- `docs-site/docs/getting-started/configuration.md` — OrcaRouter setup section.
- `docs/llm_gateway/Architecture.md`, `docs/SIF_and_AI_Tools_model_LLM_choices.md` — provider registration and routing contract.

### Tests
- New `tests/test_orcarouter_provider.py` — 6 unit tests covering provider alias normalization, env var resolution, default model, module constants, and API key format validation. All pass.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update
- [x] 🧪 Test additions/updates

## Related Issues
N/A

## Testing
- [x] Backend tests pass — `pytest tests/test_orcarouter_provider.py` (6 passed); changed modules compile (`py_compile`) and import cleanly.
- [x] Manual testing completed — **L3 live test**: with a real key, `orcarouter_text_response` and `orcarouter_structured_json_response` both hit `https://api.orcarouter.ai/v1/chat/completions` (`orcarouter/auto` → `deepseek-v4-pro`) and returned 200 with generated content.
- [ ] Frontend tests pass — not applicable (backend-only change).

## Component/Feature
- [x] LLM Gateway (backend/services/llm_providers)

Disclosure: I'm an engineer on the OrcaRouter team.
