### PR TITLE
Add CI workflow to run backend and frontend tests on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  backend-tests:
+    name: Backend (pytest)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.9'
+          cache: 'pip'
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run pytest
+        run: pytest
+
+  frontend-tests:
+    name: Frontend (jest)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test -- --watchAll=false


### PR DESCRIPTION
What I found

While reviewing the repo from a QA perspective, I checked .github/workflows/ and found it currently only contains docs.yml and lint-forced-user-id.yml. There is no workflow that runs the test suites — pytest in backend/ and the Jest tests in frontend/ — automatically on pull requests or pushes to main.

This means tests can currently fail (or be skipped entirely) without blocking a merge, since nothing in CI actually runs them.

What this PR does

Adds .github/workflows/test.yml with two jobs:

backend-tests: sets up Python 3.11.9 (matching backend/runtime.txt), installs backend/requirements.txt, and runs pytest.
frontend-tests: sets up Node 20, installs frontend dependencies with npm ci, and runs npm test -- --watchAll=false (non-interactive, so it doesn't hang in CI).

Both jobs run on every pull request targeting main and on pushes to main.

Why this matters

The repo already has real test coverage (pytest suite in backend/tests/, Jest set up in frontend/), but without CI enforcement, those tests aren't guaranteed to run before code is merged. This is a low-risk, additive change — it doesn't touch any existing code, only adds automated test execution.

Testing

I ran both test commands locally before submitting this PR to confirm they execute successfully in this environment.